### PR TITLE
Improve extraction of Visit ID

### DIFF
--- a/docs/source/user_manual/input_files.rst
+++ b/docs/source/user_manual/input_files.rst
@@ -16,10 +16,10 @@ Visit ID
 
 In order to associate input files with auxiliary data, such as time stamps or PSFs, each visit uses a unique numeric ID. This ID string can be provided in the ``IDNUM`` field of the FITS file’s header 0. If no ``IDNUM`` field is provided, then KBMOD will attempt to derive the visit ID from the file name as described in the next section.
 
-Naming Scheme and 
---------------------------
+Naming Scheme
+-------------
 
- Each file **must** include ``.fits`` somewhere in the file name. Additionally the file names can be used to encode the visit ID. If no ``IDNUM`` field is provided, KBMOD will look for a contiguous sequence of five or more numeric digits in the file name. If found, the first such sequence is used as the visit ID. For example a file name “my12345.fits” will map to the visit ID “12345”.
+Each file **must** include ``.fits`` somewhere in the file name. Additionally the file names can be used to encode the visit ID. If no ``IDNUM`` field is provided, KBMOD will look for a contiguous sequence of five or more numeric digits in the file name. If found, the first such sequence is used as the visit ID. For example a file name “my12345.fits” will map to the visit ID “12345”.
 
 Time file
 ---------

--- a/docs/source/user_manual/input_files.rst
+++ b/docs/source/user_manual/input_files.rst
@@ -11,13 +11,15 @@ stored in 1st, 2nd and 3rd header extension/plane respectively. The zeroth heade
 
 The images are expected to be warped, i.e. geometrically transformed to a set of images with a consistent and uniform relationship between sky coordinates and image pixels on a shared pixel grid. 
 
-Naming scheme
--------------
+Visit ID
+--------
 
-Each file must include the image’s numeric visit ID in the file name. The parameter ``visit_in_filename`` (see :ref:`Search Parameters`) indicates character range, not including the directory name, that contains the visit ID in the filename. For example the image file ``./my_data/my_data_433932.fits`` would use the following parameters::
+In order to associate input files with auxiliary data, such as time stamps or PSFs, each visit uses a unique numeric ID. This ID string can be provided in the ``IDNUM`` field of the FITS file’s header 0. If no ``IDNUM`` field is provided, then KBMOD will attempt to derive the visit ID from the file name as described in the next section.
 
-    im_filepath=“./my_data”
-    visit_in_filename=[8, 14]
+Naming Scheme and 
+--------------------------
+
+ Each file **must** include ``.fits`` somewhere in the file name. Additionally the file names can be used to encode the visit ID. If no ``IDNUM`` field is provided, KBMOD will look for a contiguous sequence of five or more numeric digits in the file name. If found, the first such sequence is used as the visit ID. For example a file name “my12345.fits” will map to the visit ID “12345”.
 
 Time file
 ---------

