### PR TITLE
Clean up region search (part 2)

### DIFF
--- a/analysis/evaluate.py
+++ b/analysis/evaluate.py
@@ -1,35 +1,6 @@
 import math
 from kbmod import *
 
-def trajectory_distances(trjA, trjB, times=[0.0]):
-    """
-    Evaluate the distance between two trajectories (in pixels)
-    at different times.
-    
-    Arguments:
-        trjA : trajectory
-            The first trajectory to evaluate.
-        trjB : trajectory
-            The second trajectory to evaluate.
-        times : list
-            The list of zero-shifted times at which to evaluate the
-            matches. The average of the distances at these times
-            are used.
-
-    Returns:
-        list : The distance at each time.
-    """
-    num_times = len(times)
-    results = [0.0] * num_times
-    for i in range(num_times):
-        xA = trjA.x + trjA.x_v * times[i]
-        yA = trjA.y + trjA.y_v * times[i]
-        xB = trjB.x + trjB.x_v * times[i]
-        yB = trjB.y + trjB.y_v * times[i]
-        results[i] = math.sqrt((xA - xB)**2 + (yA - yB)**2)
-    return results
-
-
 def ave_trajectory_distance(trjA, trjB, times=[0.0]):
     """
     Evaluate the average distance between two trajectories (in pixels)
@@ -50,13 +21,11 @@ def ave_trajectory_distance(trjA, trjB, times=[0.0]):
     """
     num_times = len(times)
     assert(num_times > 0)
-
-    dists = trajectory_distances(trjA, trjB, times)
-
-    sum = 0.0
-    for d in dists:
-        sum += d
-    return sum / float(num_times)
+    
+    posA = [get_trajectory_pos(trjA, times[i]) for i in range(num_times)]
+    posB = [get_trajectory_pos(trjB, times[i]) for i in range(num_times)]
+    ave_dist = ave_trajectory_dist(posA, posB)
+    return ave_dist
 
 
 def find_unique_overlap(traj_query, traj_base, threshold, times=[0.0]):

--- a/analysis/evaluate.py
+++ b/analysis/evaluate.py
@@ -5,7 +5,7 @@ def ave_trajectory_distance(trjA, trjB, times=[0.0]):
     """
     Evaluate the average distance between two trajectories (in pixels)
     at different times.
-    
+
     Arguments:
         trjA : trajectory
             The first trajectory to evaluate.
@@ -21,7 +21,7 @@ def ave_trajectory_distance(trjA, trjB, times=[0.0]):
     """
     num_times = len(times)
     assert(num_times > 0)
-    
+
     posA = [get_trajectory_pos(trjA, times[i]) for i in range(num_times)]
     posB = [get_trajectory_pos(trjB, times[i]) for i in range(num_times)]
     ave_dist = ave_trajectory_dist(posA, posB)
@@ -69,7 +69,7 @@ def find_unique_overlap(traj_query, traj_base, threshold, times=[0.0]):
                 if dist < best_dist:
                     best_dist = dist
                     best_ind = j
-        
+
         # If we found a good match, save it.
         if best_dist <= threshold:
             results.append(query)
@@ -118,7 +118,7 @@ def find_set_difference(traj_query, traj_base, threshold, times=[0.0]):
                 if dist < best_dist:
                     best_dist = dist
                     best_ind = j
-        
+
         # If we found a good match, save it.
         if best_dist <= threshold:
             used[best_ind] = True

--- a/search/pybinds/classBindings.cpp
+++ b/search/pybinds/classBindings.cpp
@@ -8,6 +8,7 @@
 #include "../src/KBMOSearch.cpp"
 #include "../src/PooledImage.cpp"
 #include "../src/Filtering.cpp"
+#include "../src/TrajectoryUtils.cpp"
 
 namespace py = pybind11;
 
@@ -19,6 +20,7 @@ using ks = kbmod::KBMOSearch;
 using tj = kbmod::trajectory;
 using bc = kbmod::baryCorrection;
 using td = kbmod::trajRegion;
+using pp = kbmod::pixelPos;
 using pi = kbmod::PooledImage;
 
 using std::to_string;
@@ -167,10 +169,8 @@ PYBIND11_MODULE(kbmod, m) {
         .def("filter_min_obs", &ks::filterResults)
         // For testing
         .def("extreme_in_region", &ks::findExtremeInRegion)
-        .def("subdivide", &ks::subdivide)
         .def("filter_bounds", &ks::filterBounds)
         .def("square_sdf", &ks::squareSDF)
-        .def("filter_lh", &ks::filterLH)
         .def("stacked_sci", (ri (ks::*)(tj &, int)) &ks::stackedScience, "set")
         .def("stacked_sci", (ri (ks::*)(td &, int)) &ks::stackedScience, "set")
         .def("summed_sci", (std::vector<ri> (ks::*)(std::vector<tj>, int)) &ks::summedScience)
@@ -209,6 +209,14 @@ PYBIND11_MODULE(kbmod, m) {
                               " obs_count: " + to_string(t.obsCount);
             }
         );
+    py::class_<pp>(m, "pixel_pos")
+        .def(py::init<>())
+        .def_readwrite("x", &pp::x)
+        .def_readwrite("y", &pp::y)
+        .def("__repr__", [](const pp &p) {
+            return "x: " + to_string(p.x) + " y: " + to_string(p.y);
+            }
+        );
     py::class_<bc>(m, "baryCorrection")
         .def(py::init<>())
         .def_readwrite("dx", &bc::dx)
@@ -244,5 +252,13 @@ PYBIND11_MODULE(kbmod, m) {
             }
         );
     m.def("sigmag_filtered_indices", &kbmod::sigmaGFilteredIndices);
+    
+    // Functions from TrajectoryUtils (for testing)
+    m.def("get_trajectory_pos", &kbmod::getTrajectoryPos);
+    m.def("get_trajectory_pos_bc", &kbmod::getTrajectoryPosBC);
+    m.def("ave_trajectory_dist", &kbmod::aveTrajectoryDistance);
+    m.def("convert_traj_region", &kbmod::convertTrajRegion);
+    m.def("subdivide_traj_region", &kbmod::subdivideTrajRegion);
+    m.def("filter_traj_regions_lh", &kbmod::filterTrajRegionsLH);
 }
 

