### PR TITLE
Clean up MakeStamp API

### DIFF
--- a/src/kbmod/analysis_utils.py
+++ b/src/kbmod/analysis_utils.py
@@ -599,30 +599,23 @@ class PostProcess(SharedTools):
         start = time.time()
         # The C++ stamp generation types require a different format than the
         # python types
+        num_images = len(keep["psi_curves"][0])
         if stamp_type == "cpp_median" or stamp_type == "median":
-            num_images = len(keep["psi_curves"][0])
-            boolean_idx = []
-            for keep in keep["lc_index"]:
-                bool_row = np.zeros(num_images)
-                bool_row[keep] = 1
-                boolean_idx.append(bool_row.astype(int).tolist())
-            coadd_stamps = [np.array(stamp) for stamp in search.median_stamps(results, boolean_idx, radius)]
-        elif stamp_type == "cpp_mean":
-            num_images = len(keep["psi_curves"][0])
-            boolean_idx = []
-            for keep in keep["lc_index"]:
-                bool_row = np.zeros(num_images)
-                bool_row[keep] = 1
-                boolean_idx.append(bool_row.astype(int).tolist())
-            coadd_stamps = [np.array(stamp) for stamp in search.mean_stamps(results, boolean_idx, radius)]
+            trj_res = [kb.trj_result(t, num_images, inds) for t, inds in zip(results, keep["lc_index"])]
+            coadd_stamps = [np.array(stamp) for stamp in search.median_sci_stamps(trj_res, radius)]
+        elif stamp_type == "cpp_mean" or stamp_type == "mean":
+            trj_res = [kb.trj_result(t, num_images, inds) for t, inds in zip(results, keep["lc_index"])]
+            coadd_stamps = [np.array(stamp) for stamp in search.mean_sci_stamps(trj_res, radius)]
         elif stamp_type == "parallel_sum":
-            coadd_stamps = [np.array(stamp) for stamp in search.summed_sci(results, radius)]
+            trj_res = [kb.trj_result(t, num_images) for t in results]
+            coadd_stamps = [np.array(stamp) for stamp in search.summed_sci_stamps(trj_res, radius)]
         else:
             # Python stamp generation
             coadd_stamps = []
             for i, result in enumerate(results):
                 if stamp_type == "sum":
