### PR TITLE
Clean ups and refactoring pre-work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _version.py
 CMakeCache.txt
 CMakeFiles
 requirements.txt
+.DS_Store

--- a/src/kbmod/search/Filtering.cpp
+++ b/src/kbmod/search/Filtering.cpp
@@ -47,8 +47,8 @@ std::vector<int> sigmaGFilteredIndices(const std::vector<float>& values, float s
 }
 
 std::vector<int> clippedAverageFilteredIndices(const std::vector<float>& psi_curve,
-                                               const std::vector<float>& phi_curve,
-                                               int num_clipped, int n_sigma, float lower_lh_limit) {
+                                               const std::vector<float>& phi_curve, int num_clipped,
+                                               int n_sigma, float lower_lh_limit) {
     /*
      * This function applies a clipped median filter to a set of likelihood values. The largest
      * likelihood values (N=num_clipped) are eliminated if they are more than n_sigma*st_dev
@@ -67,10 +67,10 @@ std::vector<int> clippedAverageFilteredIndices(const std::vector<float>& psi_cur
      * Returns: The indices of psi & phi that pass the filtering.
      */
     const int num_times = psi_curve.size();
-    assert (num_times == phi_curve.size());
+    assert(num_times == phi_curve.size());
 
     // Compute the likelihood for each index.
-    std::vector<std::pair<float, int> > scores;
+    std::vector<std::pair<float, int>> scores;
     for (int t = 0; t < num_times; ++t) {
         float val = 0.0;
         if ((psi_curve[t] == NO_DATA) || (phi_curve[t] == NO_DATA)) {
@@ -110,8 +110,9 @@ std::vector<int> clippedAverageFilteredIndices(const std::vector<float>& psi_cur
     if (num_values % 2 == 1) {
         median_val = scores[(last_valid + first_valid) / 2].first;
     } else {
-        median_val = (scores[(last_valid + first_valid) / 2].first
-                      + scores[(last_valid + first_valid) / 2 + 1].first) / 2.0;
+        median_val = (scores[(last_valid + first_valid) / 2].first +
+                      scores[(last_valid + first_valid) / 2 + 1].first) /
+                     2.0;
     }
 
     // Compute the mean and variance of the non-filtered LHs.

--- a/src/kbmod/search/Filtering.h
+++ b/src/kbmod/search/Filtering.h
@@ -23,8 +23,8 @@ std::vector<int> sigmaGFilteredIndices(const std::vector<float>& values, float s
 // likelihood values (N=num_clipped) are eliminated if they are more than n_sigma*st_dev
 // away from the median, which is calculated excluding the largest values.
 std::vector<int> clippedAverageFilteredIndices(const std::vector<float>& psi_curve,
-                                               const std::vector<float>& phi_curve,
-                                               int num_clipped, int n_sigma, float lower_lh_limit);
+                                               const std::vector<float>& phi_curve, int num_clipped,
+                                               int n_sigma, float lower_lh_limit);
 
 double calculateLikelihoodFromPsiPhi(std::vector<double> psiValues, std::vector<double> phiValues);
 

--- a/src/kbmod/search/ImageStack.cpp
+++ b/src/kbmod/search/ImageStack.cpp
@@ -72,7 +72,7 @@ LayeredImage& ImageStack::getSingleImage(int index) {
     if (index < 0 || index > images.size()) throw std::runtime_error("ImageStack index out of bounds.");
     return images[index];
 }
-    
+
 void ImageStack::setSingleImage(int index, LayeredImage& img) {
     if (index < 0 || index > images.size()) throw std::runtime_error("ImageStack index out of bounds.");
     images[index] = img;
@@ -93,9 +93,7 @@ void ImageStack::convolvePSF() {
     for (auto& i : images) i.convolvePSF();
 }
 
-void ImageStack::saveGlobalMask(const std::string& path) {
-    globalMask.saveToFile(path, false);
-}
+void ImageStack::saveGlobalMask(const std::string& path) { globalMask.saveToFile(path, false); }
 
 void ImageStack::saveImages(const std::string& path) {
     for (auto& i : images) i.saveLayers(path);

--- a/src/kbmod/search/KBMORegionSearch.cpp
+++ b/src/kbmod/search/KBMORegionSearch.cpp
@@ -17,8 +17,8 @@ KBMORegionSearch::KBMORegionSearch(ImageStack& imstack) : KBMOSearch(imstack) {
     nodesProcessed = 0;
 }
 
-std::vector<trajRegion> KBMORegionSearch::regionSearch(float xVel, float yVel, float radius,
-                                                       float minLH, int minObservations) {
+std::vector<trajRegion> KBMORegionSearch::regionSearch(float xVel, float yVel, float radius, float minLH,
+                                                       int minObservations) {
     preparePsiPhi();
     startTimer("Searching regions");
     std::vector<trajRegion> res = resSearch(xVel, yVel, radius, minObservations, minLH);
@@ -53,8 +53,8 @@ void KBMORegionSearch::repoolArea(trajRegion& t, std::vector<PooledImage>& poole
     }
 }
 
-std::vector<trajRegion> KBMORegionSearch::resSearch(float xVel, float yVel, float radius,
-                                                    int minObservations, float minLH) {
+std::vector<trajRegion> KBMORegionSearch::resSearch(float xVel, float yVel, float radius, int minObservations,
+                                                    float minLH) {
     startTimer("Pooling images");
     std::vector<PooledImage> pooledPsi = PoolMultipleImages(psiImages, POOL_MAX, false);
     std::vector<PooledImage> pooledPhi = PoolMultipleImages(phiImages, POOL_MIN, false);
@@ -125,7 +125,8 @@ std::vector<trajRegion>& KBMORegionSearch::filterBounds(std::vector<trajRegion>&
             std::remove_if(
                     tlist.begin(), tlist.end(),
                     std::bind(
-                            [](trajRegion t, KBMORegionSearch* s, float xv, float yv, float finalT, float rad) {
+                            [](trajRegion t, KBMORegionSearch* s, float xv, float yv, float finalT,
+                               float rad) {
                                 // 2 raised to the depth power
                                 float scale = std::pow(2.0, static_cast<float>(t.depth));
                                 float centerX = scale * (t.fx + 0.5);
@@ -206,7 +207,8 @@ void KBMORegionSearch::calculateLH(trajRegion& t, std::vector<PooledImage>& pool
     t.flux = phiSum > 0.0 ? psiSum / phiSum : NO_DATA;
 }
 
-float KBMORegionSearch::findExtremeInRegion(float x, float y, int size, PooledImage& pooledImgs, int poolType) {
+float KBMORegionSearch::findExtremeInRegion(float x, float y, int size, PooledImage& pooledImgs,
+                                            int poolType) {
     regionsMaxed++;
     // check that maxSize is a power of two
     assert((size & (-size)) == size);

--- a/src/kbmod/search/KBMOSearch.cpp
+++ b/src/kbmod/search/KBMOSearch.cpp
@@ -233,68 +233,145 @@ void KBMOSearch::fillPsiAndPhiVects(const std::vector<RawImage>& psiImgs,
             phiVect->push_back(phiRef[p]);
         }
     }
+} 
+
+std::vector<RawImage> KBMOSearch::scienceStamps(const TrajectoryResult& trj, int radius, bool interpolate,
+                                                bool keep_no_data, bool all_stamps) {
+    std::vector<RawImage> stamps;
+    int num_times = stack.imgCount();
+    const trajectory& t = trj.get_const_trajectory();
+    for (int i = 0; i < num_times; ++i) {
+        if (all_stamps || trj.check_index_valid(i)) {
+            pixelPos pos = getTrajPos(t, i);
+            RawImage& img = stack.getSingleImage(i).getScience();
+            stamps.push_back(img.createStamp(pos.x, pos.y, radius, interpolate, keep_no_data));
+        }
+    }
+    return stamps;
 }
 
+inline std::vector<RawImage> KBMOSearch::scienceStampsForFilter(const TrajectoryResult& trj, int radius) {
+    return scienceStamps(trj, radius, false, true, false);
+}
+
+inline std::vector<RawImage> KBMOSearch::scienceStampsForViz(const TrajectoryResult& trj, int radius) {
+    return scienceStamps(trj, radius, true, false, true);
+}
+
+std::vector<RawImage> KBMOSearch::scienceStamps(trajectory& t, int radius) {
+    TrajectoryResult trj(t, stack.imgCount());
+    return scienceStampsForViz(trj, radius);
+}
+
+
+RawImage KBMOSearch::medianScienceStamp(const TrajectoryResult& trj, int radius, bool use_all) {
+    return createMedianImage(scienceStamps(trj, radius, false, true, use_all));
+}
+
+std::vector<RawImage> KBMOSearch::medianScienceStamps(const std::vector<TrajectoryResult>& t_array,
+                                                      int radius) {
+    const int num_results = t_array.size();
+    std::vector<RawImage> results(num_results);
+    omp_set_num_threads(16);
+
+#pragma omp parallel for
+    for (int s = 0; s < num_results; ++s) {
+        results[s] = medianScienceStamp(t_array[s], radius, true);
+    }
+    omp_set_num_threads(1);
+
+    return (results);
+}
+
+// To be deprecated in later PR.
 std::vector<RawImage> KBMOSearch::medianStamps(const std::vector<trajectory>& t_array,
                                                const std::vector<std::vector<int>>& goodIdx, int radius) {
-    int numResults = t_array.size();
-    int dim = radius * 2 + 1;
+    const int num_results = t_array.size();
+    std::vector<TrajectoryResult> arr;
+    for (int s = 0; s < num_results; ++s) {
+        TrajectoryResult trj(t_array[s], goodIdx[s]);
+        arr.push_back(trj);
+    }
 
-    std::vector<LayeredImage>& imgs = stack.getImages();
-    size_t N = imgs.size() / 2;
-    std::vector<RawImage> results(numResults);
+    return medianScienceStamps(arr, radius);
+}
+
+
+RawImage KBMOSearch::meanScienceStamp(const TrajectoryResult& trj, int radius, bool use_all) {
+    return createMeanImage(scienceStamps(trj, radius, false, true, use_all));
+}
+
+std::vector<RawImage> KBMOSearch::meanScienceStamps(const std::vector<TrajectoryResult>& t_array,
+                                                    int radius) {
+    const int num_results = t_array.size();
+    std::vector<RawImage> results(num_results);
     omp_set_num_threads(16);
 
 #pragma omp parallel for
-    for (int s = 0; s < numResults; ++s) {
-        // Create stamps around the current trajectory.
-        std::vector<RawImage> stamps;
-        trajectory t = t_array[s];
-        for (int i = 0; i < goodIdx[s].size(); ++i) {
-            if (goodIdx[s][i] == 1) {
-                pixelPos pos = getTrajPos(t, i);
-                stamps.push_back(imgs[i].getScience().createStamp(pos.x, pos.y, radius, false, true));
-            }
-        }
-
-        // Compute the median of those stamps.
-        results[s] = createMedianImage(stamps);
+    for (int s = 0; s < num_results; ++s) {
+        results[s] = meanScienceStamp(t_array[s], radius, true);
     }
     omp_set_num_threads(1);
 
     return (results);
 }
 
+// To be deprecated in later PR.
 std::vector<RawImage> KBMOSearch::meanStamps(const std::vector<trajectory>& t_array,
                                              const std::vector<std::vector<int>>& goodIdx, int radius) {
-    int numResults = t_array.size();
-    int dim = radius * 2 + 1;
+    const int num_results = t_array.size();
+    std::vector<TrajectoryResult> arr;
+    for (int s = 0; s < num_results; ++s) {
+        TrajectoryResult trj(t_array[s], goodIdx[s]);
+        arr.push_back(trj);
+    }
 
-    std::vector<LayeredImage>& imgs = stack.getImages();
-    size_t N = imgs.size() / 2;
-    std::vector<RawImage> results(numResults);
+    return meanScienceStamps(arr, radius);
+}
+
+
+RawImage KBMOSearch::summedScienceStamp(const TrajectoryResult& trj, int radius, bool use_all) {
+    return createSummedImage(scienceStamps(trj, radius, false, true, use_all));
+}
+
+// To be deprecated in later PR.
+RawImage KBMOSearch::stackedScience(trajectory& t, int radius) {
+    TrajectoryResult trj(t, stack.imgCount());
+    return createSummedImage(scienceStamps(trj, radius, false, false, true));
+}                                           
+
+std::vector<RawImage> KBMOSearch::summedScienceStamps(const std::vector<TrajectoryResult>& t_array,
+                                                      int radius) {
+    const int num_results = t_array.size();
+    std::vector<RawImage> results(num_results);
     omp_set_num_threads(16);
 
 #pragma omp parallel for
-    for (int s = 0; s < numResults; ++s) {
-        // Create stamps around the current trajectory.
-        std::vector<RawImage> stamps;
-        trajectory t = t_array[s];
-        for (int i = 0; i < goodIdx[s].size(); ++i) {
-            if (goodIdx[s][i] == 1) {
-                pixelPos pos = getTrajPos(t, i);
-                stamps.push_back(imgs[i].getScience().createStamp(pos.x, pos.y, radius, false, true));
-            }
-        }
-
-        // Compute the mean of those stamps.
-        results[s] = createMeanImage(stamps);
+    for (int s = 0; s < num_results; ++s) {
+        results[s] = summedScienceStamp(t_array[s], radius, true);
     }
     omp_set_num_threads(1);
 
     return (results);
 }
 
+// To be deprecated in later PR.
+std::vector<RawImage> KBMOSearch::summedScience(const std::vector<trajectory>& t_array, int radius) {
+    int numResults = t_array.size();
+    std::vector<RawImage> results(numResults);
+
+    // Build the result for each trajectory.
+    omp_set_num_threads(30);
+#pragma omp parallel for
+    for (int s = 0; s < numResults; ++s) {
+        TrajectoryResult trj(t_array[s], stack.imgCount());
+        results[s] = createSummedImage(scienceStamps(trj, radius, false, false, true));
+    }
+    omp_set_num_threads(1);
+
+    return (results);
+}
+    
 std::vector<RawImage> KBMOSearch::createStamps(trajectory t, int radius, const std::vector<RawImage*>& imgs,
                                                bool interpolate) {
     if (radius < 0) throw std::runtime_error("stamp radius must be at least 0");
@@ -358,45 +435,6 @@ std::vector<float> KBMOSearch::createCurves(trajectory t, const std::vector<RawI
         lightcurve.push_back(pixVal);
     }
     return lightcurve;
-}
-
-std::vector<RawImage> KBMOSearch::scienceStamps(trajectory& t, int radius) {
-    std::vector<RawImage*> imgs;
-    for (auto& im : stack.getImages()) imgs.push_back(&im.getScience());
-    return createStamps(t, radius, imgs, true);
-}
-
-RawImage KBMOSearch::stackedScience(trajectory& t, int radius) {
-    std::vector<RawImage*> imgs;
-    for (auto& im : stack.getImages()) imgs.push_back(&im.getScience());
-
-    std::vector<RawImage> stamps = createStamps(t, radius, imgs, false);
-    RawImage summedStamp = createSummedImage(stamps);
-    return summedStamp;
-}
-
-std::vector<RawImage> KBMOSearch::summedScience(const std::vector<trajectory>& t_array, int radius) {
-    int numResults = t_array.size();
-    std::vector<RawImage> results(numResults);
-
-    // Extract the science images.
-    std::vector<RawImage*> imgs;
-    for (auto& im : stack.getImages()) imgs.push_back(&im.getScience());
-
-    // Build the result for each trajectory.
-    omp_set_num_threads(30);
-#pragma omp parallel for
-    for (int s = 0; s < numResults; ++s) {
-        // Create stamps around the current trajectory.
-        trajectory t = t_array[s];
-        std::vector<RawImage> stamps = createStamps(t, radius, imgs, false);
-
-        // Compute the summation of those stamps.
-        results[s] = createSummedImage(stamps);
-    }
-    omp_set_num_threads(1);
-
-    return (results);
 }
 
 std::vector<RawImage> KBMOSearch::psiStamps(trajectory& t, int radius) {

--- a/src/kbmod/search/KBMOSearch.cpp
+++ b/src/kbmod/search/KBMOSearch.cpp
@@ -233,7 +233,7 @@ void KBMOSearch::fillPsiAndPhiVects(const std::vector<RawImage>& psiImgs,
             phiVect->push_back(phiRef[p]);
         }
     }
-} 
+}
 
 std::vector<RawImage> KBMOSearch::scienceStamps(const TrajectoryResult& trj, int radius, bool interpolate,
                                                 bool keep_no_data, bool all_stamps) {
@@ -262,7 +262,6 @@ std::vector<RawImage> KBMOSearch::scienceStamps(trajectory& t, int radius) {
     TrajectoryResult trj(t, stack.imgCount());
     return scienceStampsForViz(trj, radius);
 }
-
 
 RawImage KBMOSearch::medianScienceStamp(const TrajectoryResult& trj, int radius, bool use_all) {
     return createMedianImage(scienceStamps(trj, radius, false, true, use_all));
@@ -296,7 +295,6 @@ std::vector<RawImage> KBMOSearch::medianStamps(const std::vector<trajectory>& t_
     return medianScienceStamps(arr, radius);
 }
 
-
 RawImage KBMOSearch::meanScienceStamp(const TrajectoryResult& trj, int radius, bool use_all) {
     return createMeanImage(scienceStamps(trj, radius, false, true, use_all));
 }
@@ -329,7 +327,6 @@ std::vector<RawImage> KBMOSearch::meanStamps(const std::vector<trajectory>& t_ar
     return meanScienceStamps(arr, radius);
 }
 
-
 RawImage KBMOSearch::summedScienceStamp(const TrajectoryResult& trj, int radius, bool use_all) {
     return createSummedImage(scienceStamps(trj, radius, false, true, use_all));
 }
@@ -338,7 +335,7 @@ RawImage KBMOSearch::summedScienceStamp(const TrajectoryResult& trj, int radius,
 RawImage KBMOSearch::stackedScience(trajectory& t, int radius) {
     TrajectoryResult trj(t, stack.imgCount());
     return createSummedImage(scienceStamps(trj, radius, false, false, true));
-}                                           
+}
 
 std::vector<RawImage> KBMOSearch::summedScienceStamps(const std::vector<TrajectoryResult>& t_array,
                                                       int radius) {
@@ -371,7 +368,7 @@ std::vector<RawImage> KBMOSearch::summedScience(const std::vector<trajectory>& t
 
     return (results);
 }
-    
+
 std::vector<RawImage> KBMOSearch::createStamps(trajectory t, int radius, const std::vector<RawImage*>& imgs,
                                                bool interpolate) {
     if (radius < 0) throw std::runtime_error("stamp radius must be at least 0");
@@ -428,8 +425,7 @@ std::vector<float> KBMOSearch::createCurves(trajectory t, const std::vector<RawI
         }
         /* Does not use getTrajPos to be backwards compatible with Hits_Rerun */
         else {
-            pixVal =
-                    imgs[i].getPixel(t.x + int(times[i] * t.xVel + 0.5), t.y + int(times[i] * t.yVel + 0.5));
+            pixVal = imgs[i].getPixel(t.x + int(times[i] * t.xVel + 0.5), t.y + int(times[i] * t.yVel + 0.5));
         }
         if (pixVal == NO_DATA) pixVal = 0.0;
         lightcurve.push_back(pixVal);

--- a/src/kbmod/search/KBMOSearch.h
+++ b/src/kbmod/search/KBMOSearch.h
@@ -73,7 +73,7 @@ public:
     std::vector<RawImage> medianScienceStamps(const std::vector<TrajectoryResult>& t_array, int radius);
     std::vector<RawImage> meanScienceStamps(const std::vector<TrajectoryResult>& t_array, int radius);
     std::vector<RawImage> summedScienceStamps(const std::vector<TrajectoryResult>& t_array, int radius);
-    
+
     // Functions to create and access stamps around proposed trajectories or
     // regions. Used to visualize the results.
     // These functions drop pixels with NO_DATA from the computation.

--- a/src/kbmod/search/KBMOSearch.h
+++ b/src/kbmod/search/KBMOSearch.h
@@ -60,6 +60,20 @@ public:
     void filterResults(int minObservations);
     void filterResultsLH(float minLH);
 
+    // Functions for creating science stamps for filtering, visualization, etc. User can specify
+    // the radius of the stamp, whether to interpolate among pixels, whether to keep NO_DATA values
+    // or replace them with zero, and whether to use all stamps or just the unfiltered indices.
+    std::vector<RawImage> scienceStamps(const TrajectoryResult& trj, int radius, bool interpolate,
+                                        bool keep_no_data, bool all_stamps);
+    std::vector<RawImage> scienceStampsForFilter(const TrajectoryResult& trj, int radius);
+    std::vector<RawImage> scienceStampsForViz(const TrajectoryResult& trj, int radius);
+    RawImage medianScienceStamp(const TrajectoryResult& trj, int radius, bool use_all);
+    RawImage meanScienceStamp(const TrajectoryResult& trj, int radius, bool use_all);
+    RawImage summedScienceStamp(const TrajectoryResult& trj, int radius, bool use_all);
+    std::vector<RawImage> medianScienceStamps(const std::vector<TrajectoryResult>& t_array, int radius);
+    std::vector<RawImage> meanScienceStamps(const std::vector<TrajectoryResult>& t_array, int radius);
+    std::vector<RawImage> summedScienceStamps(const std::vector<TrajectoryResult>& t_array, int radius);
+    
     // Functions to create and access stamps around proposed trajectories or
     // regions. Used to visualize the results.
     // These functions drop pixels with NO_DATA from the computation.

--- a/src/kbmod/search/LayeredImage.cpp
+++ b/src/kbmod/search/LayeredImage.cpp
@@ -24,8 +24,8 @@ LayeredImage::LayeredImage(std::string path, const PointSpreadFunc& psf) : psf(p
 
 LayeredImage::LayeredImage(std::string name, int w, int h, float noiseStDev, float pixelVariance, double time,
                            const PointSpreadFunc& psf)
-    : LayeredImage(name, w, h, noiseStDev, pixelVariance, time, psf, -1) { }
-    
+        : LayeredImage(name, w, h, noiseStDev, pixelVariance, time, psf, -1) {}
+
 LayeredImage::LayeredImage(std::string name, int w, int h, float noiseStDev, float pixelVariance, double time,
                            const PointSpreadFunc& psf, int seed)
         : psf(psf), psfSQ(psf) {
@@ -39,7 +39,9 @@ LayeredImage::LayeredImage(std::string name, int w, int h, float noiseStDev, flo
     std::vector<float> rawSci(pixelsPerImage);
     std::random_device r;
     std::default_random_engine generator(r());
-    if (seed >= 0) { generator.seed(seed); }
+    if (seed >= 0) {
+        generator.seed(seed);
+    }
     std::normal_distribution<float> distrib(0.0, noiseStDev);
     for (float& p : rawSci) p = distrib(generator);
     science = RawImage(w, h, rawSci);

--- a/src/kbmod/search/PooledImage.cpp
+++ b/src/kbmod/search/PooledImage.cpp
@@ -8,8 +8,8 @@
 
 namespace search {
 
-PooledImage::PooledImage(const RawImage& org_image, int mode, bool pool_symmetric) :
-        images(), pool_mode(mode), symmetric(pool_symmetric) {
+PooledImage::PooledImage(const RawImage& org_image, int mode, bool pool_symmetric)
+        : images(), pool_mode(mode), symmetric(pool_symmetric) {
     images.push_back(org_image);
 
     int last_ind = 0;

--- a/src/kbmod/search/TrajectoryUtils.cpp
+++ b/src/kbmod/search/TrajectoryUtils.cpp
@@ -10,6 +10,40 @@
 
 namespace search {
 
+TrajectoryResult::TrajectoryResult(const trajectory& trj, int num_times) :
+        trj_(trj), num_times_(num_times) {
+    valid_indices_.resize(num_times, true);
+}
+
+TrajectoryResult::TrajectoryResult(const trajectory& trj, const std::vector<int>& binary_valid) : trj_(trj) {
+    num_times_ = binary_valid.size();
+    valid_indices_.reserve(num_times_);
+    for (int i = 0; i < num_times_; ++i) {
+        valid_indices_[i] = (binary_valid[i] != 0);
+    }
+}
+
+TrajectoryResult::TrajectoryResult(const trajectory& trj, int num_times, const std::vector<int>& valid_indices) :
+        trj_(trj), num_times_(num_times) {
+    const int num_valid = valid_indices.size();
+    valid_indices_.resize(num_times, false);
+    for (int i = 0; i < num_valid; ++i) {
+        int ind = valid_indices[i];
+        assert((ind >= 0) && (ind < num_times_));
+        valid_indices_[ind] = true;
+    }
+}
+
+inline bool TrajectoryResult::check_index_valid(int index) const {
+    return ((index >= 0) && (index < num_times_)) ? valid_indices_[index] : false;
+}
+
+inline void TrajectoryResult::set_index_valid(int index, bool is_valid) {
+    if ((index >= 0) && (index < num_times_)) {
+        valid_indices_[index] = is_valid;
+    }
+}
+
 /* Compute the average distance between two trajectories at the
    given time steps. Used in duplicate filtering and clustering. */
 double aveTrajectoryDistance(const std::vector<pixelPos>& posA, const std::vector<pixelPos>& posB) {

--- a/src/kbmod/search/TrajectoryUtils.cpp
+++ b/src/kbmod/search/TrajectoryUtils.cpp
@@ -10,8 +10,7 @@
 
 namespace search {
 
-TrajectoryResult::TrajectoryResult(const trajectory& trj, int num_times) :
-        trj_(trj), num_times_(num_times) {
+TrajectoryResult::TrajectoryResult(const trajectory& trj, int num_times) : trj_(trj), num_times_(num_times) {
     valid_indices_.resize(num_times, true);
 }
 
@@ -23,8 +22,9 @@ TrajectoryResult::TrajectoryResult(const trajectory& trj, const std::vector<int>
     }
 }
 
-TrajectoryResult::TrajectoryResult(const trajectory& trj, int num_times, const std::vector<int>& valid_indices) :
-        trj_(trj), num_times_(num_times) {
+TrajectoryResult::TrajectoryResult(const trajectory& trj, int num_times,
+                                   const std::vector<int>& valid_indices)
+        : trj_(trj), num_times_(num_times) {
     const int num_valid = valid_indices.size();
     valid_indices_.resize(num_times, false);
     for (int i = 0; i < num_valid; ++i) {

--- a/src/kbmod/search/TrajectoryUtils.cpp
+++ b/src/kbmod/search/TrajectoryUtils.cpp
@@ -44,6 +44,14 @@ inline void TrajectoryResult::set_index_valid(int index, bool is_valid) {
     }
 }
 
+std::vector<int> TrajectoryResult::get_valid_indices_list() const {
+    std::vector<int> inds;
+    for (int i = 0; i < num_times_; ++i) {
+        if (valid_indices_[i]) inds.push_back(i);
+    }
+    return inds;
+}
+
 /* Compute the average distance between two trajectories at the
    given time steps. Used in duplicate filtering and clustering. */
 double aveTrajectoryDistance(const std::vector<pixelPos>& posA, const std::vector<pixelPos>& posB) {

--- a/src/kbmod/search/TrajectoryUtils.h
+++ b/src/kbmod/search/TrajectoryUtils.h
@@ -14,7 +14,7 @@
 #include <vector>
 
 namespace search {
-    
+
 /* TrajectoryResult provides a wrapper for results that can be passed to filtering functions. */
 class TrajectoryResult {
 public:
@@ -27,7 +27,7 @@ public:
     // Take in an array of the individual indices that are valid.
     TrajectoryResult(const trajectory& trj, int num_times, const std::vector<int>& valid_indices);
 
-    virtual ~TrajectoryResult() {};
+    virtual ~TrajectoryResult(){};
 
     // Simple inline getters.
     trajectory& get_trajectory() { return trj_; }

--- a/src/kbmod/search/TrajectoryUtils.h
+++ b/src/kbmod/search/TrajectoryUtils.h
@@ -35,6 +35,9 @@ public:
     int num_times() const { return num_times_; }
     bool check_index_valid(int index) const;
 
+    // Get the list of indices that are valid. Takes linear time.
+    std::vector<int> get_valid_indices_list() const;
+
     // Simple inline setters.
     void set_index_valid(int index, bool is_valid);
 

--- a/src/kbmod/search/TrajectoryUtils.h
+++ b/src/kbmod/search/TrajectoryUtils.h
@@ -14,6 +14,35 @@
 #include <vector>
 
 namespace search {
+    
+/* TrajectoryResult provides a wrapper for results that can be passed to filtering functions. */
+class TrajectoryResult {
+public:
+    // Default all indices to valid.
+    TrajectoryResult(const trajectory& trj, int num_times);
+
+    // Take in a binary array indicating if each element is valid (1) or invalid (0).
+    TrajectoryResult(const trajectory& trj, const std::vector<int>& binary_valid);
+
+    // Take in an array of the individual indices that are valid.
+    TrajectoryResult(const trajectory& trj, int num_times, const std::vector<int>& valid_indices);
+
+    virtual ~TrajectoryResult() {};
+
+    // Simple inline getters.
+    trajectory& get_trajectory() { return trj_; }
+    const trajectory& get_const_trajectory() const { return trj_; }
+    int num_times() const { return num_times_; }
+    bool check_index_valid(int index) const;
+
+    // Simple inline setters.
+    void set_index_valid(int index, bool is_valid);
+
+private:
+    trajectory trj_;
+    int num_times_;
+    std::vector<bool> valid_indices_;
+};
 
 /* Compute the predicted trajectory position. */
 inline pixelPos computeTrajPos(const trajectory& t, float time) {

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -21,6 +21,7 @@ using is = search::ImageStack;
 using ks = search::KBMOSearch;
 using krs = search::KBMORegionSearch;
 using tj = search::trajectory;
+using tjr = search::TrajectoryResult;
 using bc = search::baryCorrection;
 using td = search::trajRegion;
 using pp = search::pixelPos;
@@ -222,6 +223,14 @@ PYBIND11_MODULE(search, m) {
                               " obs_count: " + to_string(t.obsCount);
             }
         );
+    py::class_<tjr>(m, "trj_result")
+        .def(py::init<tj&, int>())
+        .def(py::init<tj&, std::vector<int> >())
+        .def(py::init<tj&, int, std::vector<int> >())
+        .def("get_trajectory", &tjr::get_trajectory)
+        .def("num_times", &tjr::num_times)
+        .def("check_index_valid", &tjr::check_index_valid)
+        .def("set_index_valid", &tjr::set_index_valid);
     py::class_<pp>(m, "pixel_pos")
         .def(py::init<>())
         .def_readwrite("x", &pp::x)

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -32,247 +32,226 @@ using std::to_string;
 PYBIND11_MODULE(search, m) {
     m.attr("KB_NO_DATA") = pybind11::float_(search::NO_DATA);
     py::class_<pf>(m, "psf", py::buffer_protocol())
-        .def_buffer([](pf &m) -> py::buffer_info {
-            return py::buffer_info(
-                m.kernelData(),
-                sizeof(float),
-                py::format_descriptor<float>::format(),
-                2,
-                { m.getDim(), m.getDim() },
-                { sizeof(float) * m.getDim(),
-                  sizeof(float) }
-            );
-        })
-        .def(py::init<float>())
-        .def(py::init<py::array_t<float>>())
-        .def(py::init<pf &>())
-        .def("set_array", &pf::setArray)
-        .def("get_stdev", &pf::getStdev)
-        .def("get_sum", &pf::getSum)
-        .def("get_dim", &pf::getDim)
-        .def("get_radius", &pf::getRadius)
-        .def("get_size", &pf::getSize)
-        .def("get_kernel", &pf::getKernel)
-        .def("square_psf", &pf::squarePSF)
-        .def("print_psf", &pf::printPSF);
+            .def_buffer([](pf &m) -> py::buffer_info {
+                return py::buffer_info(m.kernelData(), sizeof(float), py::format_descriptor<float>::format(),
+                                       2, {m.getDim(), m.getDim()},
+                                       {sizeof(float) * m.getDim(), sizeof(float)});
+            })
+            .def(py::init<float>())
+            .def(py::init<py::array_t<float>>())
+            .def(py::init<pf &>())
+            .def("set_array", &pf::setArray)
+            .def("get_stdev", &pf::getStdev)
+            .def("get_sum", &pf::getSum)
+            .def("get_dim", &pf::getDim)
+            .def("get_radius", &pf::getRadius)
+            .def("get_size", &pf::getSize)
+            .def("get_kernel", &pf::getKernel)
+            .def("square_psf", &pf::squarePSF)
+            .def("print_psf", &pf::printPSF);
 
     py::class_<ri>(m, "raw_image", py::buffer_protocol())
-        .def_buffer([](ri &m) -> py::buffer_info {
-            return py::buffer_info(
-                m.getDataRef(),
-                sizeof(float),
-                py::format_descriptor<float>::format(),
-                2,
-                { m.getHeight(), m.getWidth() },
-                { sizeof(float) * m.getWidth(),
-                  sizeof(float) }
-            );
-        })
-        .def(py::init<int, int>())
-        .def(py::init<py::array_t<float>>())
-        .def("get_height", &ri::getHeight)
-        .def("get_width", &ri::getWidth)
-        .def("get_ppi", &ri::getPPI)
-        .def("set_array", &ri::setArray)
-        .def("compute_bounds", &ri::computeBounds)
-        .def("pool", &ri::pool)
-        .def("pool_min", &ri::poolMin)
-        .def("pool_max", &ri::poolMax)
-        .def("create_stamp", &ri::createStamp)
-        .def("set_pixel", &ri::setPixel)
-        .def("add_pixel", &ri::addToPixel)
-        .def("apply_mask", &ri::applyMask)
-        .def("mask_object", &ri::maskObject)
-        .def("grow_mask", &ri::growMask)
-        .def("pixel_has_data", &ri::pixelHasData)
-        .def("set_all", &ri::setAllPix)
-        .def("get_pixel", &ri::getPixel)
-        .def("get_pixel_interp", &ri::getPixelInterp)
-        .def("get_ppi", &ri::getPPI)
-        .def("extreme_in_region", &ri::extremeInRegion)
-        .def("convolve", &ri::convolve)
-        .def("save_fits", &ri::saveToFile);
+            .def_buffer([](ri &m) -> py::buffer_info {
+                return py::buffer_info(m.getDataRef(), sizeof(float), py::format_descriptor<float>::format(),
+                                       2, {m.getHeight(), m.getWidth()},
+                                       {sizeof(float) * m.getWidth(), sizeof(float)});
+            })
+            .def(py::init<int, int>())
+            .def(py::init<py::array_t<float>>())
+            .def("get_height", &ri::getHeight)
+            .def("get_width", &ri::getWidth)
+            .def("get_ppi", &ri::getPPI)
+            .def("set_array", &ri::setArray)
+            .def("compute_bounds", &ri::computeBounds)
+            .def("pool", &ri::pool)
+            .def("pool_min", &ri::poolMin)
+            .def("pool_max", &ri::poolMax)
+            .def("create_stamp", &ri::createStamp)
+            .def("set_pixel", &ri::setPixel)
+            .def("add_pixel", &ri::addToPixel)
+            .def("apply_mask", &ri::applyMask)
+            .def("mask_object", &ri::maskObject)
+            .def("grow_mask", &ri::growMask)
+            .def("pixel_has_data", &ri::pixelHasData)
+            .def("set_all", &ri::setAllPix)
+            .def("get_pixel", &ri::getPixel)
+            .def("get_pixel_interp", &ri::getPixelInterp)
+            .def("get_ppi", &ri::getPPI)
+            .def("extreme_in_region", &ri::extremeInRegion)
+            .def("convolve", &ri::convolve)
+            .def("save_fits", &ri::saveToFile);
     m.def("create_median_image", &search::createMedianImage);
     m.def("create_summed_image", &search::createSummedImage);
     m.def("create_mean_image", &search::createMeanImage);
     py::class_<li>(m, "layered_image")
-        .def(py::init<const std::string, pf&>())
-        .def(py::init<std::string, int, int, double, float, float, pf&>())
-        .def(py::init<std::string, int, int, double, float, float, pf&, int>())
-        .def("set_psf", &li::setPSF)
-        .def("get_psf", &li::getPSF)
-        .def("get_psfsq", &li::getPSFSQ)
-        .def("apply_mask_flags", &li::applyMaskFlags)
-        .def("apply_mask_threshold", &li::applyMaskThreshold)
-        .def("sub_template", &li::subtractTemplate)
-        .def("save_layers", &li::saveLayers)
-        .def("save_sci", &li::saveSci)
-        .def("save_mask", &li::saveMask)
-        .def("save_var", &li::saveVar)
-        .def("get_science", &li::getScience)
-        .def("get_mask", &li::getMask)
-        .def("get_variance", &li::getVariance)
-        .def("set_science", &li::setScience)
-        .def("set_mask", &li::setMask)
-        .def("set_variance", &li::setVariance)
-        .def("convolve_psf", &li::convolvePSF)
-        .def("add_object", &li::addObject)
-        .def("mask_object", &li::maskObject)
-        .def("grow_mask", &li::growMask)
-        .def("get_name", &li::getName)
-        .def("get_width", &li::getWidth)
-        .def("get_height", &li::getHeight)
-        .def("get_ppi", &li::getPPI)
-        .def("get_time", &li::getTime)
-        .def("set_time", &li::setTime)
-        .def("generate_psi_image", &li::generatePsiImage)
-        .def("generate_phi_image", &li::generatePhiImage);
+            .def(py::init<const std::string, pf &>())
+            .def(py::init<std::string, int, int, double, float, float, pf &>())
+            .def(py::init<std::string, int, int, double, float, float, pf &, int>())
+            .def("set_psf", &li::setPSF)
+            .def("get_psf", &li::getPSF)
+            .def("get_psfsq", &li::getPSFSQ)
+            .def("apply_mask_flags", &li::applyMaskFlags)
+            .def("apply_mask_threshold", &li::applyMaskThreshold)
+            .def("sub_template", &li::subtractTemplate)
+            .def("save_layers", &li::saveLayers)
+            .def("save_sci", &li::saveSci)
+            .def("save_mask", &li::saveMask)
+            .def("save_var", &li::saveVar)
+            .def("get_science", &li::getScience)
+            .def("get_mask", &li::getMask)
+            .def("get_variance", &li::getVariance)
+            .def("set_science", &li::setScience)
+            .def("set_mask", &li::setMask)
+            .def("set_variance", &li::setVariance)
+            .def("convolve_psf", &li::convolvePSF)
+            .def("add_object", &li::addObject)
+            .def("mask_object", &li::maskObject)
+            .def("grow_mask", &li::growMask)
+            .def("get_name", &li::getName)
+            .def("get_width", &li::getWidth)
+            .def("get_height", &li::getHeight)
+            .def("get_ppi", &li::getPPI)
+            .def("get_time", &li::getTime)
+            .def("set_time", &li::setTime)
+            .def("generate_psi_image", &li::generatePsiImage)
+            .def("generate_phi_image", &li::generatePhiImage);
     py::class_<is>(m, "image_stack")
-        .def(py::init<std::vector<std::string>, std::vector<pf> >())
-        .def(py::init<std::vector<li>>())
-        .def("get_images", &is::getImages)
-        .def("get_single_image", &is::getSingleImage)
-        .def("set_single_image", &is::setSingleImage)
-        .def("get_times", &is::getTimes)
-        .def("set_times", &is::setTimes)
-        .def("img_count", &is::imgCount)
-        .def("apply_mask_flags", &is::applyMaskFlags)
-        .def("apply_mask_threshold", &is::applyMaskThreshold)
-        .def("apply_global_mask", &is::applyGlobalMask)
-        .def("grow_mask", &is::growMask)
-        .def("simple_difference", &is::simpleDifference)
-        .def("save_global_mask", &is::saveGlobalMask)
-        .def("save_images", &is::saveImages)
-        .def("get_global_mask", &is::getGlobalMask)
-        .def("get_sciences", &is::getSciences)
-        .def("get_masks", &is::getMasks)
-        .def("get_variances", &is::getVariances)
-        .def("convolve_psf", &is::convolvePSF)
-        .def("get_width", &is::getWidth)
-        .def("get_height", &is::getHeight)
-        .def("get_ppi", &is::getPPI);
+            .def(py::init<std::vector<std::string>, std::vector<pf>>())
+            .def(py::init<std::vector<li>>())
+            .def("get_images", &is::getImages)
+            .def("get_single_image", &is::getSingleImage)
+            .def("set_single_image", &is::setSingleImage)
+            .def("get_times", &is::getTimes)
+            .def("set_times", &is::setTimes)
+            .def("img_count", &is::imgCount)
+            .def("apply_mask_flags", &is::applyMaskFlags)
+            .def("apply_mask_threshold", &is::applyMaskThreshold)
+            .def("apply_global_mask", &is::applyGlobalMask)
+            .def("grow_mask", &is::growMask)
+            .def("simple_difference", &is::simpleDifference)
+            .def("save_global_mask", &is::saveGlobalMask)
+            .def("save_images", &is::saveImages)
+            .def("get_global_mask", &is::getGlobalMask)
+            .def("get_sciences", &is::getSciences)
+            .def("get_masks", &is::getMasks)
+            .def("get_variances", &is::getVariances)
+            .def("convolve_psf", &is::convolvePSF)
+            .def("get_width", &is::getWidth)
+            .def("get_height", &is::getHeight)
+            .def("get_ppi", &is::getPPI);
     py::class_<pi>(m, "pooled_image")
-        .def(py::init<ri, int, bool>())
-        .def("num_levels", &pi::numLevels)
-        .def("get_base_height", &pi::getBaseHeight)
-        .def("get_base_width", &pi::getBaseWidth)
-        .def("get_base_ppi", &pi::getBasePPI)
-        .def("get_images", &pi::getImages)
-        .def("get_image", &pi::getImage)
-        .def("get_pixel", &pi::getPixel)
-        .def("contains_pixel", &pi::containsPixel)
-        .def("get_pixel_dist_bounds", &pi::getPixelDistanceBounds)
-        .def("get_mapped_pixel_at_depth", &pi::getMappedPixelAtDepth)
-        .def("repool_area", &pi::repoolArea);
+            .def(py::init<ri, int, bool>())
+            .def("num_levels", &pi::numLevels)
+            .def("get_base_height", &pi::getBaseHeight)
+            .def("get_base_width", &pi::getBaseWidth)
+            .def("get_base_ppi", &pi::getBasePPI)
+            .def("get_images", &pi::getImages)
+            .def("get_image", &pi::getImage)
+            .def("get_pixel", &pi::getPixel)
+            .def("contains_pixel", &pi::containsPixel)
+            .def("get_pixel_dist_bounds", &pi::getPixelDistanceBounds)
+            .def("get_mapped_pixel_at_depth", &pi::getMappedPixelAtDepth)
+            .def("repool_area", &pi::repoolArea);
     m.def("pool_multiple_images", &search::PoolMultipleImages);
     py::class_<ks>(m, "stack_search")
-        .def(py::init<is &>())
-        .def("save_psi_phi", &ks::savePsiPhi)
-        .def("search", &ks::search)
-        .def("enable_gpu_sigmag_filter", &ks::enableGPUSigmaGFilter)
-        .def("enable_gpu_encoding", &ks::enableGPUEncoding)
-        .def("enable_corr", &ks::enableCorr)
-        .def("set_debug", &ks::setDebug)
-        .def("filter_min_obs", &ks::filterResults)
-        .def("get_num_images", &ks::numImages)
-        .def("get_image_stack", &ks::getImageStack)
-        // For testing
-        .def("get_traj_pos", &ks::getTrajPos)
-        .def("get_mult_traj_pos", &ks::getMultTrajPos)
-        .def("stacked_sci", (ri (ks::*)(tj &, int)) &ks::stackedScience, "set")
-        .def("summed_sci", (std::vector<ri> (ks::*)(std::vector<tj>, int)) &ks::summedScience)
-        .def("mean_stamps", (std::vector<ri> (ks::*)(std::vector<tj>, std::vector<std::vector<int>>, int)) &ks::meanStamps)
-        .def("median_stamps", (std::vector<ri> (ks::*)(std::vector<tj>, std::vector<std::vector<int>>, int)) &ks::medianStamps)
-        .def("sci_stamps", (std::vector<ri> (ks::*)(tj &, int)) &ks::scienceStamps, "set")
-        .def("psi_stamps", (std::vector<ri> (ks::*)(tj &, int)) &ks::psiStamps, "set2")
-        .def("phi_stamps", (std::vector<ri> (ks::*)(tj &, int)) &ks::phiStamps, "set3")
-        .def("psi_curves", (std::vector<float> (ks::*)(tj &)) &ks::psiCurves)
-        .def("phi_curves", (std::vector<float> (ks::*)(tj &)) &ks::phiCurves)
-        .def("prepare_psi_phi", &ks::preparePsiPhi)
-        .def("get_psi_images", &ks::getPsiImages)
-        .def("get_phi_images", &ks::getPhiImages)
-        .def("get_results", &ks::getResults)
-        .def("save_results", &ks::saveResults);
+            .def(py::init<is &>())
+            .def("save_psi_phi", &ks::savePsiPhi)
+            .def("search", &ks::search)
+            .def("enable_gpu_sigmag_filter", &ks::enableGPUSigmaGFilter)
+            .def("enable_gpu_encoding", &ks::enableGPUEncoding)
+            .def("enable_corr", &ks::enableCorr)
+            .def("set_debug", &ks::setDebug)
+            .def("filter_min_obs", &ks::filterResults)
+            .def("get_num_images", &ks::numImages)
+            .def("get_image_stack", &ks::getImageStack)
+            // For testing
+            .def("get_traj_pos", &ks::getTrajPos)
+            .def("get_mult_traj_pos", &ks::getMultTrajPos)
+            .def("stacked_sci", (ri(ks::*)(tj &, int)) & ks::stackedScience, "set")
+            .def("summed_sci", (std::vector<ri>(ks::*)(std::vector<tj>, int)) & ks::summedScience)
+            .def("mean_stamps",
+                 (std::vector<ri>(ks::*)(std::vector<tj>, std::vector<std::vector<int>>, int)) &
+                         ks::meanStamps)
+            .def("median_stamps",
+                 (std::vector<ri>(ks::*)(std::vector<tj>, std::vector<std::vector<int>>, int)) &
+                         ks::medianStamps)
+            .def("sci_stamps", (std::vector<ri>(ks::*)(tj &, int)) & ks::scienceStamps, "set")
+            .def("psi_stamps", (std::vector<ri>(ks::*)(tj &, int)) & ks::psiStamps, "set2")
+            .def("phi_stamps", (std::vector<ri>(ks::*)(tj &, int)) & ks::phiStamps, "set3")
+            .def("psi_curves", (std::vector<float>(ks::*)(tj &)) & ks::psiCurves)
+            .def("phi_curves", (std::vector<float>(ks::*)(tj &)) & ks::phiCurves)
+            .def("prepare_psi_phi", &ks::preparePsiPhi)
+            .def("get_psi_images", &ks::getPsiImages)
+            .def("get_phi_images", &ks::getPhiImages)
+            .def("get_results", &ks::getResults)
+            .def("save_results", &ks::saveResults);
     py::class_<krs, ks>(m, "stack_region_search")
-        .def(py::init<is &>())
-        .def("region_search", &krs::regionSearch)
-        // For testing
-        .def("extreme_in_region", &krs::findExtremeInRegion)
-        .def("filter_bounds", &krs::filterBounds)
-        .def("square_sdf", &krs::squareSDF)
-        .def("stacked_sci", (ri (krs::*)(td &, int)) &krs::stackedScience, "set")
-        .def("sci_stamps", (std::vector<ri> (krs::*)(td &, int)) &krs::scienceStamps, "set4")
-        .def("psi_stamps", (std::vector<ri> (krs::*)(td &, int)) &krs::psiStamps, "set5")
-        .def("phi_stamps", (std::vector<ri> (krs::*)(td &, int)) &krs::phiStamps, "set6");
+            .def(py::init<is &>())
+            .def("region_search", &krs::regionSearch)
+            // For testing
+            .def("extreme_in_region", &krs::findExtremeInRegion)
+            .def("filter_bounds", &krs::filterBounds)
+            .def("square_sdf", &krs::squareSDF)
+            .def("stacked_sci", (ri(krs::*)(td &, int)) & krs::stackedScience, "set")
+            .def("sci_stamps", (std::vector<ri>(krs::*)(td &, int)) & krs::scienceStamps, "set4")
+            .def("psi_stamps", (std::vector<ri>(krs::*)(td &, int)) & krs::psiStamps, "set5")
+            .def("phi_stamps", (std::vector<ri>(krs::*)(td &, int)) & krs::phiStamps, "set6");
     py::class_<tj>(m, "trajectory")
-        .def(py::init<>())
-        .def_readwrite("x_v", &tj::xVel)
-        .def_readwrite("y_v", &tj::yVel)
-        .def_readwrite("lh", &tj::lh)
-        .def_readwrite("flux", &tj::flux)
-        .def_readwrite("x", &tj::x)
-        .def_readwrite("y", &tj::y)
-        .def_readwrite("obs_count", &tj::obsCount)
-        .def("__repr__", [](const tj &t) {
-            return "lh: " + to_string(t.lh) + 
-                            " flux: " + to_string(t.flux) + 
-                   " x: " + to_string(t.x) + 
-                               " y: " + to_string(t.y) + 
-                  " x_v: " + to_string(t.xVel) + 
-                              " y_v: " + to_string(t.yVel) +
-                              " obs_count: " + to_string(t.obsCount);
-            }
-        );
+            .def(py::init<>())
+            .def_readwrite("x_v", &tj::xVel)
+            .def_readwrite("y_v", &tj::yVel)
+            .def_readwrite("lh", &tj::lh)
+            .def_readwrite("flux", &tj::flux)
+            .def_readwrite("x", &tj::x)
+            .def_readwrite("y", &tj::y)
+            .def_readwrite("obs_count", &tj::obsCount)
+            .def("__repr__", [](const tj &t) {
+                return "lh: " + to_string(t.lh) + " flux: " + to_string(t.flux) + " x: " + to_string(t.x) +
+                       " y: " + to_string(t.y) + " x_v: " + to_string(t.xVel) + " y_v: " + to_string(t.yVel) +
+                       " obs_count: " + to_string(t.obsCount);
+            });
     py::class_<tjr>(m, "trj_result")
-        .def(py::init<tj&, int>())
-        .def(py::init<tj&, std::vector<int> >())
-        .def(py::init<tj&, int, std::vector<int> >())
-        .def("get_trajectory", &tjr::get_trajectory)
-        .def("num_times", &tjr::num_times)
-        .def("check_index_valid", &tjr::check_index_valid)
-        .def("set_index_valid", &tjr::set_index_valid);
+            .def(py::init<tj &, int>())
+            .def(py::init<tj &, std::vector<int>>())
+            .def(py::init<tj &, int, std::vector<int>>())
+            .def("get_trajectory", &tjr::get_trajectory)
+            .def("num_times", &tjr::num_times)
+            .def("check_index_valid", &tjr::check_index_valid)
+            .def("set_index_valid", &tjr::set_index_valid);
     py::class_<pp>(m, "pixel_pos")
-        .def(py::init<>())
-        .def_readwrite("x", &pp::x)
-        .def_readwrite("y", &pp::y)
-        .def("__repr__", [](const pp &p) {
-            return "x: " + to_string(p.x) + " y: " + to_string(p.y);
-            }
-        );
+            .def(py::init<>())
+            .def_readwrite("x", &pp::x)
+            .def_readwrite("y", &pp::y)
+            .def("__repr__", [](const pp &p) { return "x: " + to_string(p.x) + " y: " + to_string(p.y); });
     py::class_<bc>(m, "baryCorrection")
-        .def(py::init<>())
-        .def_readwrite("dx", &bc::dx)
-        .def_readwrite("dxdx", &bc::dxdx)
-        .def_readwrite("dxdy", &bc::dxdy)
-        .def_readwrite("dy", &bc::dy)
-        .def_readwrite("dydx", &bc::dydx)
-        .def_readwrite("dydy", &bc::dydy)
-        .def("__repr__", [](const bc &b) {
-            return "dx = " + to_string(b.dx) + " + " + to_string(b.dxdx) + " x + " + to_string(b.dxdy) + " y; "+
-                " dy = " + to_string(b.dy) + " + " + to_string(b.dydx) + " x + " + to_string(b.dydy)+ " y";
-            }
-        );
+            .def(py::init<>())
+            .def_readwrite("dx", &bc::dx)
+            .def_readwrite("dxdx", &bc::dxdx)
+            .def_readwrite("dxdy", &bc::dxdy)
+            .def_readwrite("dy", &bc::dy)
+            .def_readwrite("dydx", &bc::dydx)
+            .def_readwrite("dydy", &bc::dydy)
+            .def("__repr__", [](const bc &b) {
+                return "dx = " + to_string(b.dx) + " + " + to_string(b.dxdx) + " x + " + to_string(b.dxdy) +
+                       " y; " + " dy = " + to_string(b.dy) + " + " + to_string(b.dydx) + " x + " +
+                       to_string(b.dydy) + " y";
+            });
     py::class_<td>(m, "traj_region")
-        .def(py::init<>())
-        .def_readwrite("ix", &td::ix)
-        .def_readwrite("iy", &td::iy)
-        .def_readwrite("fx", &td::fx)
-        .def_readwrite("fy", &td::fy)
-        .def_readwrite("depth", &td::depth)
-        .def_readwrite("obs_count", &td::obs_count)
-        .def_readwrite("likelihood", &td::likelihood)
-        .def_readwrite("flux", &td::flux)
-        .def("__repr__", [](const td &t) {
-            return "ix: " + to_string(t.ix) +
-                              " iy: " + to_string(t.iy) +
-                  " fx: " + to_string(t.fx) +
-                              " fy: " + to_string(t.fy) +
-               " depth: " + to_string(static_cast<int>(t.depth)) +
+            .def(py::init<>())
+            .def_readwrite("ix", &td::ix)
+            .def_readwrite("iy", &td::iy)
+            .def_readwrite("fx", &td::fx)
+            .def_readwrite("fy", &td::fy)
+            .def_readwrite("depth", &td::depth)
+            .def_readwrite("obs_count", &td::obs_count)
+            .def_readwrite("likelihood", &td::likelihood)
+            .def_readwrite("flux", &td::flux)
+            .def("__repr__", [](const td &t) {
+                return "ix: " + to_string(t.ix) + " iy: " + to_string(t.iy) + " fx: " + to_string(t.fx) +
+                       " fy: " + to_string(t.fy) + " depth: " + to_string(static_cast<int>(t.depth)) +
                        " obs_count: " + to_string(static_cast<int>(t.obs_count)) +
-                  " lh: " + to_string(t.likelihood) +
-                 " flux " + to_string(t.flux);
-            }
-        );
+                       " lh: " + to_string(t.likelihood) + " flux " + to_string(t.flux);
+            });
     // Functions from Filtering.cpp
     m.def("sigmag_filtered_indices", &search::sigmaGFilteredIndices);
     m.def("kalman_filtered_indices", &search::kalmanFiteredIndices);
@@ -287,4 +266,3 @@ PYBIND11_MODULE(search, m) {
     m.def("subdivide_traj_region", &search::subdivideTrajRegion);
     m.def("filter_traj_regions_lh", &search::filterTrajRegionsLH);
 }
-

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -164,9 +164,15 @@ PYBIND11_MODULE(search, m) {
             .def("filter_min_obs", &ks::filterResults)
             .def("get_num_images", &ks::numImages)
             .def("get_image_stack", &ks::getImageStack)
-            // For testing
-            .def("get_traj_pos", &ks::getTrajPos)
-            .def("get_mult_traj_pos", &ks::getMultTrajPos)
+            // Science Stamp Functions
+            .def("science_viz_stamps", &ks::scienceStampsForViz)
+            .def("science_filter_stamps", &ks::scienceStampsForFilter)
+            .def("median_sci_stamp", &ks::medianScienceStamp)
+            .def("mean_sci_stamp", &ks::meanScienceStamp)
+            .def("summed_sci_stamp", &ks::summedScienceStamp)
+            .def("median_sci_stamps", &ks::medianScienceStamps)
+            .def("mean_sci_stamps", &ks::meanScienceStamps)
+            .def("summed_sci_stamps", &ks::summedScienceStamps)
             .def("stacked_sci", (ri(ks::*)(tj &, int)) & ks::stackedScience, "set")
             .def("summed_sci", (std::vector<ri>(ks::*)(std::vector<tj>, int)) & ks::summedScience)
             .def("mean_stamps",
@@ -176,6 +182,9 @@ PYBIND11_MODULE(search, m) {
                  (std::vector<ri>(ks::*)(std::vector<tj>, std::vector<std::vector<int>>, int)) &
                          ks::medianStamps)
             .def("sci_stamps", (std::vector<ri>(ks::*)(tj &, int)) & ks::scienceStamps, "set")
+            // For testing
+            .def("get_traj_pos", &ks::getTrajPos)
+            .def("get_mult_traj_pos", &ks::getMultTrajPos)
             .def("psi_stamps", (std::vector<ri>(ks::*)(tj &, int)) & ks::psiStamps, "set2")
             .def("phi_stamps", (std::vector<ri>(ks::*)(tj &, int)) & ks::phiStamps, "set3")
             .def("psi_curves", (std::vector<float>(ks::*)(tj &)) & ks::psiCurves)
@@ -215,6 +224,7 @@ PYBIND11_MODULE(search, m) {
             .def(py::init<tj &, std::vector<int>>())
             .def(py::init<tj &, int, std::vector<int>>())
             .def("get_trajectory", &tjr::get_trajectory)
+            .def("get_valid_indices_list", &tjr::get_valid_indices_list)
             .def("num_times", &tjr::num_times)
             .def("check_index_valid", &tjr::check_index_valid)
             .def("set_index_valid", &tjr::set_index_valid);

--- a/tests/test_trajectory_utils.py
+++ b/tests/test_trajectory_utils.py
@@ -19,6 +19,51 @@ class test_predicted_position(unittest.TestCase):
         self.trj2.x_v = 0
         self.trj2.y_v = 0
 
+    def test_trajectory_result_default(self):
+        res = trj_result(self.trj, 10)
+        inds = res.get_valid_indices_list()
+        self.assertEqual(res.num_times(), 10)
+        self.assertEqual(len(inds), 10)
+        for i in range(10):
+            self.assertTrue(res.check_index_valid(i))
+            self.assertEqual(inds[i], i)
+
+        # Set 3 and 6 False
+        res.set_index_valid(3, False)
+        res.set_index_valid(6, False)
+
+        # Check that the False indices are showing as False.
+        inds = res.get_valid_indices_list()
+        self.assertEqual(res.num_times(), 10)
+        self.assertEqual(len(inds), 8)
+        for i in range(10):
+            if i != 3 and i != 6:
+                self.assertTrue(res.check_index_valid(i))
+                self.assertTrue(i in inds)
+            else:
+                self.assertFalse(res.check_index_valid(i))
+                self.assertFalse(i in inds)
+
+    def test_trajectory_result_indices(self):
+        valid = [1, 2, 5, 6, 7]
+        res = trj_result(self.trj, 10, valid)
+        inds = res.get_valid_indices_list()
+        self.assertEqual(res.num_times(), 10)
+        self.assertEqual(len(inds), len(valid))
+        for i in range(10):
+            self.assertEqual(res.check_index_valid(i), i in valid)
+            self.assertEqual(i in inds, i in valid)
+
+    def test_trajectory_result_boolean(self):
+        valid = [0, 1, 1, 0, 0, 1, 0, 1, 1, 0]
+        res = trj_result(self.trj, valid)
+        inds = res.get_valid_indices_list()
+        self.assertEqual(res.num_times(), 10)
+        self.assertEqual(len(inds), 5)
+        for i in range(10):
+            self.assertEqual(res.check_index_valid(i), valid[i] == 1)
+            self.assertEqual(i in inds, valid[i] == 1)
+
     def test_prediction(self):
         p = compute_traj_pos(self.trj, 0)
         self.assertAlmostEqual(p.x, self.trj.x, delta=1e-5)


### PR DESCRIPTION
- Rerun clang format on the files (lots of small style improvements).
- Add a new TrajectoryResults class that we can later use to pass around the combination of trajectories + valid indices.
- Modify the stamp production functions to use TrajectoryResults, but keep the functions as thin wrappers so that we do not need to modify the python code yet.