### PR TITLE
Reduce internal copies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ __pycache__
 CMakeCache.txt
 CMakeFiles
 search/pybinds/cuda_script
+search/src/.DS_Store
+search/.DS_Store
+.DS_Store

--- a/search/pybinds/classBindings.cpp
+++ b/search/pybinds/classBindings.cpp
@@ -41,6 +41,7 @@ PYBIND11_MODULE(kbmod, m) {
         .def("get_dim", &pf::getDim)
         .def("get_radius", &pf::getRadius)
         .def("get_size", &pf::getSize)
+        .def("get_kernel", &pf::getKernel)
         .def("square_psf", &pf::squarePSF)
         .def("print_psf", &pf::printPSF);
     

--- a/search/src/ImageBase.h
+++ b/search/src/ImageBase.h
@@ -18,10 +18,10 @@ class ImageBase {
 public:
 	ImageBase() {};
 	virtual void convolve(PointSpreadFunc psf) = 0;
-	virtual unsigned getWidth() = 0;
-	virtual unsigned getHeight() = 0;
+	virtual unsigned getWidth() const = 0;
+	virtual unsigned getHeight() const = 0;
 	virtual long* getDimensions() = 0;
-	virtual unsigned getPPI() = 0;
+	virtual unsigned getPPI() const = 0;
 	virtual ~ImageBase() {};
 };
 

--- a/search/src/ImageStack.h
+++ b/search/src/ImageStack.h
@@ -21,21 +21,21 @@ namespace kbmod {
 
 class ImageStack : public ImageBase {
 public:
-	ImageStack(std::vector<std::string> files);
-	ImageStack(std::vector<LayeredImage> imgs);
+	ImageStack(const std::vector<std::string>& filenames);
+	ImageStack(const std::vector<LayeredImage>& imgs);
 	std::vector<LayeredImage>& getImages();
-	unsigned imgCount();
+	unsigned imgCount() const;
 	std::vector<float> getTimes();
-	void setTimes(std::vector<float> times);
+	void setTimes(const std::vector<float>& times);
 	void resetImages();
-	void saveMasterMask(std::string path);
-	void saveImages(std::string path);
-	RawImage getMasterMask();
+	void saveMasterMask(const std::string& path);
+	void saveImages(const std::string& path);
+	const RawImage& getMasterMask() const;
 	std::vector<RawImage> getSciences();
 	std::vector<RawImage> getMasks();
 	std::vector<RawImage> getVariances();
 	void applyMasterMask(int flags, int threshold);
-	void applyMaskFlags(int flags, std::vector<int> exceptions);
+	void applyMaskFlags(int flags, const std::vector<int>& exceptions);
 	void applyMaskThreshold(float thresh);
 	void growMask();
 	void simpleDifference();
@@ -47,12 +47,11 @@ public:
 	virtual ~ImageStack() {};
 
 private:
-	void loadImages();
+	void loadImages(const std::vector<std::string>& fileNames);
 	void extractImageTimes();
 	void setTimeOrigin();
 	void createMasterMask(int flags, int threshold);
 	void createTemplate();
-	std::vector<std::string> fileNames;
 	std::vector<LayeredImage> images;
 	RawImage masterMask;
 	RawImage avgTemplate;

--- a/search/src/ImageStack.h
+++ b/search/src/ImageStack.h
@@ -40,10 +40,10 @@ public:
 	void growMask();
 	void simpleDifference();
 	virtual void convolve(PointSpreadFunc psf) override;
-	unsigned getWidth() override { return images[0].getWidth(); }
-	unsigned getHeight() override { return images[0].getHeight(); }
+	unsigned getWidth() const override { return images[0].getWidth(); }
+	unsigned getHeight() const override { return images[0].getHeight(); }
 	long* getDimensions() override { return images[0].getDimensions(); }
-	unsigned getPPI() override { return images[0].getPPI(); }
+	unsigned getPPI() const override { return images[0].getPPI(); }
 	virtual ~ImageStack() {};
 
 private:

--- a/search/src/LayeredImage.cpp
+++ b/search/src/LayeredImage.cpp
@@ -99,9 +99,10 @@ void LayeredImage::readFitsImg(const char *name, float *target)
 		fits_report_error(stderr, status);
 }
 
-void LayeredImage::addObject(float x, float y, float flux, PointSpreadFunc psf)
+void LayeredImage::addObject(float x, float y, float flux,
+			     const PointSpreadFunc& psf)
 {
-	std::vector<float> k = psf.getKernel();
+	const std::vector<float>& k = psf.getKernel();
 	int dim = psf.getDim();
 	float initialX = x-static_cast<float>(psf.getRadius());
 	float initialY = y-static_cast<float>(psf.getRadius());
@@ -119,9 +120,9 @@ void LayeredImage::addObject(float x, float y, float flux, PointSpreadFunc psf)
 	}
 }
 
-void LayeredImage::maskObject(float x, float y, PointSpreadFunc psf)
+void LayeredImage::maskObject(float x, float y, const PointSpreadFunc& psf)
 {
-	std::vector<float> k = psf.getKernel();
+	const std::vector<float>& k = psf.getKernel();
 	int dim = psf.getDim();
 	float initialX = x-static_cast<float>(psf.getRadius());
 	float initialY = y-static_cast<float>(psf.getRadius());
@@ -150,14 +151,14 @@ void LayeredImage::convolve(PointSpreadFunc psf)
 	variance.convolve(psfSQ);
 }
 
-void LayeredImage::applyMaskFlags(int flags, std::vector<int> exceptions)
+void LayeredImage::applyMaskFlags(int flags, const std::vector<int>& exceptions)
 {
 	science.applyMask(flags, exceptions, mask);
 	variance.applyMask(flags, exceptions, mask);
 }
 
 /* Mask all pixels that are not 0 in master mask */
-void LayeredImage::applyMasterMask(RawImage masterM)
+void LayeredImage::applyMasterMask(const RawImage& masterM)
 {
 	science.applyMask(0xFFFFFF, {}, masterM);
 	variance.applyMask(0xFFFFFF, {}, masterM);
@@ -177,13 +178,13 @@ void LayeredImage::applyMaskThreshold(float thresh)
 	}
 }
 
