### PR TITLE
Correct combining of masked images

### DIFF
--- a/analysis/analysis_utils.py
+++ b/analysis/analysis_utils.py
@@ -630,8 +630,10 @@ class PostProcess(SharedTools):
                 An input string to generate different kinds of stamps.
                 'sum' - (default) A simple sum of all individual stamps
                 'parallel_sum' - A simple sum implemented in c++. Faster.
-                'median' - A per-pixel median of individual stamps.
+                'median' - A per-pixel median of individual stamps. DEPRECATED
+                           Now runs cpp_median.
                 'cpp_median' - A per-pixel median implemented in c++. Faster.
+                'cpp_mean' - A per pixel mean implemented in c++.
             radius : int
                 The size of the stamp. Default 10 gives a 21x21 stamp.
                 15 gives a 31x31 stamp, etc.
@@ -644,7 +646,7 @@ class PostProcess(SharedTools):
         start = time.time()
         # The C++ stamp generation types require a different format than the
         # python types
-        if stamp_type=='cpp_median':
+        if stamp_type=='cpp_median' or stamp_type=='median':
             num_images = len(keep['psi_curves'][0])
             boolean_idx = []
             for keep in keep['lc_index']:
@@ -653,6 +655,15 @@ class PostProcess(SharedTools):
                 boolean_idx.append(bool_row.astype(int).tolist())
             coadd_stamps = [np.array(stamp) for stamp in
                               search.median_stamps(results, boolean_idx, radius)]
+        elif stamp_type=='cpp_mean':
+            num_images = len(keep['psi_curves'][0])
+            boolean_idx = []
+            for keep in keep['lc_index']:
+                bool_row = np.zeros(num_images)
+                bool_row[keep] = 1
+                boolean_idx.append(bool_row.astype(int).tolist())
+            coadd_stamps = [np.array(stamp) for stamp in
+                              search.mean_stamps(results, boolean_idx, radius)]
         elif stamp_type=='parallel_sum':
             coadd_stamps = [np.array(stamp) for stamp in search.summed_sci(results, radius)]
         else:
@@ -662,12 +673,6 @@ class PostProcess(SharedTools):
                 if stamp_type=='sum':
                     stamps = np.array(search.stacked_sci(result, radius)).astype(np.float32)
                     coadd_stamps.append(stamps)
-                elif stamp_type=='median':
-                    stamps = search.sci_stamps(result, radius)
-                    stamp_arr = np.array(
-                        [np.array(stamps[s_idx]) for s_idx in keep['lc_index'][i]])
-                    stamp_arr[np.isnan(stamp_arr)]=0
-                    coadd_stamps.append(np.median(stamp_arr, axis=0))
         print('Loaded {} coadded stamps. {:.3f}s elapsed'.format(
             len(coadd_stamps), time.time()-start), flush=True)
         return(coadd_stamps)