--- a/search/pybinds/classBindings.cpp
+++ b/search/pybinds/classBindings.cpp
@@ -73,6 +73,7 @@ PYBIND11_MODULE(kbmod, m) {
         .def("pool", &ri::pool)
         .def("pool_min", &ri::poolMin)
         .def("pool_max", &ri::poolMax)
+        .def("pool_in_place", &ri::poolInPlace)
         .def("create_stamp", &ri::createStamp)
         .def("set_pixel", &ri::setPixel)
         .def("add_pixel", &ri::addToPixel)

--- a/search/src/Filtering.cpp
+++ b/search/src/Filtering.cpp
@@ -15,7 +15,6 @@ extern "C" void sigmaGFilteredIndicesCU(float* values, int num_values,
         float sGL0, float sGL1, float sigmaGCoeff, float width,
         int* idxArray, int* minKeepIndex, int* maxKeepIndex);
 
-
 /* Return the list of indices from the values array such that those elements
    pass the sigmaG filtering defined by percentiles [sGL0, sGL1] with coefficient
    sigmaGCoeff and a multiplicative factor of width. */

--- a/search/src/KBMOSearch.cpp
+++ b/search/src/KBMOSearch.cpp
@@ -318,14 +318,14 @@ std::vector<trajRegion> KBMOSearch::resSearch(float xVel, float yVel,
             fResults.push_back(t);
             if (fResults.size() >= maxResultCount) break;
         } else {
-            std::vector<trajRegion> sublist = subdivide(t);
+            std::vector<trajRegion> sublist = subdivideTrajRegion(t);
 
             // Filter out subregions with invalid velocities.
             filterBounds(sublist, xVel, yVel, finalTime, radius);
 
             // Compute the likelihood of each of the subregions.
             for (auto& t : sublist) calculateLH(t, pooledPsi, pooledPhi);
-            filterLH(sublist, minLH, minObservations);
+            filterTrajRegionsLH(sublist, minLH, minObservations);
 
             // Push the surviving subregions onto candidates.
             for (auto& nt : sublist) candidates.push(nt);
@@ -333,35 +333,6 @@ std::vector<trajRegion> KBMOSearch::resSearch(float xVel, float yVel,
     }
     std::cout << std::endl;
     return fResults;
-}
-
-std::vector<trajRegion> KBMOSearch::subdivide(trajRegion& t)
-{
-    short nDepth = t.depth-1;
-    std::vector<trajRegion> children(16);
-    float nix = t.ix*2.0;
-    float niy = t.iy*2.0;
-    float nfx = t.fx*2.0;
-    float nfy = t.fy*2.0;
-    const float s = 1.0;
-    children[0]  = { nix,    niy,   nfx,    nfy,  nDepth, 0, 0.0, 0.0 };
-    children[1]  = { nix+s,  niy,   nfx,    nfy,  nDepth, 0, 0.0, 0.0 };
-    children[2]  = { nix,    niy+s, nfx,    nfy,  nDepth, 0, 0.0, 0.0 };
-    children[3]  = { nix+s,  niy+s, nfx,    nfy,  nDepth, 0, 0.0, 0.0 };
-    children[4]  = { nix,    niy,   nfx+s,  nfy,  nDepth, 0, 0.0, 0.0 };
-    children[5]  = { nix+s,  niy,   nfx+s,  nfy,  nDepth, 0, 0.0, 0.0 };
-    children[6]  = { nix,    niy+s, nfx+s,  nfy,  nDepth, 0, 0.0, 0.0 };
-    children[7]  = { nix+s,  niy+s, nfx+s,  nfy,  nDepth, 0, 0.0, 0.0 };
-    children[8]  = { nix,    niy,   nfx,    nfy+s,nDepth, 0, 0.0, 0.0 };
-    children[9]  = { nix+s,  niy,   nfx,    nfy+s,nDepth, 0, 0.0, 0.0 };
-    children[10] = { nix,    niy+s, nfx,    nfy+s,nDepth, 0, 0.0, 0.0 };
-    children[11] = { nix+s,  niy+s, nfx,    nfy+s,nDepth, 0, 0.0, 0.0 };
-    children[12] = { nix,    niy,   nfx+s,  nfy+s,nDepth, 0, 0.0, 0.0 };
-    children[13] = { nix+s,  niy,   nfx+s,  nfy+s,nDepth, 0, 0.0, 0.0 };
-    children[14] = { nix,    niy+s, nfx+s,  nfy+s,nDepth, 0, 0.0, 0.0 };
-    children[15] = { nix+s,  niy+s, nfx+s,  nfy+s,nDepth, 0, 0.0, 0.0 };
-
-    return children;
 }
 
 std::vector<trajRegion>& KBMOSearch::filterBounds(std::vector<trajRegion>& tlist,
@@ -404,18 +375,6 @@ float KBMOSearch::squareSDF(float scale,
     float xm = std::max(xn,0.0f);
     float ym = std::max(yn,0.0f);
     return sqrt(xm*xm+ym*ym) + std::max(xk,yk);
-}
-
-std::vector<trajRegion>& KBMOSearch::filterLH(
-        std::vector<trajRegion>& tlist, float minLH, int minObs)
-{
-    tlist.erase(
-            std::remove_if(tlist.begin(), tlist.end(),
-                    std::bind([](trajRegion t, int mObs, float mLH) {
-                        return t.obs_count<mObs || t.likelihood<mLH;
-    }, std::placeholders::_1, minObs, minLH)),
-    tlist.end());
-    return tlist;
 }
 
 void KBMOSearch::calculateLH(trajRegion& t,
@@ -521,23 +480,6 @@ void KBMOSearch::removeObjectFromImages(trajRegion& t,
     }
 }
 
-trajectory KBMOSearch::convertTraj(trajRegion& t)
-{
-    const std::vector<float>& times = stack.getTimes();
-    float endTime = times.back();
-    float xv = (t.fx-t.ix)/endTime;
-    float yv = (t.fy-t.iy)/endTime;
-    trajectory tb;
-    tb.lh = t.likelihood;
-    tb.flux = t.flux;
-    tb.obsCount = t.obs_count;
-    tb.x = t.ix;
-    tb.y = t.iy;
-    tb.xVel = xv;
-    tb.yVel = yv;
-    return tb;
-}
-
 std::vector<RawImage> KBMOSearch::medianStamps(const std::vector<trajectory>& t_array,
                                                const std::vector<std::vector<int>>& goodIdx,
                                                int radius)
@@ -560,8 +502,8 @@ std::vector<RawImage> KBMOSearch::medianStamps(const std::vector<trajectory>& t_
         {
             if (goodIdx[s][i] == 1)
             {
-                std::array<float,2> pos = getTrajPos(t, i);
-                stamps.push_back(imgs[i].getScience().createStamp(pos[0], pos[1], radius, false, true));
+                pixelPos pos = getTrajPos(t, i);
+                stamps.push_back(imgs[i].getScience().createStamp(pos.x, pos.y, radius, false, true));
             }
         }
 
@@ -595,8 +537,8 @@ std::vector<RawImage> KBMOSearch::meanStamps(const std::vector<trajectory>& t_ar
         {
             if (goodIdx[s][i] == 1)
             {
-                std::array<float,2> pos = getTrajPos(t, i);
-                stamps.push_back(imgs[i].getScience().createStamp(pos[0], pos[1], radius, false, true));
+                pixelPos pos = getTrajPos(t, i);
+                stamps.push_back(imgs[i].getScience().createStamp(pos.x, pos.y, radius, false, true));
             }
         }
 
@@ -616,27 +558,19 @@ std::vector<RawImage> KBMOSearch::createStamps(trajectory t, int radius,
     std::vector<RawImage> stamps;
     for (int i=0; i < imgs.size(); ++i)
     {
-        std::array<float,2> pos = getTrajPos(t, i);
-        stamps.push_back(imgs[i]->createStamp(pos[0], pos[1], radius, interpolate, false));
+        pixelPos pos = getTrajPos(t, i);
+        stamps.push_back(imgs[i]->createStamp(pos.x, pos.y, radius, interpolate, false));
     }
     return stamps;
 }
 
-std::array<float,2> KBMOSearch::getTrajPos(trajectory t, int i){
+pixelPos KBMOSearch::getTrajPos(const trajectory& t, int i) const {
     float time = stack.getTimes()[i];
-
-    std::array<float,2> pos;
-
-    pos[0] = t.x + time * t.xVel;
-    pos[1] = t.y + time * t.yVel;
-
     if (useCorr) {
-        baryCorrection bc = baryCorrs[i];
-        pos[0] += bc.dx + t.x*bc.dxdx + t.y*bc.dxdy;
-        pos[1] += bc.dy + t.x*bc.dydx + t.y*bc.dydy;
+        return getTrajectoryPosBC(t, time, baryCorrs[i]);
+    } else {
+        return getTrajectoryPos(t, time);
     }
-
-    return pos;
 }
 
 std::vector<float> KBMOSearch::createCurves(trajectory t, std::vector<RawImage*> imgs)
@@ -662,10 +596,10 @@ std::vector<float> KBMOSearch::createCurves(trajectory t, std::vector<RawImage*>
          * gpu search.*/
         float pixVal;
         if (useCorr){
-            std::array<float,2> pos = getTrajPos(t, i);
+            pixelPos pos = getTrajPos(t, i);
             pixVal = imgs[i]->getPixel(
-                int(pos[0] + 0.5),
-                int(pos[1] + 0.5));
+                int(pos.x + 0.5),
+                int(pos.y + 0.5));
         }
         /* Does not use getTrajPos to be backwards compatible with Hits_Rerun */
         else {
@@ -682,17 +616,21 @@ std::vector<float> KBMOSearch::createCurves(trajectory t, std::vector<RawImage*>
 std::vector<RawImage> KBMOSearch::psiStamps(trajRegion& t, int radius)
 {
     preparePsiPhi();
+    const float endTime = stack.getTimes().back();
+
     std::vector<RawImage*> imgs;
     for (auto& im : psiImages) imgs.push_back(&im);
-    return createStamps(convertTraj(t), radius, imgs, true);
+    return createStamps(convertTrajRegion(t, endTime), radius, imgs, true);
 }
 
 std::vector<RawImage> KBMOSearch::phiStamps(trajRegion& t, int radius)
 {
     preparePsiPhi();
+    const float endTime = stack.getTimes().back();
+
     std::vector<RawImage*> imgs;
     for (auto& im : phiImages) imgs.push_back(&im);
-    return createStamps(convertTraj(t), radius, imgs, true);
+    return createStamps(convertTrajRegion(t, endTime), radius, imgs, true);
 }
 
 std::vector<RawImage> KBMOSearch::scienceStamps(trajectory& t, int radius)
@@ -704,9 +642,10 @@ std::vector<RawImage> KBMOSearch::scienceStamps(trajectory& t, int radius)
 
 std::vector<RawImage> KBMOSearch::scienceStamps(trajRegion& t, int radius)
 {
+    const float endTime = stack.getTimes().back();
     std::vector<RawImage*> imgs;
     for (auto& im : stack.getImages()) imgs.push_back(&im.getScience());
-    return createStamps(convertTraj(t), radius, imgs, true);
+    return createStamps(convertTrajRegion(t, endTime), radius, imgs, true);
 }
 
 RawImage KBMOSearch::stackedScience(trajectory& t, int radius)
@@ -724,7 +663,9 @@ RawImage KBMOSearch::stackedScience(trajRegion& t, int radius)
     std::vector<RawImage*> imgs;
     for (auto& im : stack.getImages()) imgs.push_back(&im.getScience());
 
-    std::vector<RawImage> stamps = createStamps(convertTraj(t), radius, imgs, false);
+    const float endTime = stack.getTimes().back();
+    std::vector<RawImage> stamps = createStamps(convertTrajRegion(t, endTime),
+                                                radius, imgs, false);
     RawImage summedStamp = createSummedImage(stamps);
     return summedStamp;
 }

--- a/search/src/KBMOSearch.h
+++ b/search/src/KBMOSearch.h
@@ -22,9 +22,10 @@
 #include <assert.h>
 #include <float.h>
 #include "common.h"
-#include "PointSpreadFunc.h"
 #include "ImageStack.h"
+#include "PointSpreadFunc.h"
 #include "PooledImage.h"
+#include "TrajectoryUtils.h"
 
 namespace kbmod {
 
@@ -70,12 +71,6 @@ public:
             float pointX, float pointY);
     float findExtremeInRegion(float x, float y, int size,
             PooledImage& pooledImg, int poolType);
-
-    // Converts a trajRegion result into a trajectory result.
-    trajectory convertTraj(trajRegion& t);
-
-    // Subdivides a trajRegion into 16 subregions.
-    std::vector<trajRegion> subdivide(trajRegion& t);
 
     // Functions to create and access stamps around proposed trajectories or
     // regions. Used to visualize the results.
@@ -179,7 +174,7 @@ private:
     // Parameters to do barycentric corrections.
     bool useCorr;
     std::vector<baryCorrection> baryCorrs;
-    std::array<float,2> getTrajPos(trajectory t, int i);
+    pixelPos getTrajPos(const trajectory& t, int i) const;
 };
 
 } /* namespace kbmod */

--- a/search/src/RawImage.cpp
+++ b/search/src/RawImage.cpp
@@ -155,6 +155,14 @@ RawImage RawImage::pool(short mode)
     return pooledImage;
 }
 
+RawImage RawImage::poolInPlace(int radius, short mode)
+{
+    RawImage pooledImage = RawImage(getWidth(), getHeight());
+    devicePoolInPlace(getWidth(), getHeight(), pixels.data(),
+                      pooledImage.getDataRef(), radius, mode);
+    return pooledImage;
+}
+
 float RawImage::extremeInRegion(int lx, int ly, int hx, int hy, short pool_mode)
 {
     // Pool over the region of the image.

--- a/search/src/RawImage.h
+++ b/search/src/RawImage.h
@@ -39,6 +39,12 @@ extern "C" void
 devicePool(int sourceWidth, int sourceHeight, float *source,
 	int destWidth, int destHeight, float *dest, char mode);
 
+// Performs a pixel pool without reducing resolution on an image
+// represented as an array of floats.
+extern "C" void
+devicePoolInPlace(int width, int height, float *source, float *dest,
+                  int radius, short mode);    
+
 class RawImage : public ImageBase {
 public:
 	RawImage();
@@ -101,6 +107,10 @@ public:
 	RawImage pool(short mode);
 	RawImage poolMin() { return pool(POOL_MIN); }
 	RawImage poolMax() { return pool(POOL_MAX); }
+
+	// Set each pixel to the min/max (depending on mode) of the local
+	// pixels in the original image without changing the size.
+	RawImage poolInPlace(int radius, short mode);
 
 	// Compute the pooling function over an arbitrary region.
 	// lx <= x <= hx and ly <= y <= hy.

--- a/search/src/TrajectoryUtils.cpp
+++ b/search/src/TrajectoryUtils.cpp
@@ -1,0 +1,92 @@
+/*
+ * TrajectoryUtils.cpp
+ *
+ * Created on: Sept 23, 2022
+ *
+ * Helper functions for filtering results.
+ */
+
+#include "TrajectoryUtils.h"
+
+namespace kbmod {
+    
+/* Compute the average distance between two trajectories at the
+   given time steps. Used in duplicate filtering and clustering. */
+double aveTrajectoryDistance(const std::vector<pixelPos>& posA,
+                             const std::vector<pixelPos>& posB)
+{
+    const int num_times = posA.size();
+    assert(posB.size() == num_times);
+
+    double sum = 0.0;
+    for (int i = 0; i < num_times; ++i)
+    {
+        double dx = posA[i].x - posB[i].x;
+        double dy = posA[i].y - posB[i].y;
+        sum += sqrt(dx*dx + dy*dy);
+    }
+    
+    return sum / (double)num_times;
+}
+    
+// Converts a trajRegion result into a trajectory result.
+trajectory convertTrajRegion(const trajRegion& t, float endTime)
+{
+    assert(endTime > 0.0);
+    float scale = 1.0;
+    if (t.depth > 0)
+        scale = std::pow(2.0, static_cast<float>(t.depth));
+
+    trajectory tb;
+    tb.lh = t.likelihood;
+    tb.flux = t.flux;
+    tb.obsCount = t.obs_count;
+    tb.x = t.ix * scale;
+    tb.y = t.iy * scale;
+    tb.xVel = (scale * t.fx - scale * t.ix) / endTime;
+    tb.yVel = (scale * t.fy - scale * t.iy) / endTime;
+    return tb;
+}
+
+std::vector<trajRegion> subdivideTrajRegion(const trajRegion& t)
+{
+    short nDepth = t.depth - 1;
+    std::vector<trajRegion> children(16);
+    float nix = t.ix*2.0;
+    float niy = t.iy*2.0;
+    float nfx = t.fx*2.0;
+    float nfy = t.fy*2.0;
+    const float s = 1.0;
+    children[0]  = { nix,    niy,   nfx,    nfy,  nDepth, 0, 0.0, 0.0 };
+    children[1]  = { nix+s,  niy,   nfx,    nfy,  nDepth, 0, 0.0, 0.0 };
+    children[2]  = { nix,    niy+s, nfx,    nfy,  nDepth, 0, 0.0, 0.0 };
+    children[3]  = { nix+s,  niy+s, nfx,    nfy,  nDepth, 0, 0.0, 0.0 };
+    children[4]  = { nix,    niy,   nfx+s,  nfy,  nDepth, 0, 0.0, 0.0 };
+    children[5]  = { nix+s,  niy,   nfx+s,  nfy,  nDepth, 0, 0.0, 0.0 };
+    children[6]  = { nix,    niy+s, nfx+s,  nfy,  nDepth, 0, 0.0, 0.0 };
+    children[7]  = { nix+s,  niy+s, nfx+s,  nfy,  nDepth, 0, 0.0, 0.0 };
+    children[8]  = { nix,    niy,   nfx,    nfy+s,nDepth, 0, 0.0, 0.0 };
+    children[9]  = { nix+s,  niy,   nfx,    nfy+s,nDepth, 0, 0.0, 0.0 };
+    children[10] = { nix,    niy+s, nfx,    nfy+s,nDepth, 0, 0.0, 0.0 };
+    children[11] = { nix+s,  niy+s, nfx,    nfy+s,nDepth, 0, 0.0, 0.0 };
+    children[12] = { nix,    niy,   nfx+s,  nfy+s,nDepth, 0, 0.0, 0.0 };
+    children[13] = { nix+s,  niy,   nfx+s,  nfy+s,nDepth, 0, 0.0, 0.0 };
+    children[14] = { nix,    niy+s, nfx+s,  nfy+s,nDepth, 0, 0.0, 0.0 };
+    children[15] = { nix+s,  niy+s, nfx+s,  nfy+s,nDepth, 0, 0.0, 0.0 };
+
+    return children;
+}
+
+std::vector<trajRegion>& filterTrajRegionsLH(std::vector<trajRegion>& tlist,
+                                             float minLH, int minObs)
+{
+    tlist.erase(
+            std::remove_if(tlist.begin(), tlist.end(),
+                    std::bind([](trajRegion t, int mObs, float mLH) {
+                        return t.obs_count < mObs || t.likelihood < mLH;
+    }, std::placeholders::_1, minObs, minLH)),
+    tlist.end());
+    return tlist;
+}
+
+} /* namespace kbmod */

--- a/search/src/TrajectoryUtils.h
+++ b/search/src/TrajectoryUtils.h
@@ -1,0 +1,51 @@
+/*
+ * TrajectoryUtils.h
+ *
+ * Created on: Sept 23, 2022
+ *
+ * Helper functions for trajectories and trajRegions.
+ */
+
+#ifndef TRAJECTORYUTILS_H_
+#define TRAJECTORYUTILS_H_
+
+#include "common.h"
+#include <cmath>
+#include <vector>
+
+namespace kbmod {
+
+/* Compute the predicted trajectory position. */
+inline pixelPos getTrajectoryPos(const trajectory& t, float time)
+{
+    return { t.x + time * t.xVel, t.y + time * t.yVel };
+}
+
+inline pixelPos getTrajectoryPosBC(const trajectory& t, float time,
+                                   const baryCorrection& bc)
+{
+    return { t.x + time*t.xVel + bc.dx + t.x*bc.dxdx + t.y*bc.dxdy,
+             t.y + time*t.yVel + bc.dy + t.x*bc.dydx + t.y*bc.dydy };
+}
+
+/* Compute the average distance between two trajectory's predicted
+   positions. Used in duplicate filtering and clustering. */
+double avePixelDistance(const std::vector<pixelPos>& posA,
+                        const std::vector<pixelPos>& posB);
+
+    
+/* --- Helper functions for trajRegion --------------- */
+
+// Converts a trajRegion result into a trajectory result.
+trajectory convertTrajRegion(const trajRegion& t, float endTime);
+
+// Subdivide the trajRegion into 16 children at the next depth.
+std::vector<trajRegion> subdivideTrajRegion(const trajRegion& t);
+
+// Filter a vector of trajRegion to remove elements that do not
+// have enough observations or likelihood.
+std::vector<trajRegion>& filterTrajRegionsLH(std::vector<trajRegion>& tlist,
+                                             float minLH, int minObs);
+} /* namespace kbmod */
+
+#endif /* TRAJECTORYUTILS_H_ */

--- a/search/src/TrajectoryUtils.h
+++ b/search/src/TrajectoryUtils.h
@@ -33,7 +33,7 @@ inline pixelPos getTrajectoryPosBC(const trajectory& t, float time,
 double avePixelDistance(const std::vector<pixelPos>& posA,
                         const std::vector<pixelPos>& posB);
 
-    
+
 /* --- Helper functions for trajRegion --------------- */
 
 // Converts a trajRegion result into a trajectory result.

--- a/search/src/common.h
+++ b/search/src/common.h
@@ -69,6 +69,12 @@ struct trajRegion {
 	float likelihood;
 	float flux;
 };
+    
+// The position (in pixels) of a trajectory.
+struct pixelPos {
+    float x;
+    float y;
+};
 
 } /* namespace kbmod */
 

--- a/search/src/common.h
+++ b/search/src/common.h
@@ -69,7 +69,7 @@ struct trajRegion {
 	float likelihood;
 	float flux;
 };
-    
+
 // The position (in pixels) of a trajectory.
 struct pixelPos {
     float x;

--- a/search/src/kernels.cu
+++ b/search/src/kernels.cu
@@ -182,6 +182,87 @@ extern "C" void devicePool(int sourceWidth, int sourceHeight, float *source,
 }
 
 /*
+ * Uses pooling to extend min/max regions without reducing the resolution
+ * of the image.
+ */
+__global__ void pool_in_place(int width, int height, float *source, float *dest,
+                              int radius, short mode)
+{
+    const int x = blockIdx.x * POOL_THREAD_DIM + threadIdx.x;
+    const int y = blockIdx.y * POOL_THREAD_DIM + threadIdx.y;
+    if (x >= width || y >= height)
+        return;
+
+    float mp = NO_DATA;
+    float pixel;
+
+    // Compute the bounds over which to pool.
+    int xs = max(x - radius, 0);
+    int xe = min(x + radius, width - 1);
+    int ys = max(y - radius, 0);
+    int ye = min(y + radius, height - 1);
+
+    if (mode == POOL_MAX) 
+    {
+        mp = -FLT_MAX;
+        for (int xi = xs; xi <= xe; ++xi)
+        {
+            for (int yi = ys; yi <= ye; ++yi)
+            {
+                pixel = source[yi * width + xi];
+                mp = (pixel == NO_DATA) ? mp : max(pixel, mp);
+            }
+        }
+        if (mp == -FLT_MAX) mp = NO_DATA;
+    } else {
+        mp = FLT_MAX;
+        for (int xi = xs; xi <= xe; ++xi)
+        {
+            for (int yi = ys; yi <= ye; ++yi)
+            {
+                pixel = source[yi * width + xi];
+                mp = (pixel == NO_DATA) ? mp : min(pixel, mp);
+            }
+        }
+        if (mp == FLT_MAX) mp = NO_DATA;
+    }
+
+    dest[y * width + x] = mp;
+}
+
+extern "C" void devicePoolInPlace(int width, int height, float *source, float *dest,
+                                  int radius, short mode)
+{
+    // Pointers to device memory //
+    float *deviceSourceImg;
+    float *deviceResultImg;
+
+    int pixCount = width * height;
+    dim3 blocks(width/POOL_THREAD_DIM + 1, height/POOL_THREAD_DIM + 1);
+    dim3 threads(POOL_THREAD_DIM, POOL_THREAD_DIM);
+
+    // Allocate Device memory
+    checkCudaErrors(cudaMalloc((void **)&deviceSourceImg, sizeof(float)*pixCount));
+    checkCudaErrors(cudaMalloc((void **)&deviceResultImg, sizeof(float)*pixCount));
+
+    // Copy the source image into GPU memory.
+    checkCudaErrors(cudaMemcpy(deviceSourceImg, source,
+                               sizeof(float)*pixCount,
+                               cudaMemcpyHostToDevice));
+
+    pool_in_place<<<blocks, threads>>> (width, height, deviceSourceImg,
+                                        deviceResultImg, radius, mode);
+
+    // Copy the final image from GPU memory to dest.
+    checkCudaErrors(cudaMemcpy(dest, deviceResultImg,
+                               sizeof(float)*pixCount,
+                               cudaMemcpyDeviceToHost));
+
+    checkCudaErrors(cudaFree(deviceSourceImg));
+    checkCudaErrors(cudaFree(deviceResultImg));
+}
+
+/*
  * Searches through images (represented as a flat array of floats) looking for most likely
  * trajectories in the given list. Outputs a results image of best trajectories. Returns a
  * fixed number of results per pixel specified by RESULTS_PER_PIXEL

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -28,13 +28,11 @@ def make_trajectory(x, y, xv, yv):
 
 class test_evaluate(unittest.TestCase):
     
-    def test_distances(self):
-        dists = trajectory_distances(make_trajectory(5, 6, 10.0, -1.0),
-                                     make_trajectory(5, 7, -10.0, 2.0),
-                                     times=[0.0, 1.0])
-        self.assertEqual(len(dists), 2)
-        self.assertAlmostEqual(dists[0], 1.0)
-        self.assertAlmostEqual(dists[1], 20.396078054, delta=1e-6)
+    def test_ave_distances(self):
+        ave_dist = ave_trajectory_distance(make_trajectory(5, 6, 10.0, -1.0),
+                                           make_trajectory(5, 7, -10.0, 2.0),
+                                           times=[0.0, 1.0])
+        self.assertAlmostEqual(ave_dist, 10.698039027)
 
     def test_match_on_start(self):
         trjA = [make_trajectory(5, 5, 1.0, -1.0),

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -27,7 +27,7 @@ def make_trajectory(x, y, xv, yv):
     return t
 
 class test_evaluate(unittest.TestCase):
-    
+
     def test_ave_distances(self):
         ave_dist = ave_trajectory_distance(make_trajectory(5, 6, 10.0, -1.0),
                                            make_trajectory(5, 7, -10.0, 2.0),
@@ -41,7 +41,7 @@ class test_evaluate(unittest.TestCase):
         trjB = [make_trajectory(5, 5, 1.0, -1.0),
                 make_trajectory(10, 6, 1.0, -1.0),
                 make_trajectory(5, 200, 1.0, -1.0)]
-        
+
         match = find_unique_overlap(trjA, trjB, 2.0, [0.0])
         self.assertEqual(len(match), 2)
         self.assertEqual(match[0].x, 5)
@@ -53,7 +53,7 @@ class test_evaluate(unittest.TestCase):
         self.assertEqual(len(diff), 1)
         self.assertEqual(diff[0].x, 5)
         self.assertEqual(diff[0].y, 20)
-        
+
     def test_match_on_end(self):
         trjA = [make_trajectory(5, 5, 2.0, 0.0),
                 make_trajectory(10, 5, 1.0, -1.0),
@@ -61,7 +61,7 @@ class test_evaluate(unittest.TestCase):
         trjB = [make_trajectory(5, 5, 0.0, -2.0),
                 make_trajectory(10, 6, 1.0, -1.5),
                 make_trajectory(7, 16, 1.0, 2.0)]
-        
+
         match = find_unique_overlap(trjA, trjB, 2.0, [2.0])
         self.assertEqual(len(match), 2)
         self.assertEqual(match[0].x, 10)
@@ -76,4 +76,3 @@ class test_evaluate(unittest.TestCase):
 
 if __name__ == '__main__':
    unittest.main()
-

--- a/tests/test_pooling.py
+++ b/tests/test_pooling.py
@@ -97,6 +97,44 @@ class test_pooling(unittest.TestCase):
       for _ in range(8):
          im = im.pool_max()
       self.assertAlmostEqual(np.array(im)[0][0], test_val, delta=0.001)
- 
+
+   def test_pool_in_place(self):
+      """
+      Tests max pooling in place on a manually constructed 10 x 10 example.
+      """
+      img = kb.raw_image(10, 8)
+      for i in range(10):
+         for j in range(8):
+            img.set_pixel(i, j, 0.0)
+      img.set_pixel(5, 5, 5.0)
+      img.set_pixel(5, 4, 4.0)
+      img.set_pixel(9, 1, 1.0)
+      img.set_pixel(9, 7, kb.KB_NO_DATA)
+      img.set_pixel(9, 6, kb.KB_NO_DATA)
+      img.set_pixel(9, 5, kb.KB_NO_DATA)
+      img.set_pixel(8, 7, kb.KB_NO_DATA)
+      img.set_pixel(8, 6, kb.KB_NO_DATA)
+      img.set_pixel(8, 5, kb.KB_NO_DATA)
+      img.set_pixel(7, 7, kb.KB_NO_DATA)
+      img.set_pixel(7, 6, kb.KB_NO_DATA)
+      img.set_pixel(7, 5, kb.KB_NO_DATA)
+
+      pooled = img.pool_in_place(2, 1)
+      self.assertEqual(pooled.get_height(), 8)
+      self.assertEqual(pooled.get_width(), 10)
+
+      for i in range(10):
+         for j in range(8):
+             if (abs(i - 5) <= 2 and abs(j - 5) <= 2):
+                self.assertAlmostEqual(pooled.get_pixel(i, j), 5.0)
+             elif (abs(i - 5) <= 2 and abs(j - 4) <= 2):
+                self.assertAlmostEqual(pooled.get_pixel(i, j), 4.0)
+             elif (abs(i - 9) <= 2 and abs(j - 1) <= 2):
+                self.assertAlmostEqual(pooled.get_pixel(i, j), 1.0)
+             elif (i == 9 and j == 7):
+                self.assertAlmostEqual(pooled.get_pixel(i, j), kb.KB_NO_DATA)
+             else:
+                self.assertAlmostEqual(pooled.get_pixel(i, j), 0.0)
+
 if __name__ == '__main__':
    unittest.main()

--- a/tests/test_trajectory_utils.py
+++ b/tests/test_trajectory_utils.py
@@ -17,16 +17,16 @@ class test_predicted_position(unittest.TestCase):
         self.trj2.y = 10
         self.trj2.x_v = 0
         self.trj2.y_v = 0
-        
+
     def test_prediction(self):
         p = get_trajectory_pos(self.trj, 0)
         self.assertAlmostEqual(p.x, self.trj.x, delta=1e-5)
         self.assertAlmostEqual(p.y, self.trj.y, delta=1e-5)
-          
+
         p = get_trajectory_pos(self.trj, 0.5)
-        self.assertAlmostEqual(p.x, self.trj.x + 0.5 * self.trj.x_v, 
+        self.assertAlmostEqual(p.x, self.trj.x + 0.5 * self.trj.x_v,
                                delta=1e-5)
-        self.assertAlmostEqual(p.y, self.trj.y + 0.5 * self.trj.y_v, 
+        self.assertAlmostEqual(p.y, self.trj.y + 0.5 * self.trj.y_v,
                                delta=1e-5)
 
     def test_prediction_bc(self):
@@ -43,15 +43,32 @@ class test_predicted_position(unittest.TestCase):
         self.assertAlmostEqual(p.x, true_x, delta=1e-5)
         true_y = self.trj.y + 0.05 + 0.005 * self.trj.x + 0.01 * self.trj.y
         self.assertAlmostEqual(p.y, true_y, delta=1e-5)
-          
+
         p = get_trajectory_pos_bc(self.trj, 2.0, bc)
-        true_x = (self.trj.x + 2.0 * self.trj.x_v + 
+        true_x = (self.trj.x + 2.0 * self.trj.x_v +
                   0.1 + 0.01 * self.trj.x + 0.02 * self.trj.y)
         self.assertAlmostEqual(p.x, true_x, delta=1e-5)
-        true_y = (self.trj.y + 2.0 * self.trj.y_v + 
+        true_y = (self.trj.y + 2.0 * self.trj.y_v +
                   0.05 + 0.005 * self.trj.x + 0.01 * self.trj.y)
         self.assertAlmostEqual(p.y, true_y, delta=1e-5)
-        
+
+    def test_prediction_bc_0(self):
+        bc = baryCorrection()
+        bc.dx = 0.0
+        bc.dxdx = 0.0
+        bc.dxdy = 0.0
+        bc.dy = 0.0
+        bc.dydx = 0.0
+        bc.dydy = 0.0
+
+        p1 = get_trajectory_pos(self.trj, 15.0)
+        p2 = get_trajectory_pos_bc(self.trj, 15.0, bc)
+
+        # With all BaryCorr coefficients set to zero the predictions
+        # should be indentical.
+        self.assertAlmostEqual(p1.x, p2.x, delta=1e-5)
+        self.assertAlmostEqual(p1.y, p2.y, delta=1e-5)
+
     def test_ave_distance(self):
         posA = [get_trajectory_pos(self.trj, 0.0)]
         posB = [get_trajectory_pos(self.trj2, 0.0)]
@@ -93,7 +110,7 @@ class test_predicted_position(unittest.TestCase):
         self.assertEqual(t.obs_count, 19)
         self.assertAlmostEqual(t.lh, 100.0)
         self.assertAlmostEqual(t.flux, 101.0)
-        
+
         # Convert with endTime = 20.0
         t = convert_traj_region(tr, 20.0)
         self.assertEqual(t.x, 15)
@@ -124,7 +141,7 @@ class test_predicted_position(unittest.TestCase):
         self.assertEqual(t.obs_count, 17)
         self.assertAlmostEqual(t.lh, 25.0)
         self.assertAlmostEqual(t.flux, 201.0)
-        
+
         # Convert with endTime = 20.0
         t = convert_traj_region(tr, 20.0)
         self.assertEqual(t.x, 60)
@@ -152,7 +169,7 @@ class test_predicted_position(unittest.TestCase):
             self.assertGreaterEqual(subregions[i].fy, tr.fy*2.0)
             self.assertLessEqual(subregions[i].fx, tr.fx*2.0 + 1.0)
             self.assertLessEqual(subregions[i].fy, tr.fy*2.0 + 1.0)
-            
+
             # Check that no two subregions are the same.
             for j in range(i + 1, 16):
                 self.assertFalse(abs(subregions[i].ix - subregions[j].ix) < 1e-6 and

--- a/tests/test_trajectory_utils.py
+++ b/tests/test_trajectory_utils.py
@@ -1,0 +1,191 @@
+import math
+import unittest
+from kbmod import *
+
+class test_predicted_position(unittest.TestCase):
+
+    def setUp(self):
+        # create a trajectory for the object
+        self.trj = trajectory()
+        self.trj.x = 10
+        self.trj.y = 11
+        self.trj.x_v = 1.0
+        self.trj.y_v = -0.5
+
+        self.trj2 = trajectory()
+        self.trj2.x = 11
+        self.trj2.y = 10
+        self.trj2.x_v = 0
+        self.trj2.y_v = 0
+        
+    def test_prediction(self):
+        p = get_trajectory_pos(self.trj, 0)
+        self.assertAlmostEqual(p.x, self.trj.x, delta=1e-5)
+        self.assertAlmostEqual(p.y, self.trj.y, delta=1e-5)
+          
+        p = get_trajectory_pos(self.trj, 0.5)
+        self.assertAlmostEqual(p.x, self.trj.x + 0.5 * self.trj.x_v, 
+                               delta=1e-5)
+        self.assertAlmostEqual(p.y, self.trj.y + 0.5 * self.trj.y_v, 
+                               delta=1e-5)
+
+    def test_prediction_bc(self):
+        bc = baryCorrection()
+        bc.dx = 0.1
+        bc.dxdx = 0.01
+        bc.dxdy = 0.02
+        bc.dy = 0.05
+        bc.dydx = 0.005
+        bc.dydy = 0.01
+
+        p = get_trajectory_pos_bc(self.trj, 0, bc)
+        true_x = self.trj.x + 0.1 + 0.01 * self.trj.x + 0.02 * self.trj.y
+        self.assertAlmostEqual(p.x, true_x, delta=1e-5)
+        true_y = self.trj.y + 0.05 + 0.005 * self.trj.x + 0.01 * self.trj.y
+        self.assertAlmostEqual(p.y, true_y, delta=1e-5)
+          
+        p = get_trajectory_pos_bc(self.trj, 2.0, bc)
+        true_x = (self.trj.x + 2.0 * self.trj.x_v + 
+                  0.1 + 0.01 * self.trj.x + 0.02 * self.trj.y)
+        self.assertAlmostEqual(p.x, true_x, delta=1e-5)
+        true_y = (self.trj.y + 2.0 * self.trj.y_v + 
+                  0.05 + 0.005 * self.trj.x + 0.01 * self.trj.y)
+        self.assertAlmostEqual(p.y, true_y, delta=1e-5)
+        
+    def test_ave_distance(self):
+        posA = [get_trajectory_pos(self.trj, 0.0)]
+        posB = [get_trajectory_pos(self.trj2, 0.0)]
+        result = ave_trajectory_dist(posA, posB)
+        self.assertAlmostEqual(result, math.sqrt(2.0), delta=1e-5)
+
+        result = ave_trajectory_dist(posB, posA)
+        self.assertAlmostEqual(result, math.sqrt(2.0), delta=1e-5)
+
+        posA.append(get_trajectory_pos(self.trj, 1.0))
+        posB.append(get_trajectory_pos(self.trj2, 1.0))
+        result = ave_trajectory_dist(posA, posB)
+        dist = (math.sqrt(2.0) + 0.5) / 2.0
+        self.assertAlmostEqual(result, dist, delta=1e-5)
+
+        posA.append(get_trajectory_pos(self.trj, 2.0))
+        posB.append(get_trajectory_pos(self.trj2, 2.0))
+        result = ave_trajectory_dist(posA, posB)
+        dist = (math.sqrt(2.0) + 0.5 + 1.0) / 3.0
+        self.assertAlmostEqual(result, dist, delta=1e-5)
+
+    def test_convert_depth0(self):
+        tr = traj_region()
+        tr.ix = 15
+        tr.iy = 23
+        tr.fx = 20
+        tr.fy = 13
+        tr.depth = 0
+        tr.obs_count = 19
+        tr.likelihood = 100.0
+        tr.flux = 101.0
+
+        # Convert with endTime = 10.0
+        t = convert_traj_region(tr, 10.0)
+        self.assertEqual(t.x, 15)
+        self.assertEqual(t.y, 23)
+        self.assertAlmostEqual(t.x_v, 0.5)
+        self.assertAlmostEqual(t.y_v, -1.0)
+        self.assertEqual(t.obs_count, 19)
+        self.assertAlmostEqual(t.lh, 100.0)
+        self.assertAlmostEqual(t.flux, 101.0)
+        
+        # Convert with endTime = 20.0
+        t = convert_traj_region(tr, 20.0)
+        self.assertEqual(t.x, 15)
+        self.assertEqual(t.y, 23)
+        self.assertAlmostEqual(t.x_v, 0.25)
+        self.assertAlmostEqual(t.y_v, -0.5)
+        self.assertEqual(t.obs_count, 19)
+        self.assertAlmostEqual(t.lh, 100.0)
+        self.assertAlmostEqual(t.flux, 101.0)
+
+    def test_convert_depth2(self):
+        tr = traj_region()
+        tr.ix = 15
+        tr.iy = 23
+        tr.fx = 20
+        tr.fy = 13
+        tr.depth = 2
+        tr.obs_count = 17
+        tr.likelihood = 25.0
+        tr.flux = 201.0
+
+        # Convert with endTime = 10.0
+        t = convert_traj_region(tr, 10.0)
+        self.assertEqual(t.x, 60)
+        self.assertEqual(t.y, 92)
+        self.assertAlmostEqual(t.x_v, 2.0)
+        self.assertAlmostEqual(t.y_v, -4.0)
+        self.assertEqual(t.obs_count, 17)
+        self.assertAlmostEqual(t.lh, 25.0)
+        self.assertAlmostEqual(t.flux, 201.0)
+        
+        # Convert with endTime = 20.0
+        t = convert_traj_region(tr, 20.0)
+        self.assertEqual(t.x, 60)
+        self.assertEqual(t.y, 92)
+        self.assertAlmostEqual(t.x_v, 1.0)
+        self.assertAlmostEqual(t.y_v, -2.0)
+
+    def test_subdivide(self):
+        tr = traj_region()
+        tr.ix = 15
+        tr.iy = 23
+        tr.fx = 20
+        tr.fy = 13
+        tr.depth = 2
+
+        subregions = subdivide_traj_region(tr)
+        self.assertEqual(len(subregions), 16)
+        for i in range(16):
+            self.assertEqual(subregions[i].depth, 1)
+            self.assertGreaterEqual(subregions[i].ix, tr.ix*2.0)
+            self.assertGreaterEqual(subregions[i].iy, tr.iy*2.0)
+            self.assertLessEqual(subregions[i].ix, tr.ix*2.0 + 1.0)
+            self.assertLessEqual(subregions[i].iy, tr.iy*2.0 + 1.0)
+            self.assertGreaterEqual(subregions[i].fx, tr.fx*2.0)
+            self.assertGreaterEqual(subregions[i].fy, tr.fy*2.0)
+            self.assertLessEqual(subregions[i].fx, tr.fx*2.0 + 1.0)
+            self.assertLessEqual(subregions[i].fy, tr.fy*2.0 + 1.0)
+            
+            # Check that no two subregions are the same.
+            for j in range(i + 1, 16):
+                self.assertFalse(abs(subregions[i].ix - subregions[j].ix) < 1e-6 and
+                                 abs(subregions[i].iy - subregions[j].iy) < 1e-6 and
+                                 abs(subregions[i].fx - subregions[j].fx) < 1e-6 and
+                                 abs(subregions[i].fy - subregions[j].fy) < 1e-6)
+
+    def test_filter_lh(self):
+        arr = []
+        for i in range(8):
+            tr = traj_region()
+            tr.ix = i
+            tr.obs_count = 10 + i
+            tr.likelihood = 100.0 + 10.0 * i
+            arr.append(tr)
+
+        # Override a few to filter.
+        arr[1].obs_count = 2
+        arr[1].likelihood = 200.0
+        arr[5].obs_count = 20
+        arr[5].likelihood = 2.0
+        arr[6].obs_count = 5
+        arr[6].likelihood = 2.0
+
+        # Check that the correct ones are filtered.
+        arr2 = filter_traj_regions_lh(arr, 100.0, 10)
+        self.assertEqual(len(arr2), 5)
+        self.assertEqual(arr2[0].ix, 0.0)
+        self.assertEqual(arr2[1].ix, 2.0)
+        self.assertEqual(arr2[2].ix, 3.0)
+        self.assertEqual(arr2[3].ix, 4.0)
+        self.assertEqual(arr2[4].ix, 7.0)
+
+if __name__ == '__main__':
+   unittest.main()
+


### PR DESCRIPTION
- Refactor region search to make it more readable.
- Always stop the search at a minDepth = 0 (this was hardcoded before).
- Pull some of the trajectory functions out of KBMOSearch and put them in TrajectoryUtils to make them easier to test (and more general).
- Incorporate the new functions in TrajectoryUtils into evaluate.py for consistency.
- Add a new function that pools an image without reducing the size.
- Change predicted trajectory position to a struct with x/y labels instead of an array.
- Add a bunch of tests.