### PR TITLE
Give ResultList the ability to track filtered results

### DIFF
--- a/tests/test_result_list.py
+++ b/tests/test_result_list.py
@@ -215,8 +215,48 @@ class test_result_list(unittest.TestCase):
             self.assertIsNotNone(rs.results[i].trajectory)
             self.assertEqual(rs.results[i].final_likelihood, float(inds[i]))
 
+        # Without tracking there should be nothing stored in the ResultList's
+        # filtered dictionary.
+        self.assertEqual(len(rs.filtered), 0)
+
+    def test_filter_track(self):
+        rs = ResultList(self.times, track_filtered=True)
+        for i in range(10):
+            t = trajectory()
+            t.x = i
+            rs.append_result(ResultRow(t, self.num_times))
+        self.assertEqual(rs.num_results(), 10)
+
+        # Do the filtering. First remove elements 0 and 2. Then remove elements
+        # 0, 5, and 6 from the resulting list (1, 7, 8 in the original list).
+        rs.filter_results([1, 3, 4, 5, 6, 7, 8, 9], label="1")
+        self.assertEqual(rs.num_results(), 8)
+        rs.filter_results([1, 2, 3, 4, 7], label="2")
+        self.assertEqual(rs.num_results(), 5)
+        self.assertEqual(rs.results[0].trajectory.x, 3)
+        self.assertEqual(rs.results[1].trajectory.x, 4)
+        self.assertEqual(rs.results[2].trajectory.x, 5)
+        self.assertEqual(rs.results[3].trajectory.x, 6)
+        self.assertEqual(rs.results[4].trajectory.x, 9)
+
+        # Check that we can get the correct filtered rows.
+        f1 = rs.get_filtered("1")
+        self.assertEqual(len(f1), 2)
+        self.assertEqual(f1[0].trajectory.x, 0)
+        self.assertEqual(f1[1].trajectory.x, 2)
+
+        f2 = rs.get_filtered("2")
+        self.assertEqual(len(f2), 3)
+        self.assertEqual(f2[0].trajectory.x, 1)
+        self.assertEqual(f2[1].trajectory.x, 7)
+        self.assertEqual(f2[2].trajectory.x, 8)
+
+        # Check that not passing a label gives us all filtered results.
+        f_all = rs.get_filtered()
+        self.assertEqual(len(f_all), 5)
+
     def test_filter_likelihood(self):
-        rs = ResultList(self.times)
+        rs = ResultList(self.times, track_filtered=True)
         for i in range(10):
             t = trajectory()
             t.lh = float(i)
@@ -229,8 +269,14 @@ class test_result_list(unittest.TestCase):
         for i in range(rs.num_results()):
             self.assertGreater(rs.results[i].final_likelihood, 4.5)
 
+        # Check the filtered results
+        filtered = rs.get_filtered("filter_on_stats")
+        self.assertEqual(len(filtered), 5)
+        for row in filtered:
+            self.assertLess(row.final_likelihood, 4.5)
+
     def test_filter_valid_indices(self):
-        rs = ResultList(self.times)
+        rs = ResultList(self.times, track_filtered=True)
         for i in range(10):
             t = trajectory()
             row = ResultRow(t, self.num_times)
@@ -243,6 +289,12 @@ class test_result_list(unittest.TestCase):
         self.assertEqual(rs.num_results(), 6)
         for i in range(rs.num_results()):
             self.assertGreaterEqual(len(rs.results[i].valid_indices), 4)
+
+        # Check the filtered results
+        filtered = rs.get_filtered()  # Use no label name.
+        self.assertEqual(len(filtered), 4)
+        for row in filtered:
+            self.assertLess(len(row.valid_indices), 4)
 
     def test_save_results(self):
         times = [0.0, 1.0, 2.0]


### PR DESCRIPTION
Allow ResultList to optionally track results that is has filtered out with a string label. This allows efficiency analyses of different filtering steps by looking at which trajectories are removed at which step. Tracking filtered results should not be used in most production runs as it will increase overall memory usage.

This is the first PR in refactoring the filtering system to make it more modular.