--- a/search/pybinds/classBindings.cpp
+++ b/search/pybinds/classBindings.cpp
@@ -169,6 +169,7 @@ PYBIND11_MODULE(kbmod, m) {
         .def("stacked_sci", (ri (ks::*)(tj &, int)) &ks::stackedScience, "set")
         .def("stacked_sci", (ri (ks::*)(td &, int)) &ks::stackedScience, "set")
         .def("summed_sci", (std::vector<ri> (ks::*)(std::vector<tj>, int)) &ks::summedScience)
+        .def("mean_stamps", (std::vector<ri> (ks::*)(std::vector<tj>, std::vector<std::vector<int>>, int)) &ks::meanStamps)
         .def("median_stamps", (std::vector<ri> (ks::*)(std::vector<tj>, std::vector<std::vector<int>>, int)) &ks::medianStamps)
         .def("sci_stamps", (std::vector<ri> (ks::*)(tj &, int)) &ks::scienceStamps, "set")
         .def("psi_stamps", (std::vector<ri> (ks::*)(tj &, int)) &ks::psiStamps, "set2")

--- a/search/pybinds/classBindings.cpp
+++ b/search/pybinds/classBindings.cpp
@@ -73,6 +73,7 @@ PYBIND11_MODULE(kbmod, m) {
         .def("create_stamp", &ri::createStamp)
         .def("set_pixel", &ri::setPixel)
         .def("add_pixel", &ri::addToPixel)
+        .def("apply_mask", &ri::applyMask)
         .def("mask_object", &ri::maskObject)
         .def("grow_mask", &ri::growMask)
         .def("pixel_has_data", &ri::pixelHasData)
@@ -85,6 +86,7 @@ PYBIND11_MODULE(kbmod, m) {
         .def("save_fits", &ri::saveToFile);
     m.def("create_median_image", &kbmod::createMedianImage);
     m.def("create_summed_image", &kbmod::createSummedImage);
+    m.def("create_mean_image", &kbmod::createMeanImage);
     py::class_<li>(m, "layered_image")
         .def(py::init<const std::string>())
         .def(py::init<std::string, int, int, 

--- a/search/src/KBMOSearch.cpp
+++ b/search/src/KBMOSearch.cpp
@@ -702,7 +702,7 @@ std::vector<RawImage> KBMOSearch::meanStamps(const std::vector<trajectory>& t_ar
             }
         }
 
-        // Compute the median of those stamps.
+        // Compute the mean of those stamps.
         results[s] = createMeanImage(stamps);
     }
     omp_set_num_threads(1);

--- a/search/src/KBMOSearch.cpp
+++ b/search/src/KBMOSearch.cpp
@@ -647,13 +647,12 @@ std::vector<RawImage> KBMOSearch::medianStamps(const std::vector<trajectory>& t_
     int numResults = t_array.size();
     int dim = radius*2+1;
 
-    std::vector<RawImage*> imgs;
-    for (auto& im : stack.getImages()) imgs.push_back(&im.getScience());
+    std::vector<LayeredImage>& imgs = stack.getImages();
     size_t N = imgs.size() / 2;
     std::vector<RawImage> results(numResults);
-    omp_set_num_threads(30);
+    omp_set_num_threads(16);
 
-    //#pragma omp parallel for
+    #pragma omp parallel for
     for (int s = 0; s < numResults; ++s)
     {
         // Create stamps around the current trajectory.
@@ -664,7 +663,7 @@ std::vector<RawImage> KBMOSearch::medianStamps(const std::vector<trajectory>& t_
             if (goodIdx[s][i] == 1)
             {
                 std::array<float,2> pos = getTrajPos(t, i);
-                stamps.push_back(imgs[i]->createStamp(pos[0], pos[1], radius, false));
+                stamps.push_back(imgs[i].getScience().createStamp(pos[0], pos[1], radius, false));
             }
         }
 

--- a/search/src/KBMOSearch.cpp
+++ b/search/src/KBMOSearch.cpp
@@ -663,12 +663,47 @@ std::vector<RawImage> KBMOSearch::medianStamps(const std::vector<trajectory>& t_
             if (goodIdx[s][i] == 1)
             {
                 std::array<float,2> pos = getTrajPos(t, i);
-                stamps.push_back(imgs[i].getScience().createStamp(pos[0], pos[1], radius, false));
+                stamps.push_back(imgs[i].getScience().createStamp(pos[0], pos[1], radius, false, true));
             }
         }
 
         // Compute the median of those stamps.
         results[s] = createMedianImage(stamps);
+    }
+    omp_set_num_threads(1);
+
+    return(results);
+}
+
+std::vector<RawImage> KBMOSearch::meanStamps(const std::vector<trajectory>& t_array,
+                                             const std::vector<std::vector<int>>& goodIdx,
+                                             int radius)
+{
+    int numResults = t_array.size();
+    int dim = radius*2+1;
+
+    std::vector<LayeredImage>& imgs = stack.getImages();
+    size_t N = imgs.size() / 2;
+    std::vector<RawImage> results(numResults);
+    omp_set_num_threads(16);
+
+    #pragma omp parallel for
+    for (int s = 0; s < numResults; ++s)
+    {
+        // Create stamps around the current trajectory.
+        std::vector<RawImage> stamps;
+        trajectory t = t_array[s];
+        for (int i = 0; i < goodIdx[s].size(); ++i)
+        {
+            if (goodIdx[s][i] == 1)
+            {
+                std::array<float,2> pos = getTrajPos(t, i);
+                stamps.push_back(imgs[i].getScience().createStamp(pos[0], pos[1], radius, false, true));
+            }
+        }
+
+        // Compute the median of those stamps.
+        results[s] = createMeanImage(stamps);
     }
     omp_set_num_threads(1);
 
@@ -684,7 +719,7 @@ std::vector<RawImage> KBMOSearch::createStamps(trajectory t, int radius,
     for (int i=0; i < imgs.size(); ++i)
     {
         std::array<float,2> pos = getTrajPos(t, i);
-        stamps.push_back(imgs[i]->createStamp(pos[0], pos[1], radius, interpolate));
+        stamps.push_back(imgs[i]->createStamp(pos[0], pos[1], radius, interpolate, false));
     }
     return stamps;
 }

--- a/search/src/KBMOSearch.h
+++ b/search/src/KBMOSearch.h
@@ -91,12 +91,17 @@ public:
 
     // Functions to create and access stamps around proposed trajectories or
     // regions. Used to visualize the results.
+    // These functions drop pixels with NO_DATA from the computation.
     std::vector<RawImage> medianStamps(const std::vector<trajectory>& t_array,
                                        const std::vector<std::vector<int>>& goodIdx,
                                        int radius);
+    std::vector<RawImage> meanStamps(const std::vector<trajectory>& t_array,
+                                     const std::vector<std::vector<int>>& goodIdx,
+                                     int radius);
 
     // Creates science stamps (or a summed stamp) around a
     // trajectory, trajRegion, or vector of trajectories.
+    // These functions replace NO_DATA with a value of 0.0.
     std::vector<RawImage> scienceStamps(trajRegion& t, int radius);
     std::vector<RawImage> scienceStamps(trajectory& t, int radius);
     RawImage stackedScience(trajRegion& t, int radius);
@@ -145,6 +150,7 @@ private:
 
     // Functions to create and access stamps around proposed trajectories or
     // regions. Used to visualize the results.
+    // This function replaces NO_DATA with a value of 0.0.
     std::vector<RawImage> createStamps(trajectory t, int radius,
                                        const std::vector<RawImage*>& imgs,
                                        bool interpolate);

--- a/search/src/RawImage.cpp
+++ b/search/src/RawImage.cpp
@@ -442,12 +442,17 @@ RawImage createMedianImage(const std::vector<RawImage>& images)
                     num_unmasked += 1;
                 }
             }
-            
-            int median_ind = num_unmasked / 2;
-            std::nth_element(pixArray.begin(),
-                             pixArray.begin() + median_ind,
-                             pixArray.begin() + num_unmasked);
-            result.setPixel(x, y, pixArray[median_ind]);
+
+            if (num_unmasked > 0)
+            {
+                int median_ind = num_unmasked / 2;
+                std::nth_element(pixArray.begin(),
+                                 pixArray.begin() + median_ind,
+                                 pixArray.begin() + num_unmasked);
+                result.setPixel(x, y, pixArray[median_ind]);
+            } else {
+                result.setPixel(x, y, NO_DATA);
+            }
         }
     }
 
