### PR TITLE
Automatically find Python and improved linking for cuda

### DIFF
--- a/search/pybinds/CMakeLists.txt
+++ b/search/pybinds/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(kbmod)
 find_package(CUDA REQUIRED)
+find_package( PythonInterp 3.6 REQUIRED )
+find_package( PythonLibs 3.6 REQUIRED )
 add_subdirectory(pybind11)
 
 set(
@@ -19,16 +21,13 @@ include_directories(
    ../include
    ../src
    ./pybind11/include
-   /usr/include/python3.6
-   /usr/include/python3.5
-   /usr/include/python3
-   /usr/local/cuda-8.0/samples/common/inc
+   /usr/local/cuda/samples/common/inc
    )
 
 link_directories(
    ../lib
-   /usr/local/cuda-8.0/samples/common/lib/linux/x86_64
-   /usr/local/cuda-8.0/lib64
+   /usr/local/cuda/samples/common/lib/linux/x86_64
+   /usr/local/cuda/lib64
    )
 
 cuda_add_library(


### PR DESCRIPTION
cmake will now find the current python and python library path and link and target that, instead of needing to manually state the path. This should make installation significantly easier on multiple machines. Also changed cuda path from /usr/local/cuda-8.0 to /usr/local/cuda because cuda installations make an automatic symlink at /user/local/cuda to the most recent version of cuda (e.g. /usr/local/cuda -> /usr/local/cuda-9.1).