-                    stamps = np.array(search.stacked_sci(result, radius)).astype(np.float32)
+                    trj_res = kb.trj_result(result, num_images)
+                    stamps = np.array(search.summed_sci_stamp(trj_res, radius, True)).astype(np.float32)
                     coadd_stamps.append(stamps)
         print(
             "Loaded {} coadded stamps. {:.3f}s elapsed".format(len(coadd_stamps), time.time() - start),
@@ -648,7 +641,7 @@ class PostProcess(SharedTools):
         stamp_edge = self.stamp_radius * 2 + 1
         final_results = keep["final_results"]
         for result in np.array(keep["results"])[final_results]:
-            stamps = search.sci_stamps(result, self.stamp_radius)
+            stamps = search.science_viz_stamps(result, self.stamp_radius)
             all_stamps = np.array([np.array(stamp).reshape(stamp_edge, stamp_edge) for stamp in stamps])
             keep["all_stamps"].append(all_stamps)
         return keep

--- a/src/kbmod/search/KBMOSearch.cpp
+++ b/src/kbmod/search/KBMOSearch.cpp
@@ -260,17 +260,9 @@ std::vector<RawImage> KBMOSearch::scienceStamps(const TrajectoryResult& trj, int
     return stamps;
 }
 
-inline std::vector<RawImage> KBMOSearch::scienceStampsForFilter(const TrajectoryResult& trj, int radius) {
-    return scienceStamps(trj, radius, false, true, false);
-}
-
-inline std::vector<RawImage> KBMOSearch::scienceStampsForViz(const TrajectoryResult& trj, int radius) {
-    return scienceStamps(trj, radius, true, false, true);
-}
-
-std::vector<RawImage> KBMOSearch::scienceStamps(trajectory& t, int radius) {
+std::vector<RawImage> KBMOSearch::scienceStampsForViz(const trajectory& t, int radius) {
     TrajectoryResult trj(t, stack.imgCount());
-    return scienceStampsForViz(trj, radius);
+    return scienceStamps(trj, radius, true, false, true);
 }
 
 RawImage KBMOSearch::medianScienceStamp(const TrajectoryResult& trj, int radius, bool use_all) {
@@ -290,19 +282,6 @@ std::vector<RawImage> KBMOSearch::medianScienceStamps(const std::vector<Trajecto
     omp_set_num_threads(1);
 
     return (results);
-}
-
-// To be deprecated in later PR.
-std::vector<RawImage> KBMOSearch::medianStamps(const std::vector<trajectory>& t_array,
-                                               const std::vector<std::vector<int>>& goodIdx, int radius) {
-    const int num_results = t_array.size();
-    std::vector<TrajectoryResult> arr;
-    for (int s = 0; s < num_results; ++s) {
-        TrajectoryResult trj(t_array[s], goodIdx[s]);
-        arr.push_back(trj);
-    }
-
-    return medianScienceStamps(arr, radius);
 }
 
 RawImage KBMOSearch::meanScienceStamp(const TrajectoryResult& trj, int radius, bool use_all) {
@@ -398,27 +377,8 @@ std::vector<RawImage> KBMOSearch::coaddedScienceStampsGPU(std::vector<Trajectory
     return coaddedScienceStampsGPU(trjs, use_index_vect, params);
 }
 
-// To be deprecated in later PR.
-std::vector<RawImage> KBMOSearch::meanStamps(const std::vector<trajectory>& t_array,
-                                             const std::vector<std::vector<int>>& goodIdx, int radius) {
-    const int num_results = t_array.size();
-    std::vector<TrajectoryResult> arr;
-    for (int s = 0; s < num_results; ++s) {
-        TrajectoryResult trj(t_array[s], goodIdx[s]);
-        arr.push_back(trj);
-    }
-
-    return meanScienceStamps(arr, radius);
-}
-
 RawImage KBMOSearch::summedScienceStamp(const TrajectoryResult& trj, int radius, bool use_all) {
-    return createSummedImage(scienceStamps(trj, radius, false, true, use_all));
-}
-
-// To be deprecated in later PR.
-RawImage KBMOSearch::stackedScience(trajectory& t, int radius) {
-    TrajectoryResult trj(t, stack.imgCount());
-    return createSummedImage(scienceStamps(trj, radius, false, false, true));
+    return createSummedImage(scienceStamps(trj, radius, false, false, use_all));
 }
 
 std::vector<RawImage> KBMOSearch::summedScienceStamps(const std::vector<TrajectoryResult>& t_array,
@@ -430,23 +390,6 @@ std::vector<RawImage> KBMOSearch::summedScienceStamps(const std::vector<Trajecto
 #pragma omp parallel for
     for (int s = 0; s < num_results; ++s) {
         results[s] = summedScienceStamp(t_array[s], radius, true);
-    }
-    omp_set_num_threads(1);
-
-    return (results);
-}
-
-// To be deprecated in later PR.
-std::vector<RawImage> KBMOSearch::summedScience(const std::vector<trajectory>& t_array, int radius) {
-    int numResults = t_array.size();
-    std::vector<RawImage> results(numResults);
-
-    // Build the result for each trajectory.
-    omp_set_num_threads(30);
-#pragma omp parallel for
-    for (int s = 0; s < numResults; ++s) {
-        TrajectoryResult trj(t_array[s], stack.imgCount());
-        results[s] = createSummedImage(scienceStamps(trj, radius, false, false, true));
     }
     omp_set_num_threads(1);
 

--- a/src/kbmod/search/KBMOSearch.h
+++ b/src/kbmod/search/KBMOSearch.h
@@ -60,21 +60,13 @@ public:
     // or replace them with zero, and whether to use all stamps or just the unfiltered indices.
     std::vector<RawImage> scienceStamps(const TrajectoryResult& trj, int radius, bool interpolate,
                                         bool keep_no_data, bool all_stamps);
-    std::vector<RawImage> scienceStampsForFilter(const TrajectoryResult& trj, int radius);
-    std::vector<RawImage> scienceStampsForViz(const TrajectoryResult& trj, int radius);
+    std::vector<RawImage> scienceStampsForViz(const trajectory& t, int radius);
     RawImage medianScienceStamp(const TrajectoryResult& trj, int radius, bool use_all);
     RawImage meanScienceStamp(const TrajectoryResult& trj, int radius, bool use_all);
     RawImage summedScienceStamp(const TrajectoryResult& trj, int radius, bool use_all);
     std::vector<RawImage> medianScienceStamps(const std::vector<TrajectoryResult>& t_array, int radius);
     std::vector<RawImage> meanScienceStamps(const std::vector<TrajectoryResult>& t_array, int radius);
     std::vector<RawImage> summedScienceStamps(const std::vector<TrajectoryResult>& t_array, int radius);
-
-    // Functions to create and access stamps around proposed trajectories. Used to visualize
-    // the results. These functions drop pixels with NO_DATA from the computation.
-    std::vector<RawImage> medianStamps(const std::vector<trajectory>& t_array,
-                                       const std::vector<std::vector<int>>& goodIdx, int radius);
-    std::vector<RawImage> meanStamps(const std::vector<trajectory>& t_array,
-                                     const std::vector<std::vector<int>>& goodIdx, int radius);
 
     // Compute a mean or summed stamp for each trajectory on the GPU. This is slower than the
     // above for small numbers of trajectories (< 500), but performs relatively better as the
@@ -90,13 +82,6 @@ public:
     // and will be more expensive than the integer array version.
     std::vector<RawImage> coaddedScienceStampsGPU(std::vector<TrajectoryResult>& t_array,
                                                   const stampParameters& params);
-
-    // Creates science stamps (or a summed stamp) around a
-    // trajectory, trajRegion, or vector of trajectories.
-    // These functions replace NO_DATA with a value of 0.0.
-    std::vector<RawImage> scienceStamps(trajectory& t, int radius);
-    RawImage stackedScience(trajectory& t, int radius);
-    std::vector<RawImage> summedScience(const std::vector<trajectory>& t_array, int radius);
 
     // Getters for the Psi and Phi data, including pooled
     // and stamped versions.

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -172,15 +172,12 @@ PYBIND11_MODULE(search, m) {
             .def("get_image_stack", &ks::getImageStack)
             // Science Stamp Functions
             .def("science_viz_stamps", &ks::scienceStampsForViz)
-            .def("science_filter_stamps", &ks::scienceStampsForFilter)
             .def("median_sci_stamp", &ks::medianScienceStamp)
             .def("mean_sci_stamp", &ks::meanScienceStamp)
             .def("summed_sci_stamp", &ks::summedScienceStamp)
             .def("median_sci_stamps", &ks::medianScienceStamps)
             .def("mean_sci_stamps", &ks::meanScienceStamps)
             .def("summed_sci_stamps", &ks::summedScienceStamps)
-            .def("stacked_sci", (ri(ks::*)(tj &, int)) & ks::stackedScience, "set")
-            .def("summed_sci", (std::vector<ri>(ks::*)(std::vector<tj>, int)) & ks::summedScience)
             .def("gpu_coadded_stamps", (std::vector<ri>(ks::*)(std::vector<tj>&, 
                                                                std::vector<std::vector<bool>>&,
                                                                const search::stampParameters&)) &
@@ -191,13 +188,6 @@ PYBIND11_MODULE(search, m) {
             .def("gpu_coadded_stamps", (std::vector<ri>(ks::*)(std::vector<tjr>&,
                                                                const search::stampParameters&)) &
                          ks::coaddedScienceStampsGPU)
-            .def("mean_stamps",
-                 (std::vector<ri>(ks::*)(std::vector<tj>, std::vector<std::vector<int>>, int)) &
-                         ks::meanStamps)
-            .def("median_stamps",
-                 (std::vector<ri>(ks::*)(std::vector<tj>, std::vector<std::vector<int>>, int)) &
-                         ks::medianStamps)
-            .def("sci_stamps", (std::vector<ri>(ks::*)(tj &, int)) & ks::scienceStamps, "set")
             // For testing
             .def("get_traj_pos", &ks::getTrajPos)
             .def("get_mult_traj_pos", &ks::getMultTrajPos)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -34,6 +34,9 @@ class test_search(unittest.TestCase):
         self.trj.x_v = self.x_vel
         self.trj.y_v = self.y_vel
 
+        # create a trajectory result for computing stamps.
+        self.trj_res = trj_result(self.trj, self.imCount)
+
         # search parameters
         self.angle_steps = 150
         self.velocity_steps = 150
@@ -135,8 +138,8 @@ class test_search(unittest.TestCase):
         self.assertAlmostEqual(best.y_v / self.y_vel, 1, delta=self.velocity_error)
         self.assertAlmostEqual(best.flux / self.object_flux, 1, delta=self.flux_error)
 
-    def test_sci_stamps(self):
-        sci_stamps = self.search.sci_stamps(self.trj, 2)
+    def test_sci_viz_stamps(self):
+        sci_stamps = self.search.science_viz_stamps(self.trj, 2)
         self.assertEqual(len(sci_stamps), self.imCount)
 
         times = self.stack.get_times()
@@ -158,12 +161,12 @@ class test_search(unittest.TestCase):
 
     def test_stacked_sci(self):
         # Compute the stacked science from a single trajectory.
-        sci = self.search.stacked_sci(self.trj, 2)
+        sci = self.search.summed_sci_stamp(self.trj_res, 2, True)
         self.assertEqual(sci.get_width(), 5)
         self.assertEqual(sci.get_height(), 5)
 
         # Compute a vector of stacked sciences from a vector of trajectories.
-        sci_vect = self.search.summed_sci([self.trj], 2)[0]
+        sci_vect = self.search.summed_sci_stamps([self.trj_res], 2)[0]
         self.assertEqual(sci_vect.get_width(), 5)
         self.assertEqual(sci_vect.get_height(), 5)
 
@@ -190,7 +193,10 @@ class test_search(unittest.TestCase):
         goodIdx[1][1] = 0
         goodIdx[1][5] = 0
         goodIdx[1][9] = 0
-        medianStamps = self.search.median_stamps([self.trj, self.trj], goodIdx, 2)
+        trj_res0 = trj_result(self.trj, goodIdx[0])
+        trj_res1 = trj_result(self.trj, goodIdx[1])
+        
+        medianStamps = self.search.median_sci_stamps([trj_res0, trj_res1], 2)
         self.assertEqual(medianStamps[0].get_width(), 5)
         self.assertEqual(medianStamps[0].get_height(), 5)
         self.assertEqual(medianStamps[1].get_width(), 5)
@@ -223,10 +229,10 @@ class test_search(unittest.TestCase):
         trj.y = self.masked_y
         trj.x_v = 0
         trj.y_v = 0
+        trj_res = trj_result(trj, self.imCount)
 
         # Compute the stacked science from a single trajectory.
-        goodIdx = [[1] * self.imCount]
-        medianStamps = self.search.median_stamps([trj], goodIdx, 2)
+        medianStamps = self.search.median_sci_stamps([trj_res], 2)
         self.assertEqual(medianStamps[0].get_width(), 5)
         self.assertEqual(medianStamps[0].get_height(), 5)
 
@@ -247,7 +253,10 @@ class test_search(unittest.TestCase):
         goodIdx[1][1] = 0
         goodIdx[1][5] = 0
         goodIdx[1][9] = 0
-        meanStamps = self.search.mean_stamps([self.trj, self.trj], goodIdx, 2)
+        trj_res0 = trj_result(self.trj, goodIdx[0])
+        trj_res1 = trj_result(self.trj, goodIdx[1])
+        
+        meanStamps = self.search.mean_sci_stamps([trj_res0, trj_res1], 2)
         self.assertEqual(meanStamps[0].get_width(), 5)
         self.assertEqual(meanStamps[0].get_height(), 5)
         self.assertEqual(meanStamps[1].get_width(), 5)
@@ -284,10 +293,10 @@ class test_search(unittest.TestCase):
         trj.y = self.masked_y
         trj.x_v = 0
         trj.y_v = 0
+        trj_res = trj_result(trj, self.imCount)
 
         # Compute the stacked science from a single trajectory.
-        goodIdx = [[1] * self.imCount]
-        meanStamps = self.search.mean_stamps([trj], goodIdx, 2)
+        meanStamps = self.search.mean_sci_stamps([trj_res], 2)
         self.assertEqual(meanStamps[0].get_width(), 5)
         self.assertEqual(meanStamps[0].get_height(), 5)
 

--- a/tests/test_stamp_parity.py
+++ b/tests/test_stamp_parity.py
@@ -80,10 +80,11 @@ class test_search(unittest.TestCase):
         goodIdx[1][0] = 0
         goodIdx[1][3] = 0
         goodIdx[1][5] = 0
+        res_trjs = [trj_result(self.trj, goodIdx[0]), trj_result(self.trj, goodIdx[1])]
 
         # Check the summed stamps. Note summed stamp does not use goodIdx.
         params.stamp_type = StampType.STAMP_SUM
-        stamps_old = self.search.summed_sci(results, radius)
+        stamps_old = self.search.summed_sci_stamps(res_trjs, radius)
         stamps_new = self.search.gpu_coadded_stamps(results, params)
         for r in range(2):
             for x in range(width):
@@ -94,8 +95,8 @@ class test_search(unittest.TestCase):
 
         # Check the mean stamps.
         params.stamp_type = StampType.STAMP_MEAN
-        stamps_old = self.search.mean_stamps(results, goodIdx, radius)
-        stamps_new = self.search.gpu_coadded_stamps(results, goodIdx, params)
+        stamps_old = self.search.mean_sci_stamps(res_trjs, radius)
+        stamps_new = self.search.gpu_coadded_stamps(res_trjs, params)
         for r in range(2):
             for x in range(width):
                 for y in range(width):


### PR DESCRIPTION
Cleans up the functions in KBMOSearch to remove duplication and improve clarity. The historical functions such as `medianStamps` and `meanStamps` are removed and the python code is switched over to use the newer functions (that use `TrajectoryResults`).

I further tested this by running the diff test with all three stamp types and confirming that **all** of the output files were identical to the old code (including the stamp files).