@@ -482,7 +487,7 @@ RawImage createSummedImage(const std::vector<RawImage>& images)
 
     return result;
 }
-    
+
 RawImage createMeanImage(const std::vector<RawImage>& images)
 {
     int num_images = images.size();
@@ -509,7 +514,12 @@ RawImage createMeanImage(const std::vector<RawImage>& images)
                     sum += pixVal;
                 }
             }
-            result.setPixel(x, y, sum/count);
+
+            if (count > 0.0) {
+                result.setPixel(x, y, sum/count);
+            } else {
+                result.setPixel(x, y, NO_DATA);
+            }
         }
     }
 

--- a/search/src/RawImage.cpp
+++ b/search/src/RawImage.cpp
@@ -112,7 +112,7 @@ void RawImage::saveToExtension(const std::string& path) {
 }
 
 RawImage RawImage::createStamp(float x, float y, int radius,
-                               bool interpolate) const
+                               bool interpolate, bool keep_no_data) const
 {
     if (radius < 0)
         throw std::runtime_error("stamp radius must be at least 0");
@@ -130,7 +130,7 @@ RawImage RawImage::createStamp(float x, float y, int radius,
             else
                 pixVal = getPixel(static_cast<int>(x) + xoff - radius,
                                   static_cast<int>(y) + yoff - radius);
-            if (pixVal == NO_DATA) pixVal = 0.0;
+            if ((pixVal == NO_DATA) && !keep_no_data) pixVal = 0.0;
             stamp.setPixel(xoff, yoff, pixVal);
         }
     }