-void LayeredImage::subtractTemplate(RawImage subTemplate)
+void LayeredImage::subtractTemplate(const RawImage& subTemplate)
 {
 	assert( getHeight() == subTemplate.getHeight() &&
 			getWidth() == subTemplate.getWidth());
 	float *sciPix = science.getDataRef();
-	float *tempPix = subTemplate.getDataRef();
-	for (unsigned i=0; i<getPPI(); ++i) sciPix[i] -= tempPix[i];
+	const std::vector<float>& tempPix = subTemplate.getPixels();
+	for (unsigned i=0; i < pixelsPerImage; ++i) sciPix[i] -= tempPix[i];
 }
 
 void LayeredImage::saveLayers(const std::string& path)
@@ -265,7 +266,7 @@ float* LayeredImage::getVDataRef() {
 	return variance.getDataRef();
 }
 
-double LayeredImage::getTime()
+double LayeredImage::getTime() const
 {
 	return captureTime;
 }

--- a/search/src/LayeredImage.h
+++ b/search/src/LayeredImage.h
@@ -31,11 +31,11 @@ public:
 
 	// Basic getter functions for image data.
 	std::string getName() { return fileName; }
-	unsigned getWidth() override { return width; }
-	unsigned getHeight() override { return height; }
+	unsigned getWidth() const override { return width; }
+	unsigned getHeight() const override { return height; }
 	long* getDimensions() override { return &dimensions[0]; }
-	unsigned getPPI() override { return pixelsPerImage; }
-	double getTime();
+	unsigned getPPI() const override { return pixelsPerImage; }
+	double getTime() const;
 
 	// Getter functions for the data in the individual layers.
 	RawImage& getScience();
@@ -46,19 +46,20 @@ public:
 	float* getMDataRef(); // Get pointer to mask pixels
 
 	// Applies the mask functions to each of the science and variance layers. 
