### PR TITLE
Small cleanups

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,14 +42,12 @@ install_requires =
     numpy>=1.18
     pandas>=1.5.1
     scipy>=1.9.2
-    scikit_image>=0.19.3
     scikit_learn>=1.0.0
 
 [options.extras_require]
 analysis =
     tqdm>=4.6
     tensorflow>=2.9
-    #mpmath>=1.2.1
     matplotlib>=3.6.1
     numba>=0.56
     ipywidgets>=8.0

--- a/src/kbmod/analysis_utils.py
+++ b/src/kbmod/analysis_utils.py
@@ -428,8 +428,9 @@ class PostProcess(SharedTools):
                     likelihood_limit = True
                     break
                 if trj.lh < max_lh:
-                    psi_curve, phi_curve = search.lightcurve(trj)
                     row = ResultRow(trj, len(self._mjds))
+                    psi_curve = np.array(search.psi_curves(trj))
+                    phi_curve = np.array(search.phi_curves(trj))
                     row.set_psi_phi(psi_curve, phi_curve)
                     result_batch.append_result(row)
                     total_count += 1

--- a/src/kbmod/kbmodpy.py
+++ b/src/kbmod/kbmodpy.py
@@ -88,15 +88,8 @@ def phi_images_to_numpy(self, copy_data=False):
     return [numpy.array(img, copy=copy_data) for img in self.get_phi_images()]
 
 
-def lightcurve(self, t):
-    psi = numpy.array(self.psi_curves(t))
-    phi = numpy.array(self.phi_curves(t))
-    return (psi, phi)
-
-
 kbmod.search.stack_search.get_psi = psi_images_to_numpy
 kbmod.search.stack_search.get_phi = phi_images_to_numpy
-kbmod.search.stack_search.lightcurve = lightcurve
 
 # trajectory utilities
 


### PR DESCRIPTION
- Remove unneeded dependency on scikit_image
- Remove unneeded "lightcurve" function in kbmodpy and replace with individual calls to get psi and phi curves.