@@ -445,13 +445,22 @@ RawImage createMedianImage(const std::vector<RawImage>& images)
 
             if (num_unmasked > 0)
             {
+                std::sort(pixArray.begin(), pixArray.begin() + num_unmasked);
+
+                // If we have an even number of elements, take the mean of the two
+                // middle ones.
                 int median_ind = num_unmasked / 2;
-                std::nth_element(pixArray.begin(),
-                                 pixArray.begin() + median_ind,
-                                 pixArray.begin() + num_unmasked);
-                result.setPixel(x, y, pixArray[median_ind]);
+                if (num_unmasked % 2 == 0)
+                {
+                    float ave_middle = (pixArray[median_ind] + pixArray[median_ind - 1]) / 2.0;
+                    result.setPixel(x, y, ave_middle);
+                } else {
+                    result.setPixel(x, y, pixArray[median_ind]);
+                }
             } else {
-                result.setPixel(x, y, NO_DATA);
+                // We use a 0.0 value if there is no data to allow for visualization
+                // and value based filtering.
+                result.setPixel(x, y, 0.0);
             }
         }
     }
@@ -518,7 +527,9 @@ RawImage createMeanImage(const std::vector<RawImage>& images)
             if (count > 0.0) {
                 result.setPixel(x, y, sum/count);
             } else {
-                result.setPixel(x, y, NO_DATA);
+                // We use a 0.0 value if there is no data to allow for visualization
+                // and value based filtering.
+                result.setPixel(x, y, 0.0);
             }
         }
     }

--- a/search/src/RawImage.h
+++ b/search/src/RawImage.h
@@ -121,6 +121,7 @@ private:
 // Helper functions for creating composite images.
 RawImage createMedianImage(const std::vector<RawImage>& images);
 RawImage createSummedImage(const std::vector<RawImage>& images);
+RawImage createMeanImage(const std::vector<RawImage>& images);
 
 } /* namespace kbmod */
 

--- a/search/src/RawImage.h
+++ b/search/src/RawImage.h
@@ -91,7 +91,9 @@ public:
 
 	// Create a "stamp" image of a give radius (width=2*radius+1)
 	// about the given point.
-	RawImage createStamp(float x, float y, int radius, bool interpolate) const;
+	// keep_no_data indicates whether to use the NO_DATA flag or replace with 0.0.
+	RawImage createStamp(float x, float y, int radius,
+                         bool interpolate, bool keep_no_data) const;
 
 	// Creates images of half the height and width where each
 	// pixel is either the min or max (depending on mode) of

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -187,6 +187,20 @@ class test_raw_image(unittest.TestCase):
         self.assertAlmostEqual(median_image.get_pixel(0, 2), 4.0, delta=1e-6)
         self.assertAlmostEqual(median_image.get_pixel(1, 2), 3.1, delta=1e-6)
 
