### PR TITLE
222 kbmod referenceipynb imports recently removed kbmodevaluate

### DIFF
--- a/notebooks/Kbmod_Reference.ipynb
+++ b/notebooks/Kbmod_Reference.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,25 +100,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0.00367206, 0.01464826, 0.02320431, 0.01464826, 0.00367206],\n",
-       "       [0.01464826, 0.05843356, 0.09256457, 0.05843356, 0.01464826],\n",
-       "       [0.02320431, 0.09256457, 0.1466315 , 0.09256457, 0.02320431],\n",
-       "       [0.01464826, 0.05843356, 0.09256457, 0.05843356, 0.01464826],\n",
-       "       [0.00367206, 0.01464826, 0.02320431, 0.01464826, 0.00367206]],\n",
-       "      dtype=float32)"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "np.array(p)"
    ]
@@ -132,22 +116,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0.      , 0.015625, 0.0625  ],\n",
-       "       [0.140625, 0.25    , 0.390625],\n",
-       "       [0.5625  , 0.765625, 1.      ]], dtype=float32)"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "arr = np.linspace(0.0, 1.0, 9).reshape(3, 3)\n",
     "p2 = kb.psf(arr)  # initialized from array\n",
@@ -165,20 +136,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "dim = 5\n",
-      "radius = 2\n",
-      "size = 25\n",
-      "sum = 0.975315511226654\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(f\"dim = {p.get_dim()}\")  # dimension of kernel width and height\n",
     "print(f\"radius = {p.get_radius()}\")  # distance from center of kernel to edge\n",
@@ -204,17 +164,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loaded a 256 by 256 image at time 57130.19921875\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "im = kb.layered_image(im_path + \"000000.fits\", p)\n",
     "print(f\"Loaded a {im.get_width()} by {im.get_height()} image at time {im.get_time()}\")"
@@ -231,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,20 +200,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Width = 100\n",
-      "Height = 100\n",
-      "Pixels Per Image = 10000\n",
-      "Time = 0.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(f\"Width = {im.get_width()}\")\n",
     "print(f\"Height = {im.get_height()}\")\n",
@@ -278,32 +219,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[ 7.7525225 , -2.9187062 ,  2.338144  , ..., -3.1354756 ,\n",
-       "        -0.46721724,  0.8170918 ],\n",
-       "       [-0.2998402 , -0.72937715, -2.2867594 , ..., -3.662991  ,\n",
-       "        11.534483  , -3.721254  ],\n",
-       "       [ 6.2469625 , -4.8458867 , -5.7789726 , ..., -4.2071733 ,\n",
-       "        -0.8960119 ,  6.8647246 ],\n",
-       "       ...,\n",
-       "       [-3.9974928 ,  4.0812836 , -2.7801142 , ...,  8.616802  ,\n",
-       "         1.5323112 ,  1.7786822 ],\n",
-       "       [-3.5956273 , -3.7854621 ,  1.6386937 , ...,  9.894979  ,\n",
-       "         2.1822436 ,  7.722599  ],\n",
-       "       [-5.8866444 ,  2.5847516 , -0.534852  , ..., -1.183502  ,\n",
-       "        -0.46746704,  7.144948  ]], dtype=float32)"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pixels = im.science()\n",
     "pixels"
@@ -318,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,26 +245,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[1., 1., 1., ..., 1., 1., 1.],\n",
-       "       [1., 1., 1., ..., 1., 1., 1.],\n",
-       "       [1., 1., 1., ..., 1., 1., 1.],\n",
-       "       ...,\n",
-       "       [1., 1., 1., ..., 1., 1., 1.],\n",
-       "       [1., 1., 1., ..., 1., 1., 1.],\n",
-       "       [1., 1., 1., ..., 1., 1., 1.]], dtype=float32)"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "im.set_science(raw)\n",
     "im.set_variance(raw)\n",
@@ -369,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -387,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -406,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -427,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -464,7 +365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -480,19 +381,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using loaded files:\n",
-      "['../data/demo/000000.fits', '../data/demo/000001.fits', '../data/demo/000002.fits', '../data/demo/000003.fits', '../data/demo/000004.fits', '../data/demo/000005.fits', '../data/demo/000006.fits', '../data/demo/000007.fits', '../data/demo/000008.fits', '../data/demo/000009.fits']\n",
-      ".........."
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "\n",
@@ -521,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -542,20 +433,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<kbmod.search.raw_image at 0x7f3273699f70>"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "stack.get_global_mask()"
    ]
@@ -569,20 +449,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Width = 256\n",
-      "Height = 256\n",
-      "Pixels Per Image = 65536\n",
-      "Times = [0.0, 0.01171875, 0.01953125, 1.0, 1.01171875, 1.01953125, 2.0, 2.01171875, 2.01953125, 3.0]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Apply the masking flags to each image.\n",
     "stack.apply_mask_flags(flags, flag_exceptions)\n",
