### PR TITLE
Change handling of single/multi thread computation of PostProccess filtering + more tests

### DIFF
--- a/analysis/analysis_utils.py
+++ b/analysis/analysis_utils.py
@@ -1041,7 +1041,7 @@ class PostProcess(SharedTools):
             keep['final_results'] = np.unique(np.concatenate(passing_stamps_idx))
         print('Keeping %i results' % len(keep['final_results']), flush=True)
         end_time = time.time()
-        time_elapsed = end_time-start_time
+        time_elapsed = end_time - start_time
         print('{:.2f}s elapsed'.format(time_elapsed))
         return(keep)
 

--- a/analysis/run_search.py
+++ b/analysis/run_search.py
@@ -167,7 +167,7 @@ class run_search:
             # Optional values
             'output_suffix':'search', 'mjd_lims':None, 'average_angle':None,
             'do_mask':True, 'mask_num_images':2, 'mask_threshold':120.,
-            'lh_level':10., 'psf_val':1.4, 'num_obs':10, 'num_cores':30,
+            'lh_level':10., 'psf_val':1.4, 'num_obs':10, 'num_cores':1,
             'visit_in_filename':[0,6], 'file_format':'{0:06d}.fits',
             'sigmaG_lims':[25,75], 'chunk_size':500000, 'max_lh':1000.,
             'filter_type':'clipped_sigmaG', 'center_thresh':0.00,

--- a/tests/run_tests.bash
+++ b/tests/run_tests.bash
@@ -1,8 +1,8 @@
 if hash python3 2>/dev/null; then
-    python3 -m unittest
+    python3 -m unittest -b
 elif hash python 2>/dev/null; then
     if python -c 'import sys; print(sys.version_info[0])' | grep -q 3; then
-        python -m unittest
+        python -m unittest -b
     else
         echo "Python detected, but it must be version 3.x"
     fi

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -19,9 +19,9 @@ class test_kernels_wrappers(unittest.TestCase):
         self.config['repeated_flag_keys'] = None
         
         # Set up old_results object for analysis_utils.PostProcess
-        psi_curves = [[1., 1., 1.], [1., 1., 1.], [1., 1., 1.]]
-        phi_curves = [[1., 1., 1.], [1., 1., 1.], [1., 1., 1.]]
-        results = [1., 1., 1.]
+        psi_curves = [[1. + (x / 100) for x in range(20)] for _ in range(3)]
+        phi_curves = [[1. + (y / 100) for y in range(20)] for _ in range(3)]
+        results = [1. for _ in range(3)]
         
         self.old_results = {}
         self.old_results['psi_curves'] = psi_curves
@@ -56,8 +56,8 @@ class test_kernels_wrappers(unittest.TestCase):
         self.trj.y_v = self.y_vel
 
         # search parameters
-        self.angle_steps = 150
-        self.velocity_steps = 150
+        self.angle_steps = 10
+        self.velocity_steps = 10
         self.min_angle = 0.0
         self.max_angle = 1.5
         self.min_vel = 5.0
@@ -69,13 +69,13 @@ class test_kernels_wrappers(unittest.TestCase):
         
         self.imlist = []
         for i in range(self.imCount):
-            time = i/self.imCount
+            time = i / self.imCount
             im = layered_image(str(i), self.dim_x, self.dim_y, 
-                                self.noise_level, self.variance, time,
-                                self.p)
-            im.add_object(self.start_x + time*self.x_vel+0.5,
-                           self.start_y + time*self.y_vel+0.5,
-                           self.object_flux)
+                               self.noise_level, self.variance, time,
+                               self.p)
+            im.add_object(self.start_x + time * self.x_vel + 0.5,
+                          self.start_y + time * self.y_vel + 0.5,
+                          self.object_flux)
 
             # Mask a pixel in half the images.
             if i % 2 == 0:
@@ -96,8 +96,8 @@ class test_kernels_wrappers(unittest.TestCase):
         self.stack = image_stack(self.imlist)
         self.search = stack_search(self.stack)
         self.search.search(self.angle_steps, self.velocity_steps,
-                         self.min_angle, self.max_angle, self.min_vel,
-                         self.max_vel, int(self.imCount/2))
+                           self.min_angle, self.max_angle, self.min_vel,
+                           self.max_vel, int(self.imCount/2))
         
         mjds = np.array(self.stack.get_times())
         self.keep = kb_p.load_results(
@@ -310,7 +310,7 @@ class test_kernels_wrappers(unittest.TestCase):
         
         self.assertEqual(len(res), 3)
         for r in res:
-            self.assertEqual(r[1], [-1])
+            self.assertFalse(np.any(res[1] == -1))
     
     def test_apply_clipped_average_multi_thread(self):
         self.config['num_cores'] = 2
@@ -320,7 +320,7 @@ class test_kernels_wrappers(unittest.TestCase):
         
         self.assertEqual(len(res), 3)
         for r in res:
-            self.assertEqual(r[1], [-1])
+            self.assertFalse(np.any(res[1]) == -1)
             
     def test_apply_clipped_sigmaG_single_thread(self):
         kb_post_process = PostProcess(self.config)


### PR DESCRIPTION
- changed default number of cores from 30 to 1
- made it so that if the number of cores is set to 1, PostProcess will calculate filters single threaded for a speed boost
- added unit tests for filters in both single and multi thread