### PR TITLE
Remove unused stamp generation functions

### DIFF
--- a/src/kbmod/analysis_utils.py
+++ b/src/kbmod/analysis_utils.py
@@ -321,54 +321,6 @@ class PostProcess(SharedTools):
             res_num += chunk_size
         return keep
 
-    def get_coadd_stamps(self, result_idx, search, keep, radius=10, stamp_type="sum"):
-        """Get the coadded stamps for the initial results from a kbmod search.
-
-        Parameters
-        ----------
-        result_idx : list
-            The index of the result trajectories for which to compute
-            the coadded stamps.
-        search : `kbmod.search.Search`
-            The search object.
-        keep : `ResultList`
-            The current set of results.
-        radius : int
-            The size of the stamp. Default 10 gives a 21x21 stamp.
-            15 gives a 31x31 stamp, etc.
-        stamp_type : string
-            An input string to generate different kinds of stamps.
-            'sum' or 'parallel_sum' - (default) A simple sum of all individual stamps
-            'median' or 'cpp_median' - A per-pixel median of individual stamps.
-            'mean' or 'cpp_median' - A per-pixel median of individual stamps.
-
-        Returns
-        -------
-        coadd_stamps : list
-            A list of numpy arrays containing the coadded stamp values for
-            each trajectory.
-        """
-        start = time.time()
-
-        # Create the list of trajectory results to use.
-        trj_list = keep.trj_result_list(indices_to_use=result_idx)
-
-        # Make the stamps.
-        if stamp_type == "cpp_median" or stamp_type == "median":
-            coadd_stamps = [np.array(stamp) for stamp in search.median_sci_stamps(trj_list, radius)]
-        elif stamp_type == "cpp_mean" or stamp_type == "mean":
-            coadd_stamps = [np.array(stamp) for stamp in search.mean_sci_stamps(trj_list, radius)]
-        elif stamp_type == "parallel_sum" or stamp_type == "sum":
-            coadd_stamps = [np.array(stamp) for stamp in search.summed_sci_stamps(trj_list, radius)]
-        else:
-            coadd_stamps = []
-
-        print(
-            "Loaded {} coadded stamps. {:.3f}s elapsed".format(len(coadd_stamps), time.time() - start),
-            flush=True,
-        )
-        return coadd_stamps
-
     def get_all_stamps(self, result_list, search, stamp_radius):
         """Get the stamps for the final results from a kbmod search.
 

--- a/src/kbmod/search/KBMOSearch.h
+++ b/src/kbmod/search/KBMOSearch.h
@@ -64,12 +64,9 @@ public:
     std::vector<RawImage> scienceStamps(const TrajectoryResult& trj, int radius, bool interpolate,
                                         bool keep_no_data, bool all_stamps);
     std::vector<RawImage> scienceStampsForViz(const trajectory& t, int radius);
-    RawImage medianScienceStamp(const TrajectoryResult& trj, int radius, bool use_all);
-    RawImage meanScienceStamp(const TrajectoryResult& trj, int radius, bool use_all);
-    RawImage summedScienceStamp(const TrajectoryResult& trj, int radius, bool use_all);
-    std::vector<RawImage> medianScienceStamps(const std::vector<TrajectoryResult>& t_array, int radius);
-    std::vector<RawImage> meanScienceStamps(const std::vector<TrajectoryResult>& t_array, int radius);
-    std::vector<RawImage> summedScienceStamps(const std::vector<TrajectoryResult>& t_array, int radius);
+    RawImage medianScienceStamp(const TrajectoryResult& trj, int radius);
+    RawImage meanScienceStamp(const TrajectoryResult& trj, int radius);
+    RawImage summedScienceStamp(const TrajectoryResult& trj, int radius);
 
     // Compute a mean or summed stamp for each trajectory on the GPU. This is slower than the
     // above for small numbers of trajectories (< 500), but performs relatively better as the

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -185,9 +185,6 @@ PYBIND11_MODULE(search, m) {
             .def("median_sci_stamp", &ks::medianScienceStamp)
             .def("mean_sci_stamp", &ks::meanScienceStamp)
             .def("summed_sci_stamp", &ks::summedScienceStamp)
-            .def("median_sci_stamps", &ks::medianScienceStamps)
-            .def("mean_sci_stamps", &ks::meanScienceStamps)
-            .def("summed_sci_stamps", &ks::summedScienceStamps)
             .def("gpu_coadded_stamps",
                  (std::vector<ri>(ks::*)(std::vector<tj> &, std::vector<std::vector<bool>> &,
                                          const search::stampParameters &)) &

--- a/tests/test_analysis_utils.py
+++ b/tests/test_analysis_utils.py
@@ -408,58 +408,6 @@ class test_analysis_utils(unittest.TestCase):
         self.assertEqual(keep.results[0].trajectory.x, self.start_x)
         self.assertEqual(keep.results[1].trajectory.x, self.start_x + 1)
 
-    def test_get_coadded_stamps(self):
-        # object properties
-        self.object_flux = 250.0
-        self.start_x = 4
-        self.start_y = 3
-        self.x_vel = 2.0
-        self.y_vel = 1.0
-
-        for i in range(self.img_count):
-            time = i / self.img_count
-            self.imlist[i].add_object(
-                self.start_x + time * self.x_vel,
-                self.start_y + time * self.y_vel,
-                self.object_flux,
-            )
-
-        stack = image_stack(self.imlist)
-        search = stack_search(stack)
-
-        # Create a first trajectory that matches perfectly.
-        trj = trajectory()
-        trj.x = self.start_x
-        trj.y = self.start_y
-        trj.x_v = self.x_vel
-        trj.y_v = self.y_vel
-
-        # Create the ResultList.
-        keep = ResultList(self.time_list)
-        for i in range(5):
-            keep.append_result(ResultRow(trj, self.img_count))
-
-        # Mark a few of the results as invalid for trajectories 2 and 3.
-        keep.results[2].filter_indices([2, 3, 4, 7, 8, 9])
-        keep.results[3].filter_indices([0, 1, 5, 6])
-
-        # Create the post processing object.
-        result_idx = [1, 3, 4]
-        kb_post_process = PostProcess(self.config, self.time_list)
-        stamps = kb_post_process.get_coadd_stamps(result_idx, search, keep, 3, "cpp_mean")
-
-        # Check that we only get three stamps back.
-        self.assertEqual(len(stamps), 3)
-
-        # Check that we are using the correct trajectories and lc_indices.
-        for i, idx in enumerate(result_idx):
-            res_trj = trj_result(trj, self.img_count, keep.results[idx].valid_indices)
-            stamp_idv = search.mean_sci_stamp(res_trj, 3, False)
-            stamp_batch = stamps[i]
-            for x in range(7):
-                for y in range(7):
-                    self.assertAlmostEqual(stamp_idv.get_pixel(x, y), stamp_batch[y][x], delta=1e-5)
-
     def test_clustering(self):
         cluster_params = {}
         cluster_params["x_size"] = self.dim_x

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -250,14 +250,9 @@ class test_search(unittest.TestCase):
 
     def test_stacked_sci(self):
         # Compute the stacked science from a single trajectory.
-        sci = self.search.summed_sci_stamp(self.trj_res, 2, True)
+        sci = self.search.summed_sci_stamp(self.trj_res, 2)
         self.assertEqual(sci.get_width(), 5)
         self.assertEqual(sci.get_height(), 5)
-
-        # Compute a vector of stacked sciences from a vector of trajectories.
-        sci_vect = self.search.summed_sci_stamps([self.trj_res], 2)[0]
-        self.assertEqual(sci_vect.get_width(), 5)
-        self.assertEqual(sci_vect.get_height(), 5)
 
         # Compute the true stacked pixel for the middle of the track.
         times = self.stack.get_times()
@@ -274,7 +269,6 @@ class test_search(unittest.TestCase):
         # Check that the two different approaches for stack science
         # match the true value.
         self.assertAlmostEqual(sci.get_pixel(2, 2), sum_middle, delta=0.001)
-        self.assertAlmostEqual(sci_vect.get_pixel(2, 2), sum_middle, delta=0.001)
 
     def test_median_stamps_trj(self):
         # Compute the stacked science from two trajectories (one with bad points).
@@ -285,11 +279,13 @@ class test_search(unittest.TestCase):
         trj_res0 = trj_result(self.trj, goodIdx[0])
         trj_res1 = trj_result(self.trj, goodIdx[1])
 
-        medianStamps = self.search.median_sci_stamps([trj_res0, trj_res1], 2)
-        self.assertEqual(medianStamps[0].get_width(), 5)
-        self.assertEqual(medianStamps[0].get_height(), 5)
-        self.assertEqual(medianStamps[1].get_width(), 5)
-        self.assertEqual(medianStamps[1].get_height(), 5)
+        medianStamps0 = self.search.median_sci_stamp(trj_res0, 2)
+        self.assertEqual(medianStamps0.get_width(), 5)
+        self.assertEqual(medianStamps0.get_height(), 5)
+
+        medianStamps1 = self.search.median_sci_stamp(trj_res1, 2)
+        self.assertEqual(medianStamps1.get_width(), 5)
+        self.assertEqual(medianStamps1.get_height(), 5)
 
         # Compute the true median pixel for the middle of the track.
         times = self.stack.get_times()
@@ -308,8 +304,8 @@ class test_search(unittest.TestCase):
         self.assertEqual(len(pix_values1), self.imCount - 3)
 
         # Check that we get the correct answer.
-        self.assertAlmostEqual(np.median(pix_values0), medianStamps[0].get_pixel(2, 2), delta=1e-5)
-        self.assertAlmostEqual(np.median(pix_values1), medianStamps[1].get_pixel(2, 2), delta=1e-5)
+        self.assertAlmostEqual(np.median(pix_values0), medianStamps0.get_pixel(2, 2), delta=1e-5)
+        self.assertAlmostEqual(np.median(pix_values1), medianStamps1.get_pixel(2, 2), delta=1e-5)
 
     def test_median_stamps_no_data(self):
         # Create a trajectory that goes through the masked pixels.
@@ -321,9 +317,9 @@ class test_search(unittest.TestCase):
         trj_res = trj_result(trj, self.imCount)
 
         # Compute the stacked science from a single trajectory.
-        medianStamps = self.search.median_sci_stamps([trj_res], 2)
-        self.assertEqual(medianStamps[0].get_width(), 5)
-        self.assertEqual(medianStamps[0].get_height(), 5)
+        medianStamp = self.search.median_sci_stamp(trj_res, 2)
+        self.assertEqual(medianStamp.get_width(), 5)
+        self.assertEqual(medianStamp.get_height(), 5)
 
         # Compute the true median pixel for the middle of the track.
         pix_values = []
@@ -334,7 +330,7 @@ class test_search(unittest.TestCase):
         self.assertEqual(len(pix_values), self.imCount / 2)
 
         # Check that we get the correct answer.
-        self.assertAlmostEqual(np.median(pix_values), medianStamps[0].get_pixel(2, 2), delta=1e-5)
+        self.assertAlmostEqual(np.median(pix_values), medianStamp.get_pixel(2, 2), delta=1e-5)
 
     def test_mean_stamps_trj(self):
         # Compute the stacked science from two trajectories (one with bad points).
@@ -345,11 +341,13 @@ class test_search(unittest.TestCase):
         trj_res0 = trj_result(self.trj, goodIdx[0])
         trj_res1 = trj_result(self.trj, goodIdx[1])
 
-        meanStamps = self.search.mean_sci_stamps([trj_res0, trj_res1], 2)
-        self.assertEqual(meanStamps[0].get_width(), 5)
-        self.assertEqual(meanStamps[0].get_height(), 5)
-        self.assertEqual(meanStamps[1].get_width(), 5)
-        self.assertEqual(meanStamps[1].get_height(), 5)
+        meanStamp0 = self.search.mean_sci_stamp(trj_res0, 2)
+        self.assertEqual(meanStamp0.get_width(), 5)
+        self.assertEqual(meanStamp0.get_height(), 5)
+
+        meanStamp1 = self.search.mean_sci_stamp(trj_res1, 2)
+        self.assertEqual(meanStamp1.get_width(), 5)
+        self.assertEqual(meanStamp1.get_height(), 5)
 
         # Compute the true median pixel for the middle of the track.
         times = self.stack.get_times()
@@ -372,8 +370,8 @@ class test_search(unittest.TestCase):
         self.assertEqual(pix_count1, self.imCount - 3)
 
         # Check that we get the correct answer.
-        self.assertAlmostEqual(pix_sum0 / pix_count0, meanStamps[0].get_pixel(2, 2), delta=1e-5)
-        self.assertAlmostEqual(pix_sum1 / pix_count1, meanStamps[1].get_pixel(2, 2), delta=1e-5)
+        self.assertAlmostEqual(pix_sum0 / pix_count0, meanStamp0.get_pixel(2, 2), delta=1e-5)
+        self.assertAlmostEqual(pix_sum1 / pix_count1, meanStamp1.get_pixel(2, 2), delta=1e-5)
 
     def test_mean_stamps_no_data(self):
         # Create a trajectory that goes through the masked pixels.
@@ -385,9 +383,9 @@ class test_search(unittest.TestCase):
         trj_res = trj_result(trj, self.imCount)
 
         # Compute the stacked science from a single trajectory.
-        meanStamps = self.search.mean_sci_stamps([trj_res], 2)
-        self.assertEqual(meanStamps[0].get_width(), 5)
-        self.assertEqual(meanStamps[0].get_height(), 5)
+        meanStamp = self.search.mean_sci_stamp(trj_res, 2)
+        self.assertEqual(meanStamp.get_width(), 5)
+        self.assertEqual(meanStamp.get_height(), 5)
 
         # Compute the true median pixel for the middle of the track.
         pix_sum = 0.0
@@ -400,7 +398,7 @@ class test_search(unittest.TestCase):
         self.assertEqual(pix_count, self.imCount / 2.0)
 
         # Check that we get the correct answer.
-        self.assertAlmostEqual(pix_sum / pix_count, meanStamps[0].get_pixel(2, 2), delta=1e-5)
+        self.assertAlmostEqual(pix_sum / pix_count, meanStamp.get_pixel(2, 2), delta=1e-5)
 
     def test_coadd_gpu_simple(self):
         # Create an image set with three images.

--- a/tests/test_stamp_parity.py
+++ b/tests/test_stamp_parity.py
@@ -85,7 +85,10 @@ class test_search(unittest.TestCase):
 
         # Check the summed stamps. Note summed stamp does not use goodIdx.
         params.stamp_type = StampType.STAMP_SUM
-        stamps_old = self.search.summed_sci_stamps(res_trjs, radius)
+        stamps_old = [
+            self.search.summed_sci_stamp(res_trjs[0], radius),
+            self.search.summed_sci_stamp(res_trjs[1], radius),
+        ]
         stamps_new = self.search.gpu_coadded_stamps(results, params)
         for r in range(2):
             for x in range(width):
@@ -96,7 +99,10 @@ class test_search(unittest.TestCase):
 
         # Check the mean stamps.
         params.stamp_type = StampType.STAMP_MEAN
-        stamps_old = self.search.mean_sci_stamps(res_trjs, radius)
+        stamps_old = [
+            self.search.mean_sci_stamp(res_trjs[0], radius),
+            self.search.mean_sci_stamp(res_trjs[1], radius),
+        ]
         stamps_new = self.search.gpu_coadded_stamps(res_trjs, params)
         for r in range(2):
             for x in range(width):
@@ -107,7 +113,10 @@ class test_search(unittest.TestCase):
 
         # Check the median stamps.
         params.stamp_type = StampType.STAMP_MEDIAN
-        stamps_old = self.search.median_sci_stamps(res_trjs, radius)
+        stamps_old = [
+            self.search.median_sci_stamp(res_trjs[0], radius),
+            self.search.median_sci_stamp(res_trjs[1], radius),
+        ]
         stamps_new = self.search.gpu_coadded_stamps(res_trjs, params)
         for r in range(2):
             for x in range(width):


### PR DESCRIPTION
This change removes the old `get_coadd_stamps` function from analysis_utils.py, which was replaced by logic in `apply_stamp_filter` a while back. It also removes the bulk stamp computation functions from KBMOSearch since nothing is using those anymore. This shifts the burden of bulk computation to the Python code if needed in the future (an can be parallelized there).

This is the first in a series of PRs to cleanup and standardize the stamp generation logic so there are not a bunch of different ways of doing the same thing.