-	void applyMaskFlags(int flag, std::vector<int> exceptions);
-	void applyMasterMask(RawImage masterMask);
+	void applyMaskFlags(int flag, const std::vector<int>& exceptions);
+	void applyMasterMask(const RawImage& masterMask);
 	void applyMaskThreshold(float thresh);
 	void growMask();
 
 	// Subtracts a template image from the science layer.
-	void subtractTemplate(RawImage subTemplate);
-
+	void subtractTemplate(const RawImage& subTemplate);
+    
 	// Adds an (artificial) object to the image (science) data.
-	void addObject(float x, float y, float flux, PointSpreadFunc psf);
+	void addObject(float x, float y, float flux,
+		       const PointSpreadFunc& psf);
 
 	// Adds an object to the mask data.
-	void maskObject(float x, float y, PointSpreadFunc psf);
+	void maskObject(float x, float y, const PointSpreadFunc& psf);
 
 	// Saves the data in each later to a file.
 	void saveLayers(const std::string& path);

--- a/search/src/LayeredImage.h
+++ b/search/src/LayeredImage.h
@@ -30,7 +30,7 @@ public:
 		float noiseStDev, float pixelVariance, double time);
 
 	// Basic getter functions for image data.
-	std::string getName() { return fileName; }
+	std::string getName() const { return fileName; }
 	unsigned getWidth() const override { return width; }
 	unsigned getHeight() const override { return height; }
 	long* getDimensions() override { return &dimensions[0]; }

--- a/search/src/PointSpreadFunc.cpp
+++ b/search/src/PointSpreadFunc.cpp
@@ -46,7 +46,7 @@ PointSpreadFunc::PointSpreadFunc(float stdev) {
 	calcSum();
 }
 