+        # Apply masks to images 1 and 3.
+        img1.apply_mask(1, [], raw_image(np.array([[0, 1], [0, 1], [0, 1]])))
+        img3.apply_mask(1, [], raw_image(np.array([[0, 0], [1, 1], [1, 0]])))
+        median_image2 = create_median_image([img1, img2, img3])
+
+        self.assertEqual(median_image2.get_width(), 2)
+        self.assertEqual(median_image2.get_height(), 3)
+        self.assertAlmostEqual(median_image2.get_pixel(0, 0), 0.0, delta=1e-6)
+        self.assertAlmostEqual(median_image2.get_pixel(1, 0), 0.0, delta=1e-6)
+        self.assertAlmostEqual(median_image2.get_pixel(0, 1), 2.0, delta=1e-6)
+        self.assertAlmostEqual(median_image2.get_pixel(1, 1), 3.5, delta=1e-6)
+        self.assertAlmostEqual(median_image2.get_pixel(0, 2), 4.0, delta=1e-6)
+        self.assertAlmostEqual(median_image2.get_pixel(1, 2), 3.3, delta=1e-6)
+
     def test_create_summed_image(self):
         img1 = raw_image(np.array([[0.0, -1.0], [2.0, 1.0], [0.7, 3.1]]))
         img2 = raw_image(np.array([[1.0, 0.0], [1.0, 3.5], [4.0, 3.0]]))
@@ -202,6 +216,49 @@ class test_raw_image(unittest.TestCase):
         self.assertAlmostEqual(summed_image.get_pixel(1, 1), 9.5, delta=1e-6)
         self.assertAlmostEqual(summed_image.get_pixel(0, 2), 8.8, delta=1e-6)
         self.assertAlmostEqual(summed_image.get_pixel(1, 2), 9.4, delta=1e-6)
