### PR TITLE
Refactor GPU Stamp Creation

### DIFF
--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -34,6 +34,7 @@ PYBIND11_MODULE(search, m) {
     py::enum_<search::StampType>(m, "StampType")
         .value("STAMP_SUM", search::StampType::STAMP_SUM)
         .value("STAMP_MEAN", search::StampType::STAMP_MEAN)
+        .value("STAMP_MEDIAN", search::StampType::STAMP_MEDIAN)
         .export_values();
     py::class_<pf>(m, "psf", py::buffer_protocol())
             .def_buffer([](pf &m) -> py::buffer_info {

--- a/src/kbmod/search/common.h
+++ b/src/kbmod/search/common.h
@@ -21,7 +21,7 @@ constexpr unsigned short THREAD_DIM_Y = 2;
 constexpr unsigned short RESULTS_PER_PIXEL = 8;
 constexpr float NO_DATA = -9999.0;
 
-enum StampType { STAMP_SUM = 0, STAMP_MEAN };
+enum StampType { STAMP_SUM = 0, STAMP_MEAN, STAMP_MEDIAN };
     
 /*
  * Data structure to represent an objects trajectory

--- a/src/kbmod/search/image_kernels.cu
+++ b/src/kbmod/search/image_kernels.cu
@@ -8,6 +8,8 @@
 #ifndef IMAGE_KERNELS_CU_
 #define IMAGE_KERNELS_CU_
 
+#define MAX_STAMP_IMAGES 140
+
 #include <assert.h>
 #include "common.h"
 #include "cuda_errors.h"
@@ -327,18 +329,21 @@ __global__ void device_get_coadd_stamp(int num_images, int width, int height, fl
     trajectory trj = trajectories[trj_index];
     int use_index_offset = num_images * trj_index;
 
-    // Allocate space for the coadd information and initialize to zero.
-    const int pixels_per_image = width * height;
+    // Get the pixel coordinates within the stamp to use.
     const int stamp_width = 2 * params.radius + 1;
-    const int stamp_ppi = stamp_width * stamp_width;
-    float sum[MAX_STAMP_EDGE * MAX_STAMP_EDGE];
-    float count[MAX_STAMP_EDGE * MAX_STAMP_EDGE];
-    for (int i = 0; i < stamp_ppi; ++i) {
-        sum[i] = 0.0;
-        count[i] = 0.0;
-    }
+    const int stamp_x = threadIdx.y;
+    if (stamp_x < 0 || stamp_x >= stamp_width)
+        return;
+
+    const int stamp_y = threadIdx.z;
+    if (stamp_y < 0 || stamp_y >= stamp_width)
+        return;
+
+    // Allocate space for the coadd information.
+    float values[MAX_STAMP_IMAGES];
 
     // Loop over each image and compute the stamp.
+    int num_values = 0;
     for (int t = 0; t < num_images; ++t) {
         // Skip entries marked 0 in the use_index_vect.
         if (use_index_vect != nullptr && use_index_vect[use_index_offset + t] == 0) {
@@ -355,66 +360,101 @@ __global__ void device_get_coadd_stamp(int num_images, int width, int height, fl
             currentY = int(trj.y + trj.yVel*cTime + bc.dy + trj.x*bc.dydx + trj.y*bc.dydy + 0.5);
         }
 
-        // Get the stamp and add it to the running totals..
-        for (int stamp_y = 0; stamp_y < stamp_width; ++stamp_y) {
-            int img_y = currentY - params.radius + stamp_y;
-            for (int stamp_x = 0; stamp_x < stamp_width; ++stamp_x) {
-                int img_x = currentX - params.radius + stamp_x;
-                if ((img_x >= 0) && (img_x < width) && (img_y >= 0) && (img_y < height)) {
-                    int pixel_index = pixels_per_image * t + img_y * width + img_x;
-                    if (image_vect[pixel_index] != NO_DATA) {
-                        int stamp_index = stamp_y * stamp_width + stamp_x;
-                        sum[stamp_index] += image_vect[pixel_index];
-                        count[stamp_index] += 1.0;
-                    }
+        // Get the stamp and add it to the list of values.
+        int img_y = currentY - params.radius + stamp_y;
+        int img_x = currentX - params.radius + stamp_x;
+        if ((img_x >= 0) && (img_x < width) && (img_y >= 0) && (img_y < height)) {
+            int pixel_index = width * height * t + img_y * width + img_x;
+            if (image_vect[pixel_index] != NO_DATA) {
+                values[num_values] = image_vect[pixel_index];
+                ++num_values;
+            }
+        }
+    }
+
+    // Do the actual computation from the values.
+    float result = 0.0;
+    if ((params.stamp_type == STAMP_MEDIAN) && (num_values > 0)) {
+        // Sort the values in ascending order.
+        for (int j = 0; j < num_values; j++) {
+            for (int k = j + 1; k < num_values; k++) {
+                if (values[j] > values[k]) {
+                    float tmp = values[j];
+                    values[j] = values[k];
+                    values[k] = tmp;
                 }
             }
-        }    
-    }
+        }
 
-    // Compute the mean if needed.
-    if (params.stamp_type == STAMP_MEAN) {
-        for (int i = 0; i < stamp_ppi; ++i) {
-            sum[i] = (count[i] > 0.0) ? sum[i]/count[i] : 0.0;
+        // Take the median value of the pixels with data.
+        int median_ind = num_values / 2;
+        if (num_values % 2 == 0) {
+            result = (values[median_ind] + values[median_ind - 1]) / 2.0;
+        } else {
+            result = values[median_ind];
+        }
+    } else if ((params.stamp_type == STAMP_SUM) || (params.stamp_type == STAMP_MEAN)) {
+        // Compute the sum for both STAMP_SUM and STAMP_MEAN
+        for (int t = 0; t < num_values; ++t) {
+            result += values[t];
+        }
+
+        if ((params.stamp_type == STAMP_MEAN) && (num_values > 0)) {
+            result /= float(num_values);
         }
     }
 
-    // Do the filtering on GPU if needed.
+    // Save the result to the correct pixel location.
+    int trj_offset = trj_index * stamp_width * stamp_width;
+    int pixel_index = stamp_width * stamp_y + stamp_x;
+    results[trj_offset + pixel_index] = result;
+}
+
+__global__ void device_filter_stamp(int num_stamps, stampParameters params, float* stamps_vect) {
+    // Get the trajectory that we are going to be using.
+    const int stamp_index = blockIdx.x * blockDim.x + threadIdx.x;
+    if (stamp_index < 0 || stamp_index >= num_stamps)
+        return;
+
+    // Allocate space for the coadd information and initialize to zero.
+    const int stamp_width = 2 * params.radius + 1;
+    const int stamp_ppi = stamp_width * stamp_width;
+    const int index_offset = stamp_ppi * stamp_index;
+    float current[MAX_STAMP_EDGE * MAX_STAMP_EDGE];
+    for (int i = 0; i < stamp_ppi; ++i) {
+        current[i] = stamps_vect[index_offset + i];
+    }
+
+    // Do the filtering.
     bool filter_stamp = false;
-    if (params.do_filtering) {
-        // Filter on the peak's position.
-        pixelPos pos =  findPeakImageVect(stamp_width, stamp_width, sum, true);
-        filter_stamp = filter_stamp || (abs(pos.x - params.radius) > params.peak_offset_x);
-        filter_stamp = filter_stamp || (abs(pos.y - params.radius) > params.peak_offset_y);
 
-        // Filter on the percentage of flux in the central pixel.
-        if (params.center_thresh > 0.0) {
-            float max_val = sum[(int)pos.y * stamp_width + (int)pos.x];
-            float pixel_sum = 0.0;
-            for (int p = 0; p < stamp_ppi; ++p) {
-                pixel_sum += sum[p];
-            }
-            filter_stamp = filter_stamp || (max_val / pixel_sum < params.center_thresh);
+    // Filter on the peak's position.
+    pixelPos pos =  findPeakImageVect(stamp_width, stamp_width, current, true);
+    filter_stamp = filter_stamp || (abs(pos.x - params.radius) > params.peak_offset_x);
+    filter_stamp = filter_stamp || (abs(pos.y - params.radius) > params.peak_offset_y);
+
+    // Filter on the percentage of flux in the central pixel.
+    if (params.center_thresh > 0.0) {
+        float max_val = current[(int)pos.y * stamp_width + (int)pos.x];
+        float pixel_sum = 0.0;
+        for (int p = 0; p < stamp_ppi; ++p) {
+            pixel_sum += current[p];
         }
-
-        // Filter on the image moments.
-        imageMoments moments = findCentralMomentsImageVect(stamp_width, stamp_width, sum);
-        filter_stamp = filter_stamp || (fabs(moments.m01) > params.m01_limit);
-        filter_stamp = filter_stamp || (fabs(moments.m10) > params.m10_limit);
-        filter_stamp = filter_stamp || (fabs(moments.m11) > params.m11_limit);
-        filter_stamp = filter_stamp || (moments.m02 > params.m02_limit);
-        filter_stamp = filter_stamp || (moments.m20 > params.m20_limit);
+        filter_stamp = filter_stamp || (max_val / pixel_sum < params.center_thresh);
     }
 
-    // Save the result.
-    int offset = stamp_ppi * trj_index;
+    // Filter on the image moments.
+    imageMoments moments = findCentralMomentsImageVect(stamp_width, stamp_width, current);
+    filter_stamp = filter_stamp || (fabs(moments.m01) > params.m01_limit);
+    filter_stamp = filter_stamp || (fabs(moments.m10) > params.m10_limit);
+    filter_stamp = filter_stamp || (fabs(moments.m11) > params.m11_limit);
+    filter_stamp = filter_stamp || (moments.m02 > params.m02_limit);
+    filter_stamp = filter_stamp || (moments.m20 > params.m20_limit);
+
+    // If we filter, overwrite the results.
     if (filter_stamp) {
         for (int i = 0; i < stamp_ppi; ++i) {
-            results[offset + i] = NO_DATA;
-        }
-    } else {
-        for (int i = 0; i < stamp_ppi; ++i) {
-            results[offset + i] = sum[i];
+            stamps_vect[index_offset + i] = NO_DATA;
         }
     }
 }
@@ -435,6 +475,7 @@ void deviceGetCoadds(ImageStack& stack, perImageData image_data, int num_traject
     const unsigned int width = stack.getWidth();
     const unsigned int height = stack.getHeight();
     const unsigned int num_image_pixels = num_images * width * height;
+    const unsigned int stamp_width = 2 * params.radius + 1;
     const unsigned int stamp_ppi = (2 * params.radius + 1) * (2 * params.radius + 1);
     const unsigned int num_stamp_pixels = num_trajectories * stamp_ppi;
 
@@ -502,29 +543,37 @@ void deviceGetCoadds(ImageStack& stack, perImageData image_data, int num_traject
     device_image_data.psiParams = nullptr;
     device_image_data.phiParams = nullptr;
 
-    dim3 blocks(num_trajectories / 256 + 1);
-    dim3 threads(256);
+    dim3 blocks(num_trajectories, 1, 1);
+    dim3 threads(1, stamp_width, stamp_width);
 
-    // Launch Search
+    // Create the stamps.
     device_get_coadd_stamp<<<blocks, threads>>> (num_images, width, height, device_img,
                                                  device_image_data, num_trajectories, device_trjs,
                                                  params, device_use_index, device_res);
 
-    // Read back results
-    checkCudaErrors(cudaMemcpy(results, device_res, sizeof(float) * num_stamp_pixels,
-                               cudaMemcpyDeviceToHost));
-
-    // Free the on GPU memory.
+    // Free up the unneeded memory (everything except for the on-device results).
     if (deviceBaryCorrs != nullptr)
         checkCudaErrors(cudaFree(deviceBaryCorrs));
-    checkCudaErrors(cudaFree(device_res));
     checkCudaErrors(cudaFree(device_img));
     if (device_use_index != nullptr)
         checkCudaErrors(cudaFree(device_use_index));
     checkCudaErrors(cudaFree(device_times));
     checkCudaErrors(cudaFree(device_trjs));
-}
 
+    // Do the filtering if needed.
+    if (params.do_filtering) {
+        dim3 blocks2(num_trajectories / 256 + 1);
+        dim3 threads2(256);
+        device_filter_stamp<<<blocks2, threads2>>> (num_trajectories, params, device_res);
+    }
+
+    // Read back results
+    checkCudaErrors(cudaMemcpy(results, device_res, sizeof(float) * num_stamp_pixels,
+                               cudaMemcpyDeviceToHost));
+
+    // Free the rest of the  on GPU memory.
+    checkCudaErrors(cudaFree(device_res));
+}
 
 } /* namespace search */
 

--- a/src/kbmod/search/image_kernels.cu
+++ b/src/kbmod/search/image_kernels.cu
@@ -352,8 +352,8 @@ __global__ void device_get_coadd_stamp(int num_images, int width, int height, fl
 
         // Predict the trajectory's position including the barycentric correction if needed.
         float cTime = image_data.imageTimes[t];
-        int currentX = trj.x + int(trj.xVel * cTime);
-        int currentY = trj.y + int(trj.yVel * cTime);
+        int currentX = int(trj.x + trj.xVel * cTime);
+        int currentY = int(trj.y + trj.yVel * cTime);
         if (image_data.baryCorrs != nullptr) {
             baryCorrection bc = image_data.baryCorrs[t];
             currentX = int(trj.x + trj.xVel*cTime + bc.dx + trj.x*bc.dxdx + trj.y*bc.dxdy);
@@ -430,8 +430,8 @@ __global__ void device_filter_stamp(int num_stamps, stampParameters params, floa
 
     // Filter on the peak's position.
     pixelPos pos =  findPeakImageVect(stamp_width, stamp_width, current, true);
-    filter_stamp = filter_stamp || (abs(pos.x - params.radius) > params.peak_offset_x);
-    filter_stamp = filter_stamp || (abs(pos.y - params.radius) > params.peak_offset_y);
+    filter_stamp = filter_stamp || (abs(pos.x - params.radius) >= params.peak_offset_x);
+    filter_stamp = filter_stamp || (abs(pos.y - params.radius) >= params.peak_offset_y);
 
     // Filter on the percentage of flux in the central pixel.
     if (params.center_thresh > 0.0) {
@@ -445,11 +445,11 @@ __global__ void device_filter_stamp(int num_stamps, stampParameters params, floa
 
     // Filter on the image moments.
     imageMoments moments = findCentralMomentsImageVect(stamp_width, stamp_width, current);
-    filter_stamp = filter_stamp || (fabs(moments.m01) > params.m01_limit);
-    filter_stamp = filter_stamp || (fabs(moments.m10) > params.m10_limit);
-    filter_stamp = filter_stamp || (fabs(moments.m11) > params.m11_limit);
-    filter_stamp = filter_stamp || (moments.m02 > params.m02_limit);
-    filter_stamp = filter_stamp || (moments.m20 > params.m20_limit);
+    filter_stamp = filter_stamp || (fabs(moments.m01) >= params.m01_limit);
+    filter_stamp = filter_stamp || (fabs(moments.m10) >= params.m10_limit);
+    filter_stamp = filter_stamp || (fabs(moments.m11) >= params.m11_limit);
+    filter_stamp = filter_stamp || (moments.m02 >= params.m02_limit);
+    filter_stamp = filter_stamp || (moments.m20 >= params.m20_limit);
 
     // If we filter, overwrite the results.
     if (filter_stamp) {

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -282,6 +282,66 @@ class test_search(unittest.TestCase):
         # Check that we get the correct answer.
         self.assertAlmostEqual(pix_sum / pix_count, meanStamps[0].get_pixel(2, 2), delta=1e-5)
 
+    def test_coadd_gpu_simple(self):
+        # Create an image set with three images.
+        imlist = []
+        for i in range(3):
+            time = i
+            im = layered_image(str(i), 3, 3, 0.1, 0.01, i, self.p, i)
+
+            # Overwrite the middle row to be i + 1.
+            sci = im.get_science()
+            for x in range(3):
+                sci.set_pixel(x, 1, i + 1)
+            im.set_science(sci)
+
+            # Mask out the row's first pixel twice and second pixel once.
+            mask = im.get_mask()
+            if i == 0:
+                mask.set_pixel(0, 1, 1)
+                mask.set_pixel(1, 1, 1)
+            if i == 1:
+                mask.set_pixel(0, 1, 1)
+            im.set_mask(mask)
+            im.apply_mask_flags(1, [])
+
+            imlist.append(im)
+        stack = image_stack(imlist)
+        search = stack_search(stack)
+
+        # One trajectory right in the image's middle.
+        trj = trajectory()
+        trj.x = 1
+        trj.y = 1
+        trj.x_v = 0
+        trj.y_v = 0
+
+        # Basic Stamp parameters.
+        params = stamp_parameters()
+        params.radius = 1
+        params.do_filtering = False
+
+        # Test summed.
+        params.stamp_type = StampType.STAMP_SUM
+        stamps = search.gpu_coadded_stamps([trj], params)
+        self.assertAlmostEqual(stamps[0].get_pixel(0, 1), 3.0)
+        self.assertAlmostEqual(stamps[0].get_pixel(1, 1), 5.0)
+        self.assertAlmostEqual(stamps[0].get_pixel(2, 1), 6.0)
+
+        # Test mean.
+        params.stamp_type = StampType.STAMP_MEAN
+        stamps = search.gpu_coadded_stamps([trj], params)
+        self.assertAlmostEqual(stamps[0].get_pixel(0, 1), 3.0)
+        self.assertAlmostEqual(stamps[0].get_pixel(1, 1), 2.5)
+        self.assertAlmostEqual(stamps[0].get_pixel(2, 1), 2.0)
+
+        # Test median.
+        params.stamp_type = StampType.STAMP_MEDIAN
+        stamps = search.gpu_coadded_stamps([trj], params)
+        self.assertAlmostEqual(stamps[0].get_pixel(0, 1), 3.0)
+        self.assertAlmostEqual(stamps[0].get_pixel(1, 1), 2.5)
+        self.assertAlmostEqual(stamps[0].get_pixel(2, 1), 2.0)
+
     def test_coadd_gpu(self):
         params = stamp_parameters()
         params.radius = 3

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -298,6 +298,11 @@ class test_search(unittest.TestCase):
         self.assertEqual(meanStamps[0].get_width(), 2 * params.radius + 1)
         self.assertEqual(meanStamps[0].get_height(), 2 * params.radius + 1)
 
+        params.stamp_type = StampType.STAMP_MEDIAN
+        medianStamps = self.search.gpu_coadded_stamps([self.trj], params)
+        self.assertEqual(medianStamps[0].get_width(), 2 * params.radius + 1)
+        self.assertEqual(medianStamps[0].get_height(), 2 * params.radius + 1)
+
         # Compute the true summed and mean pixels for all of the pixels in the stamp.
         times = self.stack.get_times()
         for stamp_x in range(2 * params.radius + 1):
@@ -307,6 +312,7 @@ class test_search(unittest.TestCase):
 
                 pix_sum = 0.0
                 pix_count = 0.0
+                pix_vals = []
                 for i in range(self.imCount):
                     t = times[i]
                     x = int(self.trj.x + self.trj.x_v * t + 0.5) + x_offset
@@ -315,12 +321,16 @@ class test_search(unittest.TestCase):
                     if pixVal != KB_NO_DATA:
                         pix_sum += pixVal
                         pix_count += 1.0
+                        pix_vals.append(pixVal)
 
                 # Check that we get the correct answers.
                 self.assertAlmostEqual(pix_sum, summedStamps[0].get_pixel(stamp_x, stamp_y),
                                        delta=1e-3)
                 self.assertAlmostEqual(pix_sum / pix_count,
                                        meanStamps[0].get_pixel(stamp_x, stamp_y),
+                                       delta=1e-3)
+                self.assertAlmostEqual(np.median(pix_vals),
+                                       medianStamps[0].get_pixel(stamp_x, stamp_y),
                                        delta=1e-3)
 
     def test_coadd_gpu_use_inds(self):

--- a/tests/test_stamp_parity.py
+++ b/tests/test_stamp_parity.py
@@ -103,6 +103,16 @@ class test_search(unittest.TestCase):
                                            stamps_new[r].get_pixel(x, y),
                                            delta = 1e-5)
 
-        
+        # Check the median stamps.
+        params.stamp_type = StampType.STAMP_MEDIAN
+        stamps_old = self.search.median_stamps(results, goodIdx, radius)
+        stamps_new = self.search.gpu_coadded_stamps(results, goodIdx, params)
+        for r in range(2):
+            for x in range(width):
+                for y in range(width):
+                    self.assertAlmostEqual(stamps_old[r].get_pixel(x, y),
+                                           stamps_new[r].get_pixel(x, y),
+                                           delta = 1e-5)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Refactor the GPU stamp creation to support median stamps. This breaks the stamp creation and stamp filtering into two different GPU steps (that can be done without copying the image data twice though).

This also makes a few small changes to on-GPU stamp creation and filtering to match the CPU code (> to >= and moving where we round the predicted position to an int).

Add a bunch of new tests to confirm the behavior.