### PR TITLE
Fix a bunch of bugs in stamp generation.

### DIFF
--- a/src/kbmod/search/KBMOSearch.cpp
+++ b/src/kbmod/search/KBMOSearch.cpp
@@ -285,7 +285,7 @@ std::vector<RawImage> KBMOSearch::medianScienceStamps(const std::vector<Trajecto
 
 #pragma omp parallel for
     for (int s = 0; s < num_results; ++s) {
-        results[s] = medianScienceStamp(t_array[s], radius, true);
+        results[s] = medianScienceStamp(t_array[s], radius, false);
     }
     omp_set_num_threads(1);
 
@@ -317,7 +317,7 @@ std::vector<RawImage> KBMOSearch::meanScienceStamps(const std::vector<Trajectory
 
 #pragma omp parallel for
     for (int s = 0; s < num_results; ++s) {
-        results[s] = meanScienceStamp(t_array[s], radius, true);
+        results[s] = meanScienceStamp(t_array[s], radius, false);
     }
     omp_set_num_threads(1);
 

--- a/src/kbmod/search/TrajectoryUtils.cpp
+++ b/src/kbmod/search/TrajectoryUtils.cpp
@@ -16,7 +16,7 @@ TrajectoryResult::TrajectoryResult(const trajectory& trj, int num_times) : trj_(
 
 TrajectoryResult::TrajectoryResult(const trajectory& trj, const std::vector<int>& binary_valid) : trj_(trj) {
     num_times_ = binary_valid.size();
-    valid_indices_.reserve(num_times_);
+    valid_indices_.resize(num_times_, true);
     for (int i = 0; i < num_times_; ++i) {
         valid_indices_[i] = (binary_valid[i] != 0);
     }

--- a/src/kbmod/search/image_kernels.cu
+++ b/src/kbmod/search/image_kernels.cu
@@ -347,12 +347,12 @@ __global__ void device_get_coadd_stamp(int num_images, int width, int height, fl
 
         // Predict the trajectory's position including the barycentric correction if needed.
         float cTime = image_data.imageTimes[t];
-        int currentX = trj.x + int(trj.xVel * cTime + 0.5);
-        int currentY = trj.y + int(trj.yVel * cTime + 0.5);
+        int currentX = trj.x + int(trj.xVel * cTime);
+        int currentY = trj.y + int(trj.yVel * cTime);
         if (image_data.baryCorrs != nullptr) {
             baryCorrection bc = image_data.baryCorrs[t];
-            currentX = int(trj.x + trj.xVel*cTime + bc.dx + trj.x*bc.dxdx + trj.y*bc.dxdy + 0.5);
-            currentY = int(trj.y + trj.yVel*cTime + bc.dy + trj.x*bc.dydx + trj.y*bc.dydy + 0.5);
+            currentX = int(trj.x + trj.xVel*cTime + bc.dx + trj.x*bc.dxdx + trj.y*bc.dxdy);
+            currentY = int(trj.y + trj.yVel*cTime + bc.dy + trj.x*bc.dydx + trj.y*bc.dydy);
         }
 
         // Get the stamp and add it to the running totals..

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -185,26 +185,36 @@ class test_search(unittest.TestCase):
         self.assertAlmostEqual(sci_vect.get_pixel(2, 2), sum_middle, delta=0.001)
 
     def test_median_stamps_trj(self):
-        # Compute the stacked science from a single trajectory.
-        goodIdx = [[1] * self.imCount]
-        medianStamps = self.search.median_stamps([self.trj], goodIdx, 2)
+        # Compute the stacked science from two trajectories (one with bad points).
+        goodIdx = [[1] * self.imCount for _ in range(2)]
+        goodIdx[1][1] = 0
+        goodIdx[1][5] = 0
+        goodIdx[1][9] = 0
+        medianStamps = self.search.median_stamps([self.trj, self.trj], goodIdx, 2)
         self.assertEqual(medianStamps[0].get_width(), 5)
         self.assertEqual(medianStamps[0].get_height(), 5)
+        self.assertEqual(medianStamps[1].get_width(), 5)
+        self.assertEqual(medianStamps[1].get_height(), 5)
 
         # Compute the true median pixel for the middle of the track.
         times = self.stack.get_times()
-        pix_values = []
+        pix_values0 = []
+        pix_values1 = []
         for i in range(self.imCount):
             t = times[i]
             x = int(self.trj.x + self.trj.x_v * t)
             y = int(self.trj.y + self.trj.y_v * t)
             pixVal = self.imlist[i].get_science().get_pixel(x, y)
-            if pixVal != KB_NO_DATA:
-                pix_values.append(pixVal)
-        self.assertEqual(len(pix_values), self.imCount)
+            if pixVal != KB_NO_DATA and goodIdx[0][i] == 1:
+                pix_values0.append(pixVal)
+            if pixVal != KB_NO_DATA and goodIdx[1][i] == 1:
+                pix_values1.append(pixVal)
+        self.assertEqual(len(pix_values0), self.imCount)
+        self.assertEqual(len(pix_values1), self.imCount - 3)
 
         # Check that we get the correct answer.
-        self.assertAlmostEqual(np.median(pix_values), medianStamps[0].get_pixel(2, 2), delta=1e-5)
+        self.assertAlmostEqual(np.median(pix_values0), medianStamps[0].get_pixel(2, 2), delta=1e-5)
+        self.assertAlmostEqual(np.median(pix_values1), medianStamps[1].get_pixel(2, 2), delta=1e-5)
 
     def test_median_stamps_no_data(self):
         # Create a trajectory that goes through the masked pixels.
@@ -232,28 +242,41 @@ class test_search(unittest.TestCase):
         self.assertAlmostEqual(np.median(pix_values), medianStamps[0].get_pixel(2, 2), delta=1e-5)
 
     def test_mean_stamps_trj(self):
-        # Compute the stacked science from a single trajectory.
-        goodIdx = [[1] * self.imCount]
-        meanStamps = self.search.mean_stamps([self.trj], goodIdx, 2)
+        # Compute the stacked science from two trajectories (one with bad points).
+        goodIdx = [[1] * self.imCount for _ in range(2)]
+        goodIdx[1][1] = 0
+        goodIdx[1][5] = 0
+        goodIdx[1][9] = 0
+        meanStamps = self.search.mean_stamps([self.trj, self.trj], goodIdx, 2)
         self.assertEqual(meanStamps[0].get_width(), 5)
         self.assertEqual(meanStamps[0].get_height(), 5)
+        self.assertEqual(meanStamps[1].get_width(), 5)
+        self.assertEqual(meanStamps[1].get_height(), 5)
 
         # Compute the true median pixel for the middle of the track.
         times = self.stack.get_times()
-        pix_sum = 0.0
-        pix_count = 0.0
+        pix_sum0 = 0.0
+        pix_sum1 = 0.0
+        pix_count0 = 0.0
+        pix_count1 = 0.0
         for i in range(self.imCount):
             t = times[i]
             x = int(self.trj.x + self.trj.x_v * t)
             y = int(self.trj.y + self.trj.y_v * t)
             pixVal = self.imlist[i].get_science().get_pixel(x, y)
-            if pixVal != KB_NO_DATA:
-                pix_sum += pixVal
-                pix_count += 1
-        self.assertEqual(pix_count, self.imCount)
+            print("%i: %f" % (i, pixVal))
+            if pixVal != KB_NO_DATA and goodIdx[0][i] == 1:
+                pix_sum0 += pixVal
+                pix_count0 += 1                
+            if pixVal != KB_NO_DATA and goodIdx[1][i] == 1:
+                pix_sum1 += pixVal
+                pix_count1 += 1
+        self.assertEqual(pix_count0, self.imCount)
+        self.assertEqual(pix_count1, self.imCount - 3)
 
         # Check that we get the correct answer.
-        self.assertAlmostEqual(pix_sum / pix_count, meanStamps[0].get_pixel(2, 2), delta=1e-5)
+        self.assertAlmostEqual(pix_sum0 / pix_count0, meanStamps[0].get_pixel(2, 2), delta=1e-5)
+        self.assertAlmostEqual(pix_sum1 / pix_count1, meanStamps[1].get_pixel(2, 2), delta=1e-5)
 
     def test_mean_stamps_no_data(self):
         # Create a trajectory that goes through the masked pixels.

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -264,7 +264,6 @@ class test_search(unittest.TestCase):
             x = int(self.trj.x + self.trj.x_v * t)
             y = int(self.trj.y + self.trj.y_v * t)
             pixVal = self.imlist[i].get_science().get_pixel(x, y)
-            print("%i: %f" % (i, pixVal))
             if pixVal != KB_NO_DATA and goodIdx[0][i] == 1:
                 pix_sum0 += pixVal
                 pix_count0 += 1                

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -331,8 +331,8 @@ class test_search(unittest.TestCase):
                 pix_count = 0.0
                 for i in range(self.imCount):
                     t = times[i]
-                    x = int(self.trj.x + self.trj.x_v * t + 0.5) + x_offset
-                    y = int(self.trj.y + self.trj.y_v * t + 0.5) + y_offset
+                    x = int(self.trj.x + self.trj.x_v * t) + x_offset
+                    y = int(self.trj.y + self.trj.y_v * t) + y_offset
                     pixVal = self.imlist[i].get_science().get_pixel(x, y)                    
                     if pixVal != KB_NO_DATA:
                         pix_sum += pixVal
@@ -375,8 +375,8 @@ class test_search(unittest.TestCase):
                 count_1 = 0.0
                 for i in range(self.imCount):
                     t = times[i]
-                    x = int(self.trj.x + self.trj.x_v * t + 0.5) + x_offset
-                    y = int(self.trj.y + self.trj.y_v * t + 0.5) + y_offset
+                    x = int(self.trj.x + self.trj.x_v * t) + x_offset
+                    y = int(self.trj.y + self.trj.y_v * t) + y_offset
                     pixVal = self.imlist[i].get_science().get_pixel(x, y)  
 
                     if pixVal != KB_NO_DATA and inds[0][i] > 0:
@@ -428,8 +428,8 @@ class test_search(unittest.TestCase):
                 count_1 = 0.0
                 for i in range(self.imCount):
                     t = times[i]
-                    x = int(self.trj.x + self.trj.x_v * t + 0.5) + x_offset
-                    y = int(self.trj.y + self.trj.y_v * t + 0.5) + y_offset
+                    x = int(self.trj.x + self.trj.x_v * t) + x_offset
+                    y = int(self.trj.y + self.trj.y_v * t) + y_offset
                     pixVal = self.imlist[i].get_science().get_pixel(x, y)  
 
                     if pixVal != KB_NO_DATA and i != 5:

--- a/tests/test_stamp_parity.py
+++ b/tests/test_stamp_parity.py
@@ -1,0 +1,108 @@
+import unittest
+
+import numpy as np
+
+from kbmod.search import *
+
+
+class test_search(unittest.TestCase):
+    def setUp(self):
+        # test pass thresholds
+        self.pixel_error = 0
+        self.velocity_error = 0.05
+        self.flux_error = 0.15
+
+        # image properties
+        self.imCount = 20
+        self.dim_x = 80
+        self.dim_y = 60
+        self.noise_level = 4.0
+        self.variance = self.noise_level**2
+        self.p = psf(1.0)
+
+        # object properties
+        self.object_flux = 250.0
+        self.start_x = 17
+        self.start_y = 12
+        self.x_vel = 21.0
+        self.y_vel = 16.0
+
+        # create a trajectory for the object
+        self.trj = trajectory()
+        self.trj.x = self.start_x
+        self.trj.y = self.start_y
+        self.trj.x_v = self.x_vel
+        self.trj.y_v = self.y_vel
+
+        # search parameters
+        self.angle_steps = 150
+        self.velocity_steps = 150
+        self.min_angle = 0.0
+        self.max_angle = 1.5
+        self.min_vel = 5.0
+        self.max_vel = 40.0
+
+        # Select one pixel to mask in every other image.
+        self.masked_x = 5
+        self.masked_y = 6
+
+        # create image set with single moving object
+        self.imlist = []
+        for i in range(self.imCount):
+            time = i / self.imCount
+            im = layered_image(str(i), self.dim_x, self.dim_y, self.noise_level, self.variance, time, self.p, i)
+            im.add_object(
+                self.start_x + time * self.x_vel + 0.5,
+                self.start_y + time * self.y_vel + 0.5,
+                self.object_flux,
+            )
+
+            # Mask a pixel in half the images.
+            if i % 2 == 0:
+                mask = im.get_mask()
+                mask.set_pixel(self.masked_x, self.masked_y, 1)
+                im.set_mask(mask)
+                im.apply_mask_flags(1, [])
+
+            self.imlist.append(im)
+        self.stack = image_stack(self.imlist)
+        self.search = stack_search(self.stack)
+
+    def test_coadd_gpu_parity(self):
+        radius = 2
+        width = 2 * radius + 1
+        params = stamp_parameters()
+        params.radius = radius
+        params.do_filtering = False
+
+        results = [self.trj, self.trj]
+        goodIdx = [[1] * self.imCount for _ in range(2)]
+        goodIdx[1][0] = 0
+        goodIdx[1][3] = 0
+        goodIdx[1][5] = 0
+
+        # Check the summed stamps. Note summed stamp does not use goodIdx.
+        params.stamp_type = StampType.STAMP_SUM
+        stamps_old = self.search.summed_sci(results, radius)
+        stamps_new = self.search.gpu_coadded_stamps(results, params)
+        for r in range(2):
+            for x in range(width):
+                for y in range(width):
+                    self.assertAlmostEqual(stamps_old[r].get_pixel(x, y),
+                                           stamps_new[r].get_pixel(x, y),
+                                           delta = 1e-5)
+
+        # Check the mean stamps.
+        params.stamp_type = StampType.STAMP_MEAN
+        stamps_old = self.search.mean_stamps(results, goodIdx, radius)
+        stamps_new = self.search.gpu_coadded_stamps(results, goodIdx, params)
+        for r in range(2):
+            for x in range(width):
+                for y in range(width):
+                    self.assertAlmostEqual(stamps_old[r].get_pixel(x, y),
+                                           stamps_new[r].get_pixel(x, y),
+                                           delta = 1e-5)
+
+        
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- mean and median stamps were ignoring goodIdx (introduced in PR-175)
- on-GPU stamp creation was using 0.5 shifts while the previous stamp generation was not. Make the on-GPU stamp generation consistent with the current stamp generation.
- One of the TrajectoryResult constructors had an allocation bug for the vector.
- Increase test coverage to include goodIdx for mean and median stamps.
- Add parity tests between the CPU and GPU stamp creation functions.