+
+        # Apply masks to images 1 and 3.
+        img1.apply_mask(1, [], raw_image(np.array([[0, 1], [0, 1], [0, 1]])))
+        img3.apply_mask(1, [], raw_image(np.array([[0, 0], [1, 1], [1, 0]])))
+        summed_image2 = create_summed_image([img1, img2, img3])
+
+        self.assertEqual(summed_image2.get_width(), 2)
+        self.assertEqual(summed_image2.get_height(), 3)
+        self.assertAlmostEqual(summed_image2.get_pixel(0, 0), 0.0, delta=1e-6)
+        self.assertAlmostEqual(summed_image2.get_pixel(1, 0), -2.0, delta=1e-6)
+        self.assertAlmostEqual(summed_image2.get_pixel(0, 1), 3.0, delta=1e-6)
+        self.assertAlmostEqual(summed_image2.get_pixel(1, 1), 3.5, delta=1e-6)
+        self.assertAlmostEqual(summed_image2.get_pixel(0, 2), 4.7, delta=1e-6)
+        self.assertAlmostEqual(summed_image2.get_pixel(1, 2), 6.3, delta=1e-6)
+
+    def test_create_mean_image(self):
+        img1 = raw_image(np.array([[0.0, -1.0], [2.0, 1.0], [0.7, 3.1]]))
+        img2 = raw_image(np.array([[1.0, 0.0], [1.0, 3.5], [4.0, 3.0]]))
+        img3 = raw_image(np.array([[-1.0, -2.0], [3.0, 5.0], [4.1, 3.3]]))
+        mean_image = create_mean_image([img1, img2, img3])
+
+        self.assertEqual(mean_image.get_width(), 2)
+        self.assertEqual(mean_image.get_height(), 3)
+        self.assertAlmostEqual(mean_image.get_pixel(0, 0), 0.0, delta=1e-6)
+        self.assertAlmostEqual(mean_image.get_pixel(1, 0), -1.0, delta=1e-6)
+        self.assertAlmostEqual(mean_image.get_pixel(0, 1), 2.0, delta=1e-6)
+        self.assertAlmostEqual(mean_image.get_pixel(1, 1), 9.5/3.0, delta=1e-6)
+        self.assertAlmostEqual(mean_image.get_pixel(0, 2), 8.8/3.0, delta=1e-6)
+        self.assertAlmostEqual(mean_image.get_pixel(1, 2), 9.4/3.0, delta=1e-6)
+
+        # Apply masks to images 1 and 3.
+        img1.apply_mask(1, [], raw_image(np.array([[0, 1], [0, 1], [0, 1]])))
+        img3.apply_mask(1, [], raw_image(np.array([[0, 0], [1, 1], [1, 0]])))
+        mean_image2 = create_mean_image([img1, img2, img3])
+
+        self.assertEqual(mean_image2.get_width(), 2)
+        self.assertEqual(mean_image2.get_height(), 3)
+        self.assertAlmostEqual(mean_image2.get_pixel(0, 0), 0.0, delta=1e-6)
+        self.assertAlmostEqual(mean_image2.get_pixel(1, 0), -1.0, delta=1e-6)
+        self.assertAlmostEqual(mean_image2.get_pixel(0, 1), 1.5, delta=1e-6)
+        self.assertAlmostEqual(mean_image2.get_pixel(1, 1), 3.5, delta=1e-6)
+        self.assertAlmostEqual(mean_image2.get_pixel(0, 2), 2.35, delta=1e-6)
+        self.assertAlmostEqual(mean_image2.get_pixel(1, 2), 3.15, delta=1e-6)
 
 if __name__ == '__main__':
    unittest.main()

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -137,7 +137,7 @@ class test_raw_image(unittest.TestCase):
             for y in range(self.height):
                 self.img.set_pixel(x, y, float(x+y*self.width))
 
-        stamp = self.img.create_stamp(2.5, 2.5, 2, True)
+        stamp = self.img.create_stamp(2.5, 2.5, 2, True, False)
         self.assertEqual(stamp.get_height(), 5)
         self.assertEqual(stamp.get_width(), 5)
         for x in range(-2,3):
@@ -195,11 +195,11 @@ class test_raw_image(unittest.TestCase):
         self.assertEqual(median_image2.get_width(), 2)
         self.assertEqual(median_image2.get_height(), 3)
         self.assertAlmostEqual(median_image2.get_pixel(0, 0), 0.0, delta=1e-6)
-        self.assertAlmostEqual(median_image2.get_pixel(1, 0), 0.0, delta=1e-6)
-        self.assertAlmostEqual(median_image2.get_pixel(0, 1), 2.0, delta=1e-6)
+        self.assertAlmostEqual(median_image2.get_pixel(1, 0), -1.0, delta=1e-6)
+        self.assertAlmostEqual(median_image2.get_pixel(0, 1), 1.5, delta=1e-6)
         self.assertAlmostEqual(median_image2.get_pixel(1, 1), 3.5, delta=1e-6)
-        self.assertAlmostEqual(median_image2.get_pixel(0, 2), 4.0, delta=1e-6)
-        self.assertAlmostEqual(median_image2.get_pixel(1, 2), 3.3, delta=1e-6)
+        self.assertAlmostEqual(median_image2.get_pixel(0, 2), 2.35, delta=1e-6)
+        self.assertAlmostEqual(median_image2.get_pixel(1, 2), 3.15, delta=1e-6)
 
     def test_create_median_image_more(self):
         img1 = raw_image(np.array([[ 1.0, -1.0], [-1.0, 1.0], [1.0, 0.1]]))
