### PR TITLE
Get rid of hardcoded stamp size

### DIFF
--- a/src/kbmod/result_list.py
+++ b/src/kbmod/result_list.py
@@ -428,7 +428,7 @@ class ResultList:
         if np.any(stamps_list == None):
             stamps_list = np.array([])
 
-        stamp_size = 0
+        stamp_size = 441
         if len(stamps_list) > 0:
             stamp_size = stamps_list[0].size
 

--- a/src/kbmod/result_list.py
+++ b/src/kbmod/result_list.py
@@ -423,12 +423,18 @@ class ResultList:
             fmt="%.4f",
         )
 
+        # Output the co-added stamps.
         stamps_list = np.array([x.stamp for x in self.results])
         if np.any(stamps_list is None):
             stamps_list = np.array([])
+
+        stamp_size = 0
+        if len(stamps_list) > 0:
+            stamp_size = stamps_list[0].size
+
         np.savetxt(
             "%s/ps_%s.txt" % (res_filepath, out_suffix),
-            stamps_list.reshape(len(stamps_list), 441),
+            stamps_list.reshape(len(stamps_list), stamp_size),
             fmt="%.4f",
         )
 

--- a/src/kbmod/result_list.py
+++ b/src/kbmod/result_list.py
@@ -425,7 +425,7 @@ class ResultList:
 
         # Output the co-added stamps.
         stamps_list = np.array([x.stamp for x in self.results])
-        if np.any(stamps_list is None):
+        if np.any(stamps_list == None):
             stamps_list = np.array([])
 
         stamp_size = 0


### PR DESCRIPTION
The stamp size output was hard coded for the default stamp setting, but would cause a problem if another size is used.