### PR TITLE
Replace move with copy in deployment section of docs workflow.

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -55,12 +55,12 @@ jobs:
       - name: Cron deploy docs
         if: ${{ github.event_name == 'schedule' }}
         run: |
-          mv docs/build/* /astro/store/epyc/users/kbmod/public_html/
+          cp -r docs/build/* /astro/store/epyc/users/kbmod/public_html/
       - name: Deploy docs
         if: ${{ startsWith(github.event.head_commit.message, '[deploy_docs]') }}
         run: |
-          mv docs/build/* /astro/store/epyc/users/kbmod/public_html/
+          cp -r docs/build/* /astro/store/epyc/users/kbmod/public_html/
       - name: Deploy alpha
         if: ${{ startsWith(github.event.head_commit.message, '[deploy_alpha]') }}
         run: |
-          mv docs/build/* /astro/store/epyc/users/kbmod/public_html/alpha
+          cp -r docs/build/* /astro/store/epyc/users/kbmod/public_html/alpha


### PR DESCRIPTION
`mv` command will refuse to overwrite non-empty directories even when forced.

Replace mv with cp -r instead.
Test deployment works.