### PR TITLE
Docs build fix

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup miniconda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
-          activate-environment: kbmod_tests
+          activate-environment: kbmod_docs
           python-version: "3.10"
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           activate-environment: kbmod_tests
-          python-version: 3.10
+          python-version: "3.10"
       - name: Checkout code
         uses: actions/checkout@v3
         with:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An image processing library for moving object detection implemented with GPUs.  
 Based on a Maximum Likelihood detection algorithm for moving astronomical objects.
 
-[![Build Status](https://travis-ci.org/dirac-institute/kbmod.svg?branch=master)](https://travis-ci.org/dirac-institute/kbmod) [![License](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](https://opensource.org/licenses/BSD-2-Clause)[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1342297.svg)](https://doi.org/10.5281/zenodo.1342297)
+[![Build Status](https://github.com/dirac-institute/kbmod/actions/workflows/test_build.yaml/badge.svg)](https://github.com/dirac-institute/kbmod/actions/workflows/test_build.yaml)[![Documentation](https://github.com/dirac-institute/kbmod/actions/workflows/build_docs.yaml/badge.svg)](https://epyc.astro.washington.edu/~kbmod/) [![License](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](https://opensource.org/licenses/BSD-2-Clause)[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1342297.svg)](https://doi.org/10.5281/zenodo.1342297)
 
 
 


### PR DESCRIPTION
Unquoted strings are not interpreted as literals, so `3.10 --> 3.1`. Quoted strings are. 
Quality of life improvements by re-linking build and docs badges in the README to their correct sources.