--- a/docs/source/user_manual/search_params.rst
+++ b/docs/source/user_manual/search_params.rst
@@ -197,6 +197,3 @@ Search parameters are set extensively via the :py:attr:`~kbmod.run_search.run_se
 |                        |                             | file containing the per-image PSFs.    |
 |                        |                             | See :ref:`PSF File` for more.          |
 +------------------------+-----------------------------+----------------------------------------+
-| ``visit_in_filename``  | [0, 6]                      | Character range that contains the visit|
-|                        |                             | ID. See :ref:`Naming Scheme` for more. |
-+------------------------+-----------------------------+----------------------------------------+

--- a/notebooks/kbmod_analysis_demo.ipynb
+++ b/notebooks/kbmod_analysis_demo.ipynb
@@ -252,7 +252,7 @@
     "file_names = [f\"{img_dir}/{f}\" for f in sorted(os.listdir(img_dir))]\n",
     "\n",
     "img_info = ImageInfoSet()\n",
-    "img_info.load_image_info_from_files(file_names, visit_in_filename=[0, 6])\n",
+    "img_info.load_image_info_from_files(file_names)\n",
     "print(f\"Loaded data for {img_info.num_images} images.\")\n",
     "\n",
     "img_info.load_times_from_file(\"../data/demo_times.dat\")\n",

--- a/src/kbmod/analysis_utils.py
+++ b/src/kbmod/analysis_utils.py
@@ -36,7 +36,6 @@ class Interface(SharedTools):
         time_file,
         psf_file,
         mjd_lims,
-        visit_in_filename,
         default_psf,
         verbose=False,
     ):
@@ -54,10 +53,6 @@ class Interface(SharedTools):
             all images.
         mjd_lims : list of ints
             Optional MJD limits on the images to search.
-        visit_in_filename : list of ints
-            The range of characters [start, end) in a filename that contain the
-            visit ID. By default, the first six characters of the filenames in
-            this folder should contain the visit ID.
         default_psf : `psf`
             The default PSF in case no image-specific PSF is provided.
         verbose : bool
@@ -70,15 +65,9 @@ class Interface(SharedTools):
             img_info : `ImageInfo`
                 The information for the images loaded.
         """
-        img_info = ImageInfoSet()
         print("---------------------------------------")
         print("Loading Images")
         print("---------------------------------------")
-
-        # Get the bounds for the characters to use for the visit ID in the file name.
-        id_start = visit_in_filename[0]
-        id_end = visit_in_filename[1]
-        id_len = id_end - id_start
 
         # Load a mapping from visit numbers to the visit times. This dictionary stays
         # empty if no time file is specified.
@@ -96,74 +85,70 @@ class Interface(SharedTools):
         patch_visits = sorted(os.listdir(im_filepath))
 
         # Load the images themselves.
-        filenames = []
+        img_info = ImageInfoSet()
         images = []
         visit_times = []
         for visit_file in np.sort(patch_visits):
-            full_file_path = "{0:s}/{1:s}".format(im_filepath, visit_file)
-
-            # Filter out files that do not match the required filename format.
-            if len(visit_file) < id_end + 5 or visit_file[-5:] != ".fits":
+            # Skip non-fits files.
+            if not ".fits" in visit_file:
                 if verbose:
-                    print(f"Skipping file {visit_file}")
-                continue
-            visit_str = visit_file[id_start:id_end]
-            if not visit_str.isnumeric():
-                if verbose:
-                    print(f"Skipping file {visit_file}")
+                    print(f"Skipping non-FITS file {visit_file}")
                 continue
 
-            # Check if we can prune the file based on the timestamp. We do this
-            # before the file load to save time, but might have to recheck if the
-            # time stamp is stored in the file itself.
+            # Compute the full file path for loading.
+            full_file_path = os.path.join(im_filepath, visit_file)
+
+            # Load the image info from the FITS header.
+            header_info = ImageInfo()
+            header_info.populate_from_fits_file(full_file_path)
+
+            # Skip files without a valid visit ID.
+            if header_info.visit_id is None:
+                if verbose:
+                    print(f"WARNING: Unable to extract visit ID for {visit_file}.")
+                continue
+
+            # Compute the time stamp as a MJD float. If there is an entry in the
+            # timestamp file, defer to that. Otherwise use the value from the header.
             time_stamp = -1.0
-            if visit_str in image_time_dict:
-                time_stamp = image_time_dict[visit_str]
-                if mjd_lims is not None:
-                    if time_stamp < mjd_lims[0] or time_stamp > mjd_lims[1]:
-                        if verbose:
-                            print(f"Pruning file {visit_str} by timestamp={time_stamp}.")
-                        continue
+            if header_info.visit_id in image_time_dict:
+                time_stamp = image_time_dict[header_info.visit_id]
+            else:
+                time_obj = header_info.get_epoch(none_if_unset=True)
+                if time_obj is not None:
+                    time_stamp = time_obj.mjd
+
+            if time_stamp <= 0.0:
+                if verbose:
+                    print(f"WARNING: No valid timestamp provided for {visit_file}.")
+                continue
+
+            # Check if we should filter the record based on the time bounds.
+            if mjd_lims is not None and (time_stamp < mjd_lims[0] or time_stamp > mjd_lims[1]):
+                if verbose:
+                    print(f"Pruning file {visit_file} by timestamp={time_stamp}.")
+                continue
 
             # Check if the image has a specific PSF.
             psf = default_psf
-            if visit_str in image_psf_dict:
-                psf = kb.psf(image_psf_dict[visit_str])
+            if header_info.visit_id in image_psf_dict:
+                psf = kb.psf(image_psf_dict[header_info.visit_id])
 
-            # Load the image file.
+            # Load the image file and set its time.
             if verbose:
                 print(f"Loading file: {full_file_path}")
             img = kb.layered_image(full_file_path, psf)
-
-            # If we didn't previously load a time stamp, check whether the file contains
-            # that information and retry the time based filteriing.
-            if time_stamp <= 0.0:
-                time_stamp = img.get_time()  # default of 0.0
-                # Skip images without valid times.
-                if time_stamp <= 0.0:
-                    print("WARNING: No timestamp provided for visit %s. Skipping." % visit_str)
-                    continue
-                # Skip images with times outside the specified range.
-                if mjd_lims is not None:
-                    if time_stamp < mjd_lims[0] or time_stamp > mjd_lims[1]:
-                        continue
-            else:
-                # If we have a valid timestamp from the file, use that for the image.
-                img.set_time(time_stamp)
+            img.set_time(time_stamp)
 
             # Save the file, time, and image information.
-            filenames.append(full_file_path)
-            images.append(img)
+            img_info.append(header_info)
             visit_times.append(time_stamp)
+            images.append(img)
 
-        print("Loaded {0:d} images".format(len(images)))
+        print(f"Loaded {len(images)} images")
         stack = kb.image_stack(images)
 
-        # Load the additional image information, including
-        # WCS and computing the ecliptic angles.
-        img_info.load_image_info_from_files(filenames)
-
-        # Create a list of visit times and visit times shifts to 0.0.
+        # Create a list of visit times and visit times shifted to 0.0.
         img_info.set_times_mjd(np.array(visit_times))
         times = img_info.get_zero_shifted_times()
         stack.set_times(times)

--- a/src/kbmod/file_utils.py
+++ b/src/kbmod/file_utils.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 import csv
 import numpy as np
 from pathlib import Path
+import re
 
 import kbmod.search as kb
 
@@ -20,6 +21,29 @@ class FileUtils:
         ``results = FileUtils.load_results_file_as_trajectories(
                       "kbmod/data/fake_results/results_DEMO.txt")``
     """
+
+    @staticmethod
+    def visit_from_file_name(filename):
+        """Automatically extract the visit ID from the file name.
+
+        Uses the heuristic that the visit ID is the first numeric
+        string of at least length 5 digits in the file name.
+
+        Parameters
+        ----------
+        filename : str
+            The file name
+
+        Returns
+        -------
+        result : str
+            The visit ID string or None if there is no match.
+        """
+        expr = re.compile(r"\d{4}(?:\d+)")
+        res = expr.search(filename)
+        if res is None:
+            return None
+        return res.group()
 
     @staticmethod
     def save_csv_from_list(file_name, data, overwrite=False):

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -81,7 +81,6 @@ class run_search:
             "psf_val": 1.4,
             "num_obs": 10,
             "num_cores": 1,
-            "visit_in_filename": [0, 6],
             "sigmaG_lims": [25, 75],
             "chunk_size": 500000,
             "max_lh": 1000.0,
@@ -269,7 +268,6 @@ class run_search:
             self.config["time_file"],
             self.config["psf_file"],
             self.config["mjd_lims"],
-            self.config["visit_in_filename"],
             default_psf,
             verbose=self.config["debug"],
         )

--- a/tests/test_analysis_utils.py
+++ b/tests/test_analysis_utils.py
@@ -56,7 +56,6 @@ class test_analysis_utils(unittest.TestCase):
             "psf_val": 1.4,
             "num_obs": 10,
             "num_cores": 1,
-            "visit_in_filename": [0, 6],
             "file_format": "{0:06d}.fits",
             "sigmaG_lims": [25, 75],
             "chunk_size": 500000,
@@ -548,7 +547,6 @@ class test_analysis_utils(unittest.TestCase):
             None,
             None,
             [0, 157130.2],
-            [0, 6],
             psf(1.0),
             verbose=False,
         )
@@ -563,6 +561,15 @@ class test_analysis_utils(unittest.TestCase):
             self.assertAlmostEqual(img.get_time(), true_times[i], delta=0.005)
             self.assertAlmostEqual(1.0, img.get_psf().get_stdev())
 
+        # Check that visit IDs and times were extracted for each file in img_info.
+        true_visit_ids = ["000000", "000001", "000002", "000003"]
+        for i in range(img_info.num_images):
+            self.assertEqual(img_info.stats[i].visit_id, true_visit_ids[i])
+
+            time_obj = img_info.stats[i].get_epoch(none_if_unset=True)
+            self.assertIsNotNone(time_obj)
+            self.assertAlmostEqual(time_obj.mjd, true_times[i], delta=0.005)
+
     def test_file_load_extra(self):
         p = psf(1.0)
 
@@ -572,7 +579,6 @@ class test_analysis_utils(unittest.TestCase):
             "./data/fake_times.dat",
             "./data/fake_psfs.dat",
             [0, 157130.2],
-            [0, 6],
             p,
             verbose=False,
         )
@@ -587,6 +593,15 @@ class test_analysis_utils(unittest.TestCase):
             self.assertEqual(img.get_height(), 64)
             self.assertAlmostEqual(img.get_time(), true_times[i], delta=0.005)
             self.assertAlmostEqual(psfs_std[i], img.get_psf().get_stdev())
+
+        # Check that visit IDs and times were extracted for each file in img_info.
+        true_visit_ids = ["000000", "000001", "000002", "000003"]
+        for i in range(img_info.num_images):
+            self.assertEqual(img_info.stats[i].visit_id, true_visit_ids[i])
+
+            time_obj = img_info.stats[i].get_epoch(none_if_unset=True)
+            self.assertIsNotNone(time_obj)
+            self.assertAlmostEqual(time_obj.mjd, true_times[i], delta=0.005)
 
 
 if __name__ == "__main__":

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -7,6 +7,21 @@ from kbmod.search import *
 
 
 class test_file_utils(unittest.TestCase):
+    def test_visit_from_file_name(self):
+        visit = FileUtils.visit_from_file_name("m00005.fits")
+        self.assertEqual(visit, "00005")
+
+        visit = FileUtils.visit_from_file_name("m654321.fits")
+        self.assertEqual(visit, "654321")
+
+        # Too few digits
+        visit = FileUtils.visit_from_file_name("m005.fits")
+        self.assertIsNone(visit)
+
+        # Nonsequential digits
+        visit = FileUtils.visit_from_file_name("m123x45.fits")
+        self.assertIsNone(visit)
+
     def test_save_load_csv(self):
         data = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
         with tempfile.TemporaryDirectory() as dir_name:


### PR DESCRIPTION
Change the logic of how the visit ID is extracted to first look for it in the `IDNUM` field and second to extract the first sequence of 5+ digits in the filename. This allows us to remove the `visit_in_filename` parameter.

Also change how the file loading function is structured to simplify the handling of timestamps. We load the header first so we can use that to compute both visit ID and timestamp.