@@ -612,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -641,7 +510,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -657,17 +526,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Data directory does not exist. Skipping file operations.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "if os.path.exists(res_path):\n",
     "    if os.path.exists(os.path.join(res_path, \"out/psi\")) is False:\n",
@@ -690,7 +551,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -708,17 +569,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Data directory does not exist. Skipping file operations.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "if os.path.exists(res_path):\n",
     "    search.save_results(res_path + \"results.txt\", 0.05)\n",
@@ -737,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -754,7 +607,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -780,7 +633,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -789,22 +642,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Flux = 20413.11328125\n",
-      "Likelihood = 32275.96875\n",
-      "x = 20\n",
-      "y = 35\n",
-      "x_v = 7.960033416748047\n",
-      "y_v = -0.7986673712730408\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# these numbers are wild because mask flags and search parameters above were chosen randomly\n",
     "print(f\"Flux = {best.flux}\")\n",
@@ -817,39 +657,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[lh: 32275.968750 flux: 20413.113281 x: 20 y: 35 x_v: 7.960033 y_v: -0.798667 obs_count: 10,\n",
-       " lh: 32275.369141 flux: 20412.734375 x: 20 y: 35 x_v: 7.974414 y_v: -0.639318 obs_count: 10,\n",
-       " lh: 32275.259766 flux: 20412.666016 x: 20 y: 35 x_v: 7.985604 y_v: -0.479712 obs_count: 10,\n",
-       " lh: 32275.259766 flux: 20412.666016 x: 20 y: 35 x_v: 7.993601 y_v: -0.319915 obs_count: 10,\n",
-       " lh: 32275.259766 flux: 20412.666016 x: 20 y: 35 x_v: 7.998400 y_v: -0.159989 obs_count: 10,\n",
-       " lh: 32275.259766 flux: 20412.666016 x: 20 y: 35 x_v: 8.000000 y_v: -0.000000 obs_count: 10,\n",
-       " lh: 32275.259766 flux: 20412.666016 x: 20 y: 35 x_v: 7.998400 y_v: 0.159989 obs_count: 10,\n",
-       " lh: 32274.650391 flux: 20412.279297 x: 20 y: 34 x_v: 7.998400 y_v: 0.159989 obs_count: 10,\n",
-       " lh: 32274.650391 flux: 20412.279297 x: 20 y: 34 x_v: 7.985604 y_v: -0.479712 obs_count: 10,\n",
-       " lh: 32274.650391 flux: 20412.279297 x: 20 y: 34 x_v: 8.000000 y_v: -0.000000 obs_count: 10,\n",
-       " lh: 32274.650391 flux: 20412.279297 x: 20 y: 34 x_v: 7.998400 y_v: -0.159989 obs_count: 10,\n",
-       " lh: 32274.650391 flux: 20412.279297 x: 20 y: 34 x_v: 7.993601 y_v: -0.319915 obs_count: 10,\n",
-       " lh: 32273.943359 flux: 20411.832031 x: 20 y: 34 x_v: 7.993601 y_v: 0.319915 obs_count: 10,\n",
-       " lh: 32273.943359 flux: 20411.832031 x: 20 y: 34 x_v: 7.985604 y_v: 0.479712 obs_count: 10,\n",
-       " lh: 31189.103516 flux: 19725.720703 x: 20 y: 34 x_v: 7.974414 y_v: -0.639318 obs_count: 10,\n",
-       " lh: 31168.183594 flux: 19712.488281 x: 19 y: 35 x_v: 7.960033 y_v: -0.798667 obs_count: 10,\n",
-       " lh: 31167.269531 flux: 19711.910156 x: 19 y: 35 x_v: 7.974414 y_v: -0.639318 obs_count: 10,\n",
-       " lh: 31167.019531 flux: 19711.751953 x: 19 y: 35 x_v: 7.993601 y_v: -0.319915 obs_count: 10,\n",
-       " lh: 31167.019531 flux: 19711.751953 x: 19 y: 35 x_v: 7.985604 y_v: -0.479712 obs_count: 10,\n",
-       " lh: 31167.019531 flux: 19711.751953 x: 19 y: 35 x_v: 7.998400 y_v: 0.159989 obs_count: 10]"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# These top_results are all be duplicating searches on the same bright object we added.\n",
     "top_results[:20]"

--- a/notebooks/Kbmod_Reference.ipynb
+++ b/notebooks/Kbmod_Reference.ipynb
@@ -35,8 +35,6 @@
    "outputs": [],
    "source": [
     "# everything we will need for this demo\n",
-    "from kbmod.evaluate import *\n",
-    "from kbmod.run_search import run_search\n",
     "import kbmod.search as kb\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",


### PR DESCRIPTION
the first of the 2 commits only removes output cells from the notebook so it is easier to see the actual (though trivial) changes. After making these changes I was able to step through the entire notebook.