@@ -217,7 +217,7 @@ class test_raw_image(unittest.TestCase):
         img5.apply_mask(1, [], raw_image(np.array([[0, 1], [0, 1], [0, 0]])))
         img6.apply_mask(1, [], raw_image(np.array([[0, 1], [1, 1], [0, 0]])))
         img7.apply_mask(1, [], raw_image(np.array([[0, 0], [1, 1], [0, 0]])))
-        
+
         vect = [img1, img2, img3, img4, img5, img6, img7]
         median_image = create_median_image(vect)
 
@@ -226,8 +226,8 @@ class test_raw_image(unittest.TestCase):
         self.assertAlmostEqual(median_image.get_pixel(0, 0), 4.0, delta=1e-6)
         self.assertAlmostEqual(median_image.get_pixel(1, 0), 0.0, delta=1e-6)
         self.assertAlmostEqual(median_image.get_pixel(0, 1), -2.0, delta=1e-6)
-        self.assertAlmostEqual(median_image.get_pixel(1, 1), KB_NO_DATA, delta=1e-6)
-        self.assertAlmostEqual(median_image.get_pixel(0, 2), 5.0, delta=1e-6)
+        self.assertAlmostEqual(median_image.get_pixel(1, 1), 0.0, delta=1e-6)
+        self.assertAlmostEqual(median_image.get_pixel(0, 2), 4.5, delta=1e-6)
         self.assertAlmostEqual(median_image.get_pixel(1, 2), 0.1, delta=1e-6)
 
     def test_create_summed_image(self):
@@ -275,7 +275,7 @@ class test_raw_image(unittest.TestCase):
         self.assertAlmostEqual(mean_image.get_pixel(0, 2), 8.8/3.0, delta=1e-6)
         self.assertAlmostEqual(mean_image.get_pixel(1, 2), 9.4/3.0, delta=1e-6)
 
-        # Apply masks to images 1 and 3.
+        # Apply masks to images 1, 2, and 3.
         img1.apply_mask(1, [], raw_image(np.array([[0, 1], [0, 1], [0, 1]])))
         img2.apply_mask(1, [], raw_image(np.array([[0, 0], [0, 0], [0, 1]])))
         img3.apply_mask(1, [], raw_image(np.array([[0, 0], [1, 1], [1, 1]])))
@@ -288,7 +288,7 @@ class test_raw_image(unittest.TestCase):
         self.assertAlmostEqual(mean_image2.get_pixel(0, 1), 1.5, delta=1e-6)
         self.assertAlmostEqual(mean_image2.get_pixel(1, 1), 3.5, delta=1e-6)
         self.assertAlmostEqual(mean_image2.get_pixel(0, 2), 2.35, delta=1e-6)
-        self.assertAlmostEqual(mean_image2.get_pixel(1, 2), KB_NO_DATA, delta=1e-6)
+        self.assertAlmostEqual(mean_image2.get_pixel(1, 2), 0.0, delta=1e-6)
 
 if __name__ == '__main__':
    unittest.main()

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -201,6 +201,35 @@ class test_raw_image(unittest.TestCase):
         self.assertAlmostEqual(median_image2.get_pixel(0, 2), 4.0, delta=1e-6)
         self.assertAlmostEqual(median_image2.get_pixel(1, 2), 3.3, delta=1e-6)
 
