### PR TITLE
Allow trajectory to be pickled

### DIFF
--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -255,7 +255,23 @@ PYBIND11_MODULE(search, m) {
                 return "lh: " + to_string(t.lh) + " flux: " + to_string(t.flux) + " x: " + to_string(t.x) +
                        " y: " + to_string(t.y) + " x_v: " + to_string(t.xVel) + " y_v: " + to_string(t.yVel) +
                        " obs_count: " + to_string(t.obsCount);
-            });
+            })
+            .def(py::pickle(
+                [](const tj &p) { // __getstate__
+                    return py::make_tuple(p.xVel, p.yVel, p.lh, p.flux, p.x, p.y, p.obsCount);
+                },
+                [](py::tuple t) { // __setstate__
+                    if (t.size() != 7)
+                        throw std::runtime_error("Invalid state!");
+                    tj trj = {t[0].cast<float>(),
+                              t[1].cast<float>(),
+                              t[2].cast<float>(),
+                              t[3].cast<float>(),
+                              t[4].cast<short>(),
+                              t[5].cast<short>(),
+                              t[6].cast<short>()};
+                    return trj;
+                }));
     py::class_<tjr>(m, "trj_result")
             .def(py::init<tj &, int>())
             .def(py::init<tj &, std::vector<int>>())


### PR DESCRIPTION
Since trajectory is based on a C++ struct, it does not automatically work with pickle. This augments the pybind setting to allow that.

This will enable future parallelizations.