### PR TITLE
Part 2 of KBMOSearch refactoring

### DIFF
--- a/analysis/analysis_utils.py
+++ b/analysis/analysis_utils.py
@@ -587,7 +587,7 @@ class PostProcess(SharedTools):
             coadd_stamps = [np.array(stamp) for stamp in
                               search.median_stamps(results, boolean_idx, radius)]
         elif stamp_type=='parallel_sum':
-            coadd_stamps = [np.array(stamp) for stamp in search.summed_stamps(results, radius)]
+            coadd_stamps = [np.array(stamp) for stamp in search.summed_sci(results, radius)]
         else:
             # Python stamp generation
             coadd_stamps = []

--- a/search/pybinds/classBindings.cpp
+++ b/search/pybinds/classBindings.cpp
@@ -82,7 +82,8 @@ PYBIND11_MODULE(kbmod, m) {
         .def("extreme_in_region", &ri::extremeInRegion)
         .def("convolve", &ri::convolve)
         .def("save_fits", &ri::saveToFile);
-
+    m.def("create_median_image", &kbmod::createMedianImage);
+    m.def("create_summed_image", &kbmod::createSummedImage);
     py::class_<li>(m, "layered_image")
         .def(py::init<const std::string>())
         .def(py::init<std::string, int, int, 
@@ -163,8 +164,8 @@ PYBIND11_MODULE(kbmod, m) {
         .def("filter_lh", &ks::filterLH)
         .def("stacked_sci", (ri (ks::*)(tj &, int)) &ks::stackedScience, "set")
         .def("stacked_sci", (ri (ks::*)(td &, int)) &ks::stackedScience, "set")
+        .def("summed_sci", (std::vector<ri> (ks::*)(std::vector<tj>, int)) &ks::summedScience)
         .def("median_stamps", (std::vector<ri> (ks::*)(std::vector<tj>, std::vector<std::vector<int>>, int)) &ks::medianStamps)
-        .def("summed_stamps", (std::vector<ri> (ks::*)(std::vector<tj>, int)) &ks::summedStamps)
         .def("sci_stamps", (std::vector<ri> (ks::*)(tj &, int)) &ks::scienceStamps, "set")
         .def("psi_stamps", (std::vector<ri> (ks::*)(tj &, int)) &ks::psiStamps, "set2")
         .def("phi_stamps", (std::vector<ri> (ks::*)(tj &, int)) &ks::phiStamps, "set3")

--- a/search/src/KBMOSearch.h
+++ b/search/src/KBMOSearch.h
@@ -88,7 +88,7 @@ public:
     int biggestFit(int x, int y, int maxX, int maxY); // inline?
     float squareSDF(float scale, float centerX, float centerY,
             float pointX, float pointY);
-    float findExtremeInRegion(float x, float y, int size, 
+    float findExtremeInRegion(float x, float y, int size,
             PooledImage& pooledImg, int poolType);
 
     // Converts a trajRegion result into a trajectory result.
@@ -99,19 +99,18 @@ public:
 
     // Functions to create and access stamps around proposed trajectories or
     // regions. Used to visualize the results.
-    std::vector<RawImage> createStamps(trajectory t, int radius, std::vector<RawImage*> imgs);
-    std::vector<RawImage> medianStamps(std::vector<trajectory> t_array,
-                                       std::vector<std::vector<int>> goodIdx,
+    std::vector<RawImage> medianStamps(const std::vector<trajectory>& t_array,
+                                       const std::vector<std::vector<int>>& goodIdx,
                                        int radius);
-    std::vector<RawImage> createMedianBatch(int radius,  std::vector<RawImage*> imgs);
-    std::vector<RawImage> summedStamps(std::vector<trajectory> t_array, int radius);
-    RawImage stackedStamps(trajectory t, int radius, std::vector<RawImage*> imgs);
+
+    // Creates science stamps (or a summed stamp) around a
+    // trajectory, trajRegion, or vector of trajectories.
     std::vector<RawImage> scienceStamps(trajRegion& t, int radius);
     std::vector<RawImage> scienceStamps(trajectory& t, int radius);
-
-    // Creates stack science stamps around a trajectory or trajRegion.
     RawImage stackedScience(trajRegion& t, int radius);
     RawImage stackedScience(trajectory& t, int radius);
+    std::vector<RawImage> summedScience(const std::vector<trajectory>& t_array,
+                                        int radius);
 
     // Getters for the Psi and Phi data, including pooled
     // and stamped versions.
@@ -156,6 +155,12 @@ private:
     void gpuSearchFilter(int minObservations); 
     void sortResults();
     std::vector<float> createCurves(trajectory t, std::vector<RawImage*> imgs);
+
+    // Functions to create and access stamps around proposed trajectories or
+    // regions. Used to visualize the results.
+    std::vector<RawImage> createStamps(trajectory t, int radius,
+                                       const std::vector<RawImage*>& imgs,
+                                       bool interpolate);
 
     // Creates list of trajectories to search.
     void createSearchList(int angleSteps, int veloctiySteps, float minAngle,

--- a/search/src/RawImage.cpp
+++ b/search/src/RawImage.cpp
@@ -432,7 +432,7 @@ RawImage createSummedImage(const std::vector<RawImage>& images)
 {
     int num_images = images.size();
     assert(num_images > 0);
-    
+
     int width = images[0].getWidth();
     int height = images[0].getHeight();
     for (auto& img : images)

--- a/search/src/RawImage.cpp
+++ b/search/src/RawImage.cpp
@@ -12,21 +12,20 @@ namespace kbmod {
 
 RawImage::RawImage()
 {
-	initDimensions(0,0);
-	pixels = std::vector<float>();
+    initDimensions(0,0);
+    pixels = std::vector<float>();
 }
 
 RawImage::RawImage(unsigned w, unsigned h) : pixels(w*h)
 {
-	initDimensions(w,h);
+    initDimensions(w,h);
 }
 
 RawImage::RawImage(unsigned w, unsigned h,
-		std::vector<float> pix) : pixels(pix)
+                   std::vector<float> pix) : pixels(pix)
 {
-	assert(w*h == pix.size());
-	initDimensions(w,h);
-	//pixels = pix;
+    assert(w*h == pix.size());
+    initDimensions(w,h);
 }
 
 #ifdef Py_PYTHON_H
@@ -140,9 +139,9 @@ RawImage RawImage::createStamp(float x, float y, int radius,
 
 void RawImage::convolve(PointSpreadFunc psf)
 {
-	deviceConvolve(pixels.data(), pixels.data(), getWidth(), getHeight(),
-			psf.kernelData(), psf.getSize(), psf.getDim(),
-			psf.getRadius(), psf.getSum());
+    deviceConvolve(pixels.data(), pixels.data(), getWidth(), getHeight(),
+                   psf.kernelData(), psf.getSize(), psf.getDim(),
+                   psf.getRadius(), psf.getSum());
 }
 
 RawImage RawImage::pool(short mode)

--- a/search/src/RawImage.h
+++ b/search/src/RawImage.h
@@ -91,7 +91,7 @@ public:
 
 	// Create a "stamp" image of a give radius (width=2*radius+1)
 	// about the given point.
-	RawImage createStamp(float x, float y, int radius) const;
+	RawImage createStamp(float x, float y, int radius, bool interpolate) const;
 
 	// Creates images of half the height and width where each
 	// pixel is either the min or max (depending on mode) of
@@ -117,6 +117,10 @@ private:
 	unsigned pixelsPerImage;
 	std::vector<float> pixels;
 };
+
+// Helper functions for creating composite images.
+RawImage createMedianImage(const std::vector<RawImage>& images);
+RawImage createSummedImage(const std::vector<RawImage>& images);
 
 } /* namespace kbmod */
 

--- a/search/src/kernels.cu
+++ b/search/src/kernels.cu
@@ -44,7 +44,7 @@ __global__ void convolvePSF(int width, int height,
                     (y + j >= 0) && (y + j < height))
                 {
                     float currentPixel = sourceImage[(y+j)*width+(x+i)];
-                    if (currentPixel != NO_DATA) 
+                    if (currentPixel != NO_DATA)
                     {
                         float currentPSF = psf[(j+psfRad)*psfDim+(i+psfRad)];
                         psfPortion += currentPSF;

--- a/search/src/kernels.cu
+++ b/search/src/kernels.cu
@@ -11,7 +11,6 @@
 #define MAX_NUM_IMAGES 140
 
 #include "common.h"
-//#include "PointSpreadFunc.h"
 #include <helper_cuda.h>
 #include <stdio.h>
 #include <float.h>
@@ -30,26 +29,27 @@ __global__ void convolvePSF(int width, int height,
     const int x = blockIdx.x*CONV_THREAD_DIM+threadIdx.x;
     const int y = blockIdx.y*CONV_THREAD_DIM+threadIdx.y;
     if (x < 0 || x > width-1 || y < 0 || y > height-1) return;
-    const int minX = max(x-psfRad, 0);
-    const int minY = max(y-psfRad, 0);
-    const int maxX = min(x+psfRad, width-1);
-    const int maxY = min(y+psfRad, height-1);
 
     // Read kernel
     float sum = 0.0;
     float psfPortion = 0.0;
     float center = sourceImage[y*width+x];
     if (center != NO_DATA) {
-        for (int j=minY; j<=maxY; j++)
+        for (int j = -psfRad; j <= psfRad; j++)
         {
             // #pragma unroll
-            for (int i=minX; i<=maxX; i++)
+            for (int i = -psfRad; i <= psfRad; i++)
             {
-                float currentPixel = sourceImage[j*width+i];
-                if (currentPixel != NO_DATA) {
-                    float currentPSF = psf[(j-minY)*psfDim+i-minX];
-                    psfPortion += currentPSF;
-                    sum += currentPixel * currentPSF;
+                if ((x + i >= 0) && (x + i < width) &&
+                    (y + j >= 0) && (y + j < height))
+                {
+                    float currentPixel = sourceImage[(y+j)*width+(x+i)];
+                    if (currentPixel != NO_DATA) 
+                    {
+                        float currentPSF = psf[(j+psfRad)*psfDim+(i+psfRad)];
+                        psfPortion += currentPSF;
+                        sum += currentPixel * currentPSF;
+                    }
                 }
             }
         }
@@ -346,7 +346,6 @@ __global__ void searchFilterImages(int trajectoryCount, int width, int height,
     float psiArray[MAX_NUM_IMAGES];
     float phiArray[MAX_NUM_IMAGES];
     int idxArray[MAX_NUM_IMAGES];
-    float tmpSortValue;
     int tmpSortIdx;
     trajectory best[RESULTS_PER_PIXEL];
     for (int r=0; r<RESULTS_PER_PIXEL; ++r)

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -103,6 +103,35 @@ class test_raw_image(unittest.TestCase):
                 # Compute the manually computed result with the convolution.
                 self.assertAlmostEqual(img2.get_pixel(x, y), ave, delta = 0.001)
 
+    def test_convolve_psf_orientation(self):
+        # Set up a non-symmetric psf where orientation matters.
+        psf_data = [[0.0, 0.0, 0.0], [0.0, 0.5, 0.4], [0.0, 0.1, 0.0]]
+        p = psf(np.array(psf_data))
+
+        # Make a clean version of the image for the average function.
+        img2 = raw_image(self.width, self.height)
+        for x in range(self.width):
+            for y in range(self.height):
+                img2.set_pixel(x, y, self.img.get_pixel(x, y))
+
+        # Convolve the psf with the copy of the image.
+        img2.convolve(p)
+
+        for x in range(self.width):
+            for y in range(self.height):
+                running_sum = 0.5 * self.img.get_pixel(x, y)
+                count = 0.5
+                if self.img.pixel_has_data(x + 1, y):
+                    running_sum += 0.4 * self.img.get_pixel(x + 1, y)
+                    count += 0.4
+                if self.img.pixel_has_data(x, y + 1):
+                    running_sum += 0.1 * self.img.get_pixel(x, y + 1)
+                    count += 0.1
+                ave = (running_sum / count)
+
+                # Compute the manually computed result with the convolution.
+                self.assertAlmostEqual(img2.get_pixel(x, y), ave, delta = 0.001)
+
     def test_make_stamp(self):
         for x in range(self.width):
             for y in range(self.height):

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -79,7 +79,7 @@ class test_raw_image(unittest.TestCase):
             for y in range(self.height):
                 img2.set_pixel(x, y, self.img.get_pixel(x, y))
 
-        # Convolce the psf with the copy of the image.
+        # Convolve the psf with the copy of the image.
         img2.convolve(p)
 
         for x in range(self.width):
@@ -173,7 +173,7 @@ class test_raw_image(unittest.TestCase):
         self.assertAlmostEqual(summed_image.get_pixel(1, 1), 9.5, delta=1e-6)
         self.assertAlmostEqual(summed_image.get_pixel(0, 2), 8.8, delta=1e-6)
         self.assertAlmostEqual(summed_image.get_pixel(1, 2), 9.4, delta=1e-6)
-        
+
 if __name__ == '__main__':
    unittest.main()
 

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -1,4 +1,5 @@
 from kbmod import *
+import numpy as np
 import tempfile
 import unittest
 
@@ -33,7 +34,7 @@ class test_raw_image(unittest.TestCase):
             for y in range(self.height):
                 self.img.set_pixel(x, y, float(x+y*self.width))
 
-        stamp = self.img.create_stamp(2.5, 2.5, 2)
+        stamp = self.img.create_stamp(2.5, 2.5, 2, True)
         self.assertEqual(stamp.get_height(), 5)
         self.assertEqual(stamp.get_width(), 5)
         for x in range(-2,3):
@@ -67,6 +68,38 @@ class test_raw_image(unittest.TestCase):
         self.assertEqual(self.img.extreme_in_region(5, 5, 6, 6, 1),
                          KB_NO_DATA)
 
+    def test_create_median_image(self):
+        img1 = raw_image(np.array([[0.0, -1.0], [2.0, 1.0], [0.7, 3.1]]))
+        img2 = raw_image(np.array([[1.0, 0.0], [1.0, 3.5], [4.0, 3.0]]))
+        img3 = raw_image(np.array([[-1.0, -2.0], [3.0, 5.0], [4.1, 3.3]]))
+        vect = [img1, img2, img3]
+        median_image = create_median_image(vect)
+
+        self.assertEqual(median_image.get_width(), 2)
+        self.assertEqual(median_image.get_height(), 3)
+        self.assertAlmostEqual(median_image.get_pixel(0, 0), 0.0, delta=1e-6)
+        self.assertAlmostEqual(median_image.get_pixel(1, 0), -1.0, delta=1e-6)
+        self.assertAlmostEqual(median_image.get_pixel(0, 1), 2.0, delta=1e-6)
+        self.assertAlmostEqual(median_image.get_pixel(1, 1), 3.5, delta=1e-6)
+        self.assertAlmostEqual(median_image.get_pixel(0, 2), 4.0, delta=1e-6)
+        self.assertAlmostEqual(median_image.get_pixel(1, 2), 3.1, delta=1e-6)
+
+    def test_create_summed_image(self):
+        img1 = raw_image(np.array([[0.0, -1.0], [2.0, 1.0], [0.7, 3.1]]))
+        img2 = raw_image(np.array([[1.0, 0.0], [1.0, 3.5], [4.0, 3.0]]))
+        img3 = raw_image(np.array([[-1.0, -2.0], [3.0, 5.0], [4.1, 3.3]]))
+        vect = [img1, img2, img3]
+        summed_image = create_summed_image(vect)
+
+        self.assertEqual(summed_image.get_width(), 2)
+        self.assertEqual(summed_image.get_height(), 3)
+        self.assertAlmostEqual(summed_image.get_pixel(0, 0), 0.0, delta=1e-6)
+        self.assertAlmostEqual(summed_image.get_pixel(1, 0), -3.0, delta=1e-6)
+        self.assertAlmostEqual(summed_image.get_pixel(0, 1), 6.0, delta=1e-6)
+        self.assertAlmostEqual(summed_image.get_pixel(1, 1), 9.5, delta=1e-6)
+        self.assertAlmostEqual(summed_image.get_pixel(0, 2), 8.8, delta=1e-6)
+        self.assertAlmostEqual(summed_image.get_pixel(1, 2), 9.4, delta=1e-6)
+        
 if __name__ == '__main__':
    unittest.main()
 

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -29,6 +29,80 @@ class test_raw_image(unittest.TestCase):
                 self.assertTrue(self.img.pixel_has_data(x, y))
                 self.assertEqual(self.img.get_pixel(x, y), 15.0)
 
+    def test_convolve_psf_identity(self):
+        psf_data = [[0.0 for _ in range(3)] for _ in range(3)]
+        psf_data[1][1] = 1.0
+        p = psf(np.array(psf_data))
+
+        # Convolve the identity PSF.
+        self.img.convolve(p)
+
+        # Check that the image is unchanged.
+        for x in range(self.width):
+            for y in range(self.height):
+                self.assertTrue(self.img.pixel_has_data(x, y))
+                self.assertEqual(self.img.get_pixel(x, y),
+                                 float(x+y*self.width))
+
+    def test_convolve_psf_mask(self):
+        p = psf(1.0)
+
+        # Mask out three pixels.
+        self.img.set_pixel(5, 6, KB_NO_DATA)
+        self.img.set_pixel(0, 3, KB_NO_DATA)
+        self.img.set_pixel(5, 7, KB_NO_DATA)
+
+        self.img.convolve(p)
+
+        # Check that the image is unchanged.
+        for x in range(self.width):
+            for y in range(self.height):
+                if ((x == 5 and y == 6) or
+                    (x == 0 and y == 3) or
+                    (x == 5 and y == 7)):
+                    self.assertFalse(self.img.pixel_has_data(x, y))
+                else:
+                    self.assertTrue(self.img.pixel_has_data(x, y))
+
+    def test_convolve_psf_average(self):
+        # Set up a simple "averaging" psf to convolve.
+        psf_data = [[0.0 for _ in range(5)] for _ in range(5)]
+        for x in range(1, 4):
+            for y in range(1, 4):
+                psf_data[x][y] = 0.1111111
+        p = psf(np.array(psf_data))
+        self.assertAlmostEqual(p.get_sum(), 1.0, delta=0.00001)
+
+        # Make a clean version of the image for the average function.
+        img2 = raw_image(self.width, self.height)
+        for x in range(self.width):
+            for y in range(self.height):
+                img2.set_pixel(x, y, self.img.get_pixel(x, y))
+
+        # Convolce the psf with the copy of the image.
+        img2.convolve(p)
+
+        for x in range(self.width):
+            for y in range(self.height):
+                # Compute the weighted average around (x, y)
+                # in the original image.
+                running_sum = 0.0
+                count = 0.0
+                for i in range(-2, 3):
+                    for j in range(-2, 3):
+                        value = self.img.get_pixel(x + i, y + j)
+                        psf_value = 0.1111111
+                        if i == -2 or i == 2 or j == -2 or j == 2:
+                            psf_value = 0.0
+
+                        if value != KB_NO_DATA:
+                            running_sum += psf_value * value
+                            count += psf_value
+                ave = (running_sum / count)
+
+                # Compute the manually computed result with the convolution.
+                self.assertAlmostEqual(img2.get_pixel(x, y), ave, delta = 0.001)
+
     def test_make_stamp(self):
         for x in range(self.width):
             for y in range(self.height):


### PR DESCRIPTION
- Breaks the stamp creation and aggregation functions out into RawImage to reduce duplication and improve test coverage. 
- Removes some duplicate functions. 
- Changes CreateStamp to produce both interpolated and non-interpolated stamps.
- Rename some of the functions for consistency (which leads to a name change only in analysis_utils.py)
- 
Note: This change has passed the updated diff test (matching results and ps_ files.)