+    def test_create_median_image_more(self):
+        img1 = raw_image(np.array([[ 1.0, -1.0], [-1.0, 1.0], [1.0, 0.1]]))
+        img2 = raw_image(np.array([[ 2.0,  0.0], [ 0.0, 2.0], [2.0, 0.0]]))
+        img3 = raw_image(np.array([[ 3.0, -2.0], [-2.0, 5.0], [4.0, 0.3]]))
+        img4 = raw_image(np.array([[ 4.0,  3.0], [ 3.0, 6.0], [5.0, 0.1]]))
+        img5 = raw_image(np.array([[ 5.0, -3.0], [-3.0, 7.0], [7.0, 0.0]]))
+        img6 = raw_image(np.array([[ 6.0,  2.0], [ 2.0, 4.0], [6.0, 0.1]]))
+        img7 = raw_image(np.array([[ 7.0,  3.0], [ 3.0, 3.0], [3.0, 0.0]]))
+
+        img1.apply_mask(1, [], raw_image(np.array([[0, 0], [1, 1], [0, 0]])))
+        img2.apply_mask(1, [], raw_image(np.array([[0, 0], [1, 1], [1, 0]])))
+        img3.apply_mask(1, [], raw_image(np.array([[0, 0], [0, 1], [0, 0]])))
+        img4.apply_mask(1, [], raw_image(np.array([[0, 0], [0, 1], [0, 0]])))
+        img5.apply_mask(1, [], raw_image(np.array([[0, 1], [0, 1], [0, 0]])))
+        img6.apply_mask(1, [], raw_image(np.array([[0, 1], [1, 1], [0, 0]])))
+        img7.apply_mask(1, [], raw_image(np.array([[0, 0], [1, 1], [0, 0]])))
+        
+        vect = [img1, img2, img3, img4, img5, img6, img7]
+        median_image = create_median_image(vect)
+
+        self.assertEqual(median_image.get_width(), 2)
+        self.assertEqual(median_image.get_height(), 3)
+        self.assertAlmostEqual(median_image.get_pixel(0, 0), 4.0, delta=1e-6)
+        self.assertAlmostEqual(median_image.get_pixel(1, 0), 0.0, delta=1e-6)
+        self.assertAlmostEqual(median_image.get_pixel(0, 1), -2.0, delta=1e-6)
+        self.assertAlmostEqual(median_image.get_pixel(1, 1), KB_NO_DATA, delta=1e-6)
+        self.assertAlmostEqual(median_image.get_pixel(0, 2), 5.0, delta=1e-6)
+        self.assertAlmostEqual(median_image.get_pixel(1, 2), 0.1, delta=1e-6)
+
     def test_create_summed_image(self):
         img1 = raw_image(np.array([[0.0, -1.0], [2.0, 1.0], [0.7, 3.1]]))
         img2 = raw_image(np.array([[1.0, 0.0], [1.0, 3.5], [4.0, 3.0]]))
@@ -248,7 +277,8 @@ class test_raw_image(unittest.TestCase):
 
         # Apply masks to images 1 and 3.
         img1.apply_mask(1, [], raw_image(np.array([[0, 1], [0, 1], [0, 1]])))
-        img3.apply_mask(1, [], raw_image(np.array([[0, 0], [1, 1], [1, 0]])))
+        img2.apply_mask(1, [], raw_image(np.array([[0, 0], [0, 0], [0, 1]])))
+        img3.apply_mask(1, [], raw_image(np.array([[0, 0], [1, 1], [1, 1]])))
         mean_image2 = create_mean_image([img1, img2, img3])
 
         self.assertEqual(mean_image2.get_width(), 2)
@@ -258,7 +288,7 @@ class test_raw_image(unittest.TestCase):
         self.assertAlmostEqual(mean_image2.get_pixel(0, 1), 1.5, delta=1e-6)
         self.assertAlmostEqual(mean_image2.get_pixel(1, 1), 3.5, delta=1e-6)
         self.assertAlmostEqual(mean_image2.get_pixel(0, 2), 2.35, delta=1e-6)
-        self.assertAlmostEqual(mean_image2.get_pixel(1, 2), 3.15, delta=1e-6)
+        self.assertAlmostEqual(mean_image2.get_pixel(1, 2), KB_NO_DATA, delta=1e-6)
 
 if __name__ == '__main__':
    unittest.main()


### PR DESCRIPTION
The median function would set masked pixels to zero, which can skew the distribution. The new code just computes the median over the non-masked pixels.

Also adds a computeMeanImage function.

Adds corresponding tests.