### PR TITLE
__syncthreads() after writing shared memory

### DIFF
--- a/search/src/kernels.cu
+++ b/search/src/kernels.cu
@@ -202,6 +202,7 @@ __global__ void searchImages(int trajectoryCount, int width, int height,
     __shared__ float sImgTimes[512];
     int idx = threadIdx.x+threadIdx.y*THREAD_DIM_X;
     if (idx<imageCount) sImgTimes[idx] = imgTimes[idx];
+    __syncthreads();
 
     // Give up on any trajectories starting outside the image
     if (x >= width || y >= height)
@@ -356,6 +357,7 @@ __global__ void searchFilterImages(int trajectoryCount, int width, int height,
     __shared__ float sImgTimes[512];
     int idx = threadIdx.x+threadIdx.y*THREAD_DIM_X;
     if (idx<imageCount) sImgTimes[idx] = imgTimes[idx];
+    __syncthreads();
 
     // Give up on any trajectories starting outside the image
     if (x >= width || y >= height)


### PR DESCRIPTION
Threadblocks should sync after writing to shared memory to avoid reading uninitialized values. 
Was rereading this as a reference while trying to help someone with an opengl compute shader question and realized I forgot to sync threads here!
If you've ever noticed inconsistent results between identical runs, this could be a cause. Possible you will notice no difference with this change, but definitely a good idea to include this in future runs.