### PR TITLE
Simplify _calc_eclip_angle function.

### DIFF
--- a/analysis/analysis_utils.py
+++ b/analysis/analysis_utils.py
@@ -238,53 +238,60 @@ class Interface(SharedTools):
             pickle.dump({"min_LH_per_px": keep["min_LH_per_px"], "num_res_per_px": keep["num_res_per_px"]}, f)
         np.save("%s/all_ps_%s.npy" % (res_filepath, out_suffix), stamps_to_save)
 
-    def _calc_ecliptic_angle(self, test_wcs, angle_to_ecliptic=0.0):
+    def _calc_ecliptic_angle(self, wcs, angle_to_ecliptic=0.0):
         """
-        This function calculates the ecliptic angle of an image using the
-        World Coordinate System (WCS). However, it is degenerate with respect
-        to PI. This is to say, the returned answer may be off by PI (180
-        degrees)
-        INPUT-
-            test_wcs : astropy WCS
-                The WCS from a fits file, as loaded in with astropy.wcs.WCS()
-            angle_to_ecliptic : [NEEDS DOC STRING]
-        OUTPUT-
-            eclip_angle : float
-                The angle to the ecliptic for the fits file corresponding to
-                test_wcs. NOTE- May be off by +/- PI (180 degrees)
+        Projects an unit-vector parallel with the ecliptic onto the image
+        and calculates the angle of the projected unit-vector in the pixel
+        space.
+
+        Parameters
+        ----------
+        wcs : `astropy.wcs.WCS`
+            World Coordinate System object.
+        angle_to_ecliptic : `float`, optional
+            Angle to ecliptic, default: 0.0 
+
+        Returns
+        -------
+        angle : `float`
+            Angle the projected unit-vector parallel to the ecliptic 
+            closes with the image axes. Used to transform the specified
+            search angles, with respect to the ecliptic, to search angles
+            within the image.
+
+        Note
+        ----
+        It is not neccessary to calculate this angle for each image in an
+        image set if they have all been warped to a common WCS.
+
+        See Also
+        --------
+        run_search.do_gpu_search
         """
-        pixel_coords = [[], []]
-        pixel_start = [[1000, 2000]]
-        angle = float(angle_to_ecliptic)
-        vel_array = np.array([[6.0 * np.cos(angle), 6.0 * np.sin(angle)]])
-        time_array = [0.0, 1.0, 2.0]
-        vel_par_arr = vel_array[:, 0]
-        vel_perp_arr = vel_array[:, 1]
+        # pick a starting pixel approximately near the center of the image
+        # convert it to ecliptic coordinates
+        start_pixel = np.array([1000, 2000])
+        start_pixel_coord = astroCoords.SkyCoord.from_pixel(
+            start_pixel[0], 
+            start_pixel[1], 
+            wcs)
+        start_ecliptic_coord = start_pixel_coord.geocentrictrueecliptic
 
-        if type(vel_par_arr) is not np.ndarray:
-            vel_par_arr = [vel_par_arr]
-        if type(vel_perp_arr) is not np.ndarray:
-            vel_perp_arr = [vel_perp_arr]
-        for start_loc, vel_par, vel_perp in zip(pixel_start, vel_par_arr, vel_perp_arr):
-
-            start_coord = astroCoords.SkyCoord.from_pixel(start_loc[0], start_loc[1], test_wcs)
-            eclip_coord = start_coord.geocentrictrueecliptic
-            eclip_l = []
-            eclip_b = []
-            for time_step in time_array:
-                eclip_l.append(eclip_coord.lon + vel_par * time_step * u.arcsec)
-                eclip_b.append(eclip_coord.lat + vel_perp * time_step * u.arcsec)
-            eclip_vector = astroCoords.SkyCoord(eclip_l, eclip_b, frame="geocentrictrueecliptic")
-            pixel_coords_set = astroCoords.SkyCoord.to_pixel(eclip_vector, test_wcs)
-            pixel_coords[0].append(pixel_coords_set[0])
-            pixel_coords[1].append(pixel_coords_set[1])
-
-        pixel_coords = np.array(pixel_coords)
-        x_dist = pixel_coords[0, 0, -1] - pixel_coords[0, 0, 0]
-        y_dist = pixel_coords[1, 0, -1] - pixel_coords[1, 0, 0]
-        eclip_angle = np.arctan2(y_dist, x_dist)
-
-        return eclip_angle
+        # pick a guess pixel by moving parallel to the ecliptic
+        # convert it to pixel coordinates for the given WCS
+        vel_par = 6
+        vel_perp = 0
+        time_step = 2
+        guess_ecliptic_coord = astroCoords.SkyCoord(
+            start_ecliptic_coord.lon + vel_par*time_step*u.arcsec,
+            start_ecliptic_coord.lat + vel_perp*time_step*u.arcsec,
+            frame="geocentrictrueecliptic")
+        guess_pixel_coord = guess_ecliptic_coord.to_pixel(wcs)
+        
+        # calculate the distance, in pixel coordinates, between the guess and 
+        # the start pixel. Calculate the angle that represents in the image.
+        x_dist, y_dist = np.array(guess_pixel_coord) - start_pixel
+        return np.arctan2(y_dist/x_dist) 
 
     def _calc_barycentric_corr(self, wcslist, mjdlist, x_size, y_size, dist):
         """


### PR DESCRIPTION
The current function implementation is needlessly convoluted and its doc-string does not accurately represent what the function does. 

The new code performs the same function - it pick a starting point approximately near the center of the image (I assume), converts it to ecliptic coordinates, moves the point in parallel with the ecliptic by `6-velocity-units*2-time-units*arcseconds` distance, converts the new point back to pixel coordinates and calculates the angle that distance represents in pixel coordinates. See image. 
<img src="https://user-images.githubusercontent.com/29500910/198150656-d014e25e-41f6-4d4d-9d01-3d8bf1871fb9.jpg" width=50%>

Regarding what the angle represents -  the function is called only once in the whole codebase, inside `load_images` code and is only called for the first image in the `image_set`. The returned value is then passed to `do_gpu_search` 
https://github.com/dirac-institute/kbmod/blob/cee465be438df5f0ec4b8284a5d5be8f4931ba80/analysis/run_search.py#L123
where it is then used to offset search angles https://github.com/dirac-institute/kbmod/blob/cee465be438df5f0ec4b8284a5d5be8f4931ba80/analysis/run_search.py#L126
My best guess is that it offsets the given search angles in the search parameter configuration, which are given with respect to the ecliptic, to the image space. This is fine to perform for the first image only, because they have all been warped to the same WCS. 

Regarding the degeneracy with respect to `pi` - I think this is something left over from previous code versions that was fixed in https://github.com/dirac-institute/kbmod/commit/4910b63d2ea6e51be5985fe1c019bf83b5293920 but never saw the docstring updated. 

I'm not sure what the `angle_to_ecliptic` actually does - it's not utilized anywhere. This is also a bit of a problem regarding v0.5.0 which has the `atan` call, making the results of the two confusing to compare to me. I want to make this a full PR after getting rid of `vel_par`, `vel_perp` and `time_step` and replacing it with a function parameter `step`, similar with the `start_pixel`, but before that I wanted to get someone else to take another look at this and maybe help out with that docstring explanation.