### PR TITLE
add assert for sizes of all image

### DIFF
--- a/src/kbmod/search/KBMOSearch.cpp
+++ b/src/kbmod/search/KBMOSearch.cpp
@@ -257,9 +257,12 @@ void KBMOSearch::fillPsiAndPhiVects(const std::vector<RawImage>& psiImgs,
     assert(num_images > 0);
     assert(phiImgs.size() == num_images);
 
-    int num_pixels = psiImgs[0].getPPI();
-    assert(phiImgs[0].getPPI() == num_pixels);
-
+    int num_pixels = psiImgs[0].getPPI();  
+    for (int i = 0; i < num_images; ++i) {
+        assert(psiImgs[i].getPPI() == num_pixels);
+        assert(phiImgs[i].getPPI() == num_pixels);
+    }
+  
     psiVect->clear();
     psiVect->reserve(num_images * num_pixels);
     phiVect->clear();


### PR DESCRIPTION
I ran KBMOD using images of slightly different sizes. This threw a segmentation fault when trying to fill the psi/phi vectors since they assume all of the images have the same number of pixels.