-PointSpreadFunc::PointSpreadFunc(PointSpreadFunc& other)
+PointSpreadFunc::PointSpreadFunc(const PointSpreadFunc& other)
 {
 	kernel = other.getKernel();
 	dim = other.getDim();

--- a/search/src/PointSpreadFunc.h
+++ b/search/src/PointSpreadFunc.h
@@ -28,19 +28,19 @@ class PointSpreadFunc
 {
 	public:
 		PointSpreadFunc(float stdev);
-		PointSpreadFunc(PointSpreadFunc& other);
+		PointSpreadFunc(const PointSpreadFunc& other);
 #ifdef Py_PYTHON_H
 		PointSpreadFunc(pybind11::array_t<float> arr);
 		void setArray(pybind11::array_t<float> arr);
 #endif
 		virtual ~PointSpreadFunc() {};
-		float getStdev() { return width; }
+		float getStdev() const { return width; }
 		void calcSum();
-		float getSum() { return sum; }
-		int getDim() { return dim; }
-		int getRadius() { return radius; }
-		int getSize() { return kernel.size(); }
-		std::vector<float> getKernel() { return kernel; };
+		float getSum() const { return sum; }
+		int getDim() const { return dim; }
+		int getRadius() const { return radius; }
+		int getSize() const { return kernel.size(); }
+		const std::vector<float>& getKernel() const { return kernel; };
 		float* kernelData() { return kernel.data(); }
 		void squarePSF();
 		std::string printPSF();

--- a/search/src/RawImage.cpp
+++ b/search/src/RawImage.cpp
@@ -130,9 +130,10 @@ RawImage RawImage::pool(short mode)
     return pooledImage;
 }
 
-void RawImage::applyMask(int flags, std::vector<int> exceptions, RawImage mask)
+void RawImage::applyMask(int flags, const std::vector<int>& exceptions,
+			 const RawImage& mask)
 {
-	float *maskPix = mask.getDataRef();
+        const std::vector<float>& maskPix = mask.getPixels();
 	assert(pixelsPerImage == mask.getPPI());
 	for (unsigned int p=0; p<pixelsPerImage; ++p)
 	{
@@ -172,7 +173,7 @@ void RawImage::growMask()
 
 }
 
-std::vector<float> RawImage::bilinearInterp(float x, float y)
+std::vector<float> RawImage::bilinearInterp(float x, float y) const
 {
 	// Linear interpolation
 	// Find the 4 pixels (aPix, bPix, cPix, dPix)
@@ -234,9 +235,9 @@ void RawImage::addPixelInterp(float x, float y, float value)
 	addToPixel(iv[9], iv[10],value*iv[11]);
 }
 
-void RawImage::maskObject(float x, float y, PointSpreadFunc psf)
+void RawImage::maskObject(float x, float y, const PointSpreadFunc& psf)
 {
-	std::vector<float> k = psf.getKernel();
+	const std::vector<float>& k = psf.getKernel();
 	// *2 to mask extra area, to be sure object is masked
 	int dim = psf.getDim()*2;
 	float initialX = x-static_cast<float>(psf.getRadius()*2);
@@ -280,7 +281,7 @@ void RawImage::setPixel(int x, int y, float value)
 		pixels[y*width+x] = value;
 }
 
-float RawImage::getPixel(int x, int y)
+float RawImage::getPixel(int x, int y) const
 {
 	if (x>=0 && x<width && y>=0 && y<height) {
 		return pixels[y*width+x];
@@ -289,7 +290,7 @@ float RawImage::getPixel(int x, int y)
 	}
 }
 
-bool RawImage::pixelHasData(int x, int y)
+bool RawImage::pixelHasData(int x, int y) const
 {
 	if (x>=0 && x<width && y>=0 && y<height) {
 		return pixels[y*width+x] != NO_DATA;
@@ -298,7 +299,7 @@ bool RawImage::pixelHasData(int x, int y)
 	}
 }
 
-float RawImage::getPixelInterp(float x, float y)
+float RawImage::getPixelInterp(float x, float y) const
 {
 	if ((x<0.0 || y<0.0) || (x>static_cast<float>(width) ||
 	     y>static_cast<float>(height))) return NO_DATA;
@@ -339,6 +340,11 @@ void RawImage::setAllPix(float value)
 
 float* RawImage::getDataRef() {
 	return pixels.data();
+}
+
+const std::vector<float>& RawImage::getPixels() const
+{
+	return pixels;
 }
 
 } /* namespace kbmod */

--- a/search/src/RawImage.h
+++ b/search/src/RawImage.h
@@ -50,26 +50,26 @@ public:
 #endif
 
 	// Basic getter functions for image data.
-	unsigned getWidth() override { return width; }
-	unsigned getHeight() override { return height; }
+	unsigned getWidth() const override { return width; }
+	unsigned getHeight() const override { return height; }
 	long* getDimensions() override { return &dimensions[0]; }
-	unsigned getPPI() override { return pixelsPerImage; }
-	float getPixel(int x, int y);
-	bool pixelHasData(int x, int y);
-	std::vector<float> getPixels();
+	unsigned getPPI() const override { return pixelsPerImage; }
+	float getPixel(int x, int y) const;
+	bool pixelHasData(int x, int y) const;
+	const std::vector<float>& getPixels() const;
 	float* getDataRef(); // Get pointer to pixels
 
 	// Get the interpolated brightness of a real values point
 	// using the four neighboring pixels.
-	float getPixelInterp(float x, float y);
+	float getPixelInterp(float x, float y) const;
   
 	// Masks out the pixels of the image where:
 	//   flags a bit vector of mask flags to apply 
 	//       (use 0xFFFFFF to apply all flags)
 	//   exceptions is a vector of pixel flags to ignore
 	//   mask is an image of bit vector mask flags
-	void applyMask(int flags, std::vector<int> exceptions,
-	               RawImage mask);
+	void applyMask(int flags, const std::vector<int>& exceptions,
+	               const RawImage& mask);
 
 	void setAllPix(float value);
 	void setPixel(int x, int y, float value);
@@ -77,10 +77,10 @@ public:
 	void addPixelInterp(float x, float y, float value);
 
 	// Mask out an object 
-	void maskObject(float x, float y, PointSpreadFunc psf);
+	void maskObject(float x, float y, const PointSpreadFunc& psf);
 	void maskPixelInterp(float x, float y);
 	void growMask();
-	std::vector<float> bilinearInterp(float x, float y);
+	std::vector<float> bilinearInterp(float x, float y) const;
 
 	// Save the RawImage to a file.
 	void saveToFile(const std::string& path);

--- a/tests/test_image_stack.py
+++ b/tests/test_image_stack.py
@@ -1,0 +1,136 @@
+from kbmod import *
+import tempfile
+import unittest
+
+class test_image_stack(unittest.TestCase):
+
+    def setUp(self):
+        self.p = psf(1.0)
+
+        # Create multiple fake layered images to use.
+        self.num_images = 5
+        self.images = [None] * self.num_images
+        for i in range(self.num_images):
+            self.images[i] = layered_image(("layered_test_%i" % i),
+                                           80,    # dim_x = 80 pixels,
+                                           60,    # dim_y = 60 pixels,
+                                           2.0,   # noise_level
+                                           4.0,   # variance
+                                           2.0 * i)  # time
+
+            # Include one masked pixel per time step at (10, 10 + i).
+            mask = self.images[i].get_mask()
+            mask.set_pixel(10, 10 + i, 1)
+            self.images[i].set_mask(mask)
+
+        self.im_stack = image_stack(self.images)
+          
+    def test_create(self):
+        self.assertEqual(self.num_images, self.im_stack.img_count())
+        self.assertEqual(self.im_stack.get_height(), 60)
+        self.assertEqual(self.im_stack.get_width(), 80)
+        self.assertEqual(self.im_stack.get_ppi(), 60 * 80)
+        self.assertEqual(len(self.im_stack.get_sciences()),
+                         self.num_images)
+        self.assertEqual(len(self.im_stack.get_variances()),
+                         self.num_images)
+        self.assertEqual(len(self.im_stack.get_masks()),
+                         self.num_images)
+
+    def test_times(self):
+        times = self.im_stack.get_times()
+        self.assertEqual(len(times), self.num_images)
+        for i in range(self.num_images):
+            self.assertEqual(times[i], 2.0 * i)
+
+        new_times = [3.0 * i for i in range(self.num_images)]
+        self.im_stack.set_times(new_times)
+
+        times2 = self.im_stack.get_times()
+        self.assertEqual(len(times2), self.num_images)
+        for i in range(self.num_images):
+            self.assertEqual(times2[i], 3.0 * i)
+
+    def test_apply_mask(self):
+        # Nothing is initially masked.
+        sci_stack = self.im_stack.get_sciences()
+        for i in range(self.num_images):
+            for y in range(self.im_stack.get_height()):
+                for x in range(self.im_stack.get_width()):
+                    self.assertTrue(sci_stack[i].pixel_has_data(x, y))
+
+        self.im_stack.apply_mask_flags(1, [])
+
+        # Check that one pixel is masked in each time.
+        sci_stack = self.im_stack.get_sciences()
+        for i in range(self.num_images):
+            for y in range(self.im_stack.get_height()):
+                for x in range(self.im_stack.get_width()):
+                    if x == 10 and y == 10 + i:
+                        self.assertFalse(sci_stack[i].pixel_has_data(x, y))
+                    else:
+                        self.assertTrue(sci_stack[i].pixel_has_data(x, y))
+
+    def test_create_master_mask(self):
+        # Before we apply the master mask it defaults to all zero.
+        # NOTE: This is current behavior, but might not be what we
+        # actually want.
+        master_mask = self.im_stack.get_master_mask()
+        for y in range(self.im_stack.get_height()):
+            for x in range(self.im_stack.get_width()):
+                self.assertEqual(master_mask.get_pixel(x, y), 0.0)
+
+        # Apply the master mask for flag=1 and a threshold of the bit set
+        # in at least one mask.
+        self.im_stack.apply_master_mask(1, 1)
+
+        # Check that the correct pixels are masked in each time.
+        sci_stack = self.im_stack.get_sciences()
+        for i in range(self.num_images):
+            for y in range(self.im_stack.get_height()):
+                for x in range(self.im_stack.get_width()):
+                    if x == 10 and y >= 10 and y <= 10 + (self.num_images - 1):
+                        self.assertFalse(sci_stack[i].pixel_has_data(x, y))
+                    else:
+                        self.assertTrue(sci_stack[i].pixel_has_data(x, y))
+
+        # Check that the master mask is now set.
+        master_mask = self.im_stack.get_master_mask()
+        for y in range(self.im_stack.get_height()):
+            for x in range(self.im_stack.get_width()):
+                if x == 10 and y >= 10 and y <= 10 + (self.num_images - 1):
+                    self.assertEqual(master_mask.get_pixel(x, y), 1.0)
+                else:
+                    self.assertEqual(master_mask.get_pixel(x, y), 0.0)
+
+    def test_subtract_template(self):
+        width = 5
+        height = 6
+
+        # Create three small images with known science pixels.
+        images = []
+        for i in range(3):
+            image = layered_image(("layered_test_%i" % i), width, height,
+                                  2.0, 4.0, 2.0 * i)
+            sci_layer = image.get_science()
+            for x in range(width):
+                for y in range(height):
+                    sci_layer.set_pixel(x, y, 10.0*i + 0.5*y)
+            image.set_science(sci_layer)
+            images.append(image)
+
+        # Compute the simple difference.
+        img_stack = image_stack(images)
+        img_stack.simple_difference()
+
+        # Check that the average for pixel (x, y) has been subtracted
+        # out of each science image.
+        sciences = img_stack.get_sciences()
+        for i in range(3):
+            for x in range(width):
+                for y in range(height):
+                    self.assertEqual(sciences[i].get_pixel(x, y), 10.0*(i-1))
+            
+if __name__ == '__main__':
+   unittest.main()
+

--- a/tests/test_layered_image.py
+++ b/tests/test_layered_image.py
@@ -1,7 +1,7 @@
 from kbmod import *
 import tempfile
 import unittest
-   
+
 class test_layered_image(unittest.TestCase):
 
    def setUp(self):
@@ -168,7 +168,26 @@ class test_layered_image(unittest.TestCase):
                            (x == 9 and y <= 13 and y >= 11) or
                            (x == 11 and y <= 13 and y >= 11))
             self.assertEqual(science.pixel_has_data(x, y), not should_mask)
-               
+
+   def test_subtract_template(self):
+      old_science = self.image.get_science()
+      
+      template = raw_image(self.image.get_width(), self.image.get_height())
+      template.set_all(0.0)
+      for h in range(old_science.get_height()):
+          template.set_pixel(10, h, 0.01 * h)
+      self.image.sub_template(template)
+
+      new_science = self.image.get_science()
+      for x in range(old_science.get_width()):
+         for y in range(old_science.get_height()):
+            val1 = old_science.get_pixel(x, y)
+            val2 = new_science.get_pixel(x, y)
+            if x == 10:
+                self.assertAlmostEqual(val2, val1 - 0.01 * y, delta=1e-6)
+            else:
+                self.assertEqual(val1, val2)
+
    def test_read_write_files(self):
       with tempfile.TemporaryDirectory() as dir_name:
           file_name = "tmp_layered_test_data"

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -8,6 +8,23 @@ class test_psf(unittest.TestCase):
       sigma_list = range(self.psf_count)
       self.psf_list = [psf(x/5+0.2) for x in sigma_list]
 
+   def test_make_and_copy(self):
+      psf1 = psf(1.0)
+      self.assertEqual(psf1.get_size(), 25)
+      self.assertEqual(psf1.get_dim(), 5)
+      self.assertEqual(psf1.get_radius(), 2)
+
+      # Make a copy.
+      psf2 = psf(psf1)
+      self.assertEqual(psf2.get_size(), 25)
+      self.assertEqual(psf2.get_dim(), 5)
+      self.assertEqual(psf2.get_radius(), 2)      
+
+      kernel1 = psf1.get_kernel()
+      kernel2 = psf2.get_kernel()
+      for i in range(psf1.get_size()):
+         self.assertEqual(kernel1[i], kernel2[i])
+      
    # Test that the PSF sums to close to 1.
    def test_sum(self):
       for p in self.psf_list:


### PR DESCRIPTION
Changed a bunch of pass by values to pass by (const) reference so that the program is not creating a new copy of the data structures with each function call.

This also marks a bunch of functions as const (where applicable) to allow the const references.

Simple benchmark tests show 10% - >50% speedup for some of the functions.

Added tests to cover the changes.