### PR TITLE
Add more stamp filters

### DIFF
--- a/src/kbmod/filters/stamp_filters.py
+++ b/src/kbmod/filters/stamp_filters.py
@@ -223,7 +223,7 @@ class StampCenterFilter(Filter):
         # Check the stamp's width is correct.
         width = 2 * self.stamp_radius + 1
         if len(row.stamp) != width * width:
-            raise ValueError("Expected stamp of size {width} by {width}.")
+            raise ValueError(f"Expected stamp of size {width} by {width}.")
 
         # Find the value of the center pixel. Filter pixels with no data.
         center_index = width * self.stamp_radius + self.stamp_radius

--- a/src/kbmod/filters/stamp_filters.py
+++ b/src/kbmod/filters/stamp_filters.py
@@ -27,7 +27,7 @@ class StampPeakFilter(Filter):
         super().__init__(*args, **kwargs)
 
         if stamp_radius <= 0:
-            raise ValueError("Invalid stamp radius {stamp_radius}.")
+            raise ValueError(f"Invalid stamp radius {stamp_radius}.")
         self.stamp_radius = stamp_radius
 
         self.x_thresh = x_thresh

--- a/src/kbmod/filters/stamp_filters.py
+++ b/src/kbmod/filters/stamp_filters.py
@@ -1,4 +1,8 @@
-import abc
+"""A series of Filter subclasses for processing basic stamp information.
+
+The filters in this file all operate over simple statistics based on the
+stamp pixels.
+"""
 
 from kbmod.filters.base_filter import *
 from kbmod.search import *
@@ -22,7 +26,10 @@ class StampPeakFilter(Filter):
         """
         super().__init__(*args, **kwargs)
 
+        if stamp_radius <= 0:
+            raise ValueError("Invalid stamp radius {stamp_radius}.")
         self.stamp_radius = stamp_radius
+
         self.x_thresh = x_thresh
         self.y_thresh = y_thresh
 
@@ -66,3 +73,174 @@ class StampPeakFilter(Filter):
             abs(peak_pos.x - self.stamp_radius) < self.x_thresh
             and abs(peak_pos.y - self.stamp_radius) < self.y_thresh
         )
+
+
+class StampMomentsFilter(Filter):
+    """A filter on how well the stamp's moments match that of a Gaussian.
+
+    Finds the moment j, k (called moment_jk) as:
+    ``SUM_x SUM_y (x - center_x) ^ j * (y - center_y) ^ k * stamp[x][y]``
+
+    For example moment_10 is the flux weighted average position of
+    each stamp pixel relative to a center of zero.
+    """
+
+    def __init__(
+        self, stamp_radius, m01_thresh, m10_thresh, m11_thresh, m02_thresh, m20_thresh, *args, **kwargs
+    ):
+        """Create a StampMomentsFilter.
+
+        Parameters
+        ----------
+        stamp_radius : ``int``
+            The radius of a stamp.
+        m01_thresh : ``float``
+            The threshold for the j=0, k=1 moment.
+        m10_thresh : ``float``
+            The threshold for the j=1, k=0 moment.
+        m11_thresh : ``float``
+            The threshold for the j=1, k=1 moment.
+        m02_thresh : ``float``
+            The threshold for the j=0, k=2 moment.
+        m20_thresh : ``float``
+            The threshold for the j=2, k=0 moment.
+        """
+        super().__init__(*args, **kwargs)
+
+        if stamp_radius <= 0:
+            raise ValueError("Invalid stamp radius {stamp_radius}.")
+        self.stamp_radius = stamp_radius
+
+        self.m01_thresh = m01_thresh
+        self.m10_thresh = m10_thresh
+        self.m11_thresh = m11_thresh
+        self.m02_thresh = m02_thresh
+        self.m20_thresh = m20_thresh
+
+    def get_filter_name(self):
+        """Get the name of the filter.
+
+        Returns
+        -------
+        str
+            The filter name.
+        """
+        return (
+            f"StampMomentsFilter_m01_{self.m01_thresh}_m10_{self.m10_thresh}"
+            f"_m11_{self.m11_thresh}_m02_{self.m02_thresh}_m20_{self.m20_thresh}"
+        )
+
+    def keep_row(self, row: ResultRow):
+        """Determine whether to keep an individual row based on
+        the offset of the stamp's peak.
+
+        Parameters
+        ----------
+        row : ResultRow
+            The row to evaluate.
+
+        Returns
+        -------
+        bool
+           An indicator of whether to keep the row.
+        """
+        # Filter any row without a stamp.
+        if row.stamp is None:
+            return False
+
+        # Check the stamp's width is correct.
+        width = 2 * self.stamp_radius + 1
+        if len(row.stamp) != width * width:
+            raise ValueError("Expected stamp of size {width} by {width}.")
+
+        # Find the peack in the image.
+        stamp = row.stamp.reshape([width, width])
+        moments = raw_image(stamp).find_central_moments()
+        return (
+            (abs(moments.m01) < self.m01_thresh)
+            and (abs(moments.m10) < self.m10_thresh)
+            and (abs(moments.m11) < self.m11_thresh)
+            and (moments.m20 < self.m20_thresh)
+            and (moments.m02 < self.m02_thresh)
+        )
+
+
+class StampCenterFilter(Filter):
+    """A filter on whether the center of the stamp is a local
+    maxima and the percentage of the stamp's total flux in this
+    pixel.
+    """
+
+    def __init__(self, stamp_radius, local_max, flux_thresh, *args, **kwargs):
+        """Create a StampCenterFilter.
+
+        Parameters
+        ----------
+        stamp_radius : ``int``
+            The radius of a stamp.
+        local_max : ``bool``
+            Require the central pixel to be a local maximum.
+        flux_thresh : ``float``
+            The fraction of the stamp's total flux that needs to be in
+            the center pixel [0.0, 1.0].
+        """
+        super().__init__(*args, **kwargs)
+
+        if stamp_radius <= 0:
+            raise ValueError("Invalid stamp radius {stamp_radius}.")
+        self.stamp_radius = stamp_radius
+
+        self.local_max = local_max
+        self.flux_thresh = flux_thresh
+
+    def get_filter_name(self):
+        """Get the name of the filter.
+
+        Returns
+        -------
+        str
+            The filter name.
+        """
+        return f"StampCenterFilter_{self.local_max}_{self.flux_thresh}"
+
+    def keep_row(self, row: ResultRow):
+        """Determine whether the center pixel meets the filtering criteria.
+
+        Parameters
+        ----------
+        row : ResultRow
+            The row to evaluate.
+
+        Returns
+        -------
+        bool
+           An indicator of whether to keep the row.
+        """
+        # Filter any row without a stamp.
+        if row.stamp is None:
+            return False
+
+        # Check the stamp's width is correct.
+        width = 2 * self.stamp_radius + 1
+        if len(row.stamp) != width * width:
+            raise ValueError("Expected stamp of size {width} by {width}.")
+
+        # Find the value of the center pixel. Filter pixels with no data.
+        center_index = width * self.stamp_radius + self.stamp_radius
+        center_val = row.stamp[center_index]
+        if center_val == KB_NO_DATA:
+            return False
+
+        # Find the total flux in the image and check for other local_maxima
+        flux_sum = 0.0
+        for i in range(width * width):
+            pix_val = row.stamp[i]
+            if pix_val != KB_NO_DATA:
+                flux_sum += pix_val
+                if i != center_index and self.local_max and (pix_val >= center_val):
+                    return False
+
+        # Check the flux percentage.
+        if flux_sum == 0.0:
+            return False
+        return center_val / flux_sum >= self.flux_thresh

--- a/src/kbmod/filters/stamp_filters.py
+++ b/src/kbmod/filters/stamp_filters.py
@@ -66,7 +66,7 @@ class StampPeakFilter(Filter):
         if len(row.stamp) != width * width:
             raise ValueError("Expected stamp of size {width} by {width}.")
 
-        # Find the peack in the image.
+        # Find the peak in the image.
         stamp = row.stamp.reshape([width, width])
         peak_pos = raw_image(stamp).find_peak(True)
         return (

--- a/src/kbmod/filters/stamp_filters.py
+++ b/src/kbmod/filters/stamp_filters.py
@@ -12,16 +12,18 @@ from kbmod.result_list import ResultRow
 
 
 class BaseStampFilter(abc.ABC):
-    """The base class for the various stamp filters."""
+    """The base class for the various stamp filters.
+
+    Attributes
+    ----------
+    stamp_radius : ``int``
+        The radius of a stamp.
+    width : ``int``
+        The width of the stamp.
+    """
 
     def __init__(self, stamp_radius, *args, **kwargs):
-        """Store data needed for all stamp filters.
-
-        Parameters
-        ----------
-        stamp_radius : ``int``
-            The radius of a stamp.
-        """
+        """Store data needed for all stamp filters."""
         super().__init__(*args, **kwargs)
 
         if stamp_radius <= 0:
@@ -54,20 +56,20 @@ class BaseStampFilter(abc.ABC):
 
 
 class StampPeakFilter(BaseStampFilter):
-    """A filter on how far the stamp's peak is from the center."""
+    """A filter on how far the stamp's peak is from the center.
+
+    Attributes
+    ----------
+    stamp_radius : ``int``
+        The radius of a stamp.
+    x_thresh : ``float``
+        The number of pixels of offset in the x-direction for filtering.
+    y_thresh : ``float``
+        The number of pixels of offset in the y-direction for filtering.
+    """
 
     def __init__(self, stamp_radius, x_thresh, y_thresh, *args, **kwargs):
-        """Create a StampPeakFilter.
-
-        Parameters
-        ----------
-        stamp_radius : ``int``
-            The radius of a stamp.
-        x_thresh : ``float``
-            The number of pixels of offset in the x-direction for filtering.
-        y_thresh : ``float``
-            The number of pixels of offset in the y-direction for filtering.
-        """
+        """Create a StampPeakFilter."""
         super().__init__(stamp_radius, *args, **kwargs)
         self.x_thresh = x_thresh
         self.y_thresh = y_thresh
@@ -117,28 +119,27 @@ class StampMomentsFilter(BaseStampFilter):
 
     For example moment_10 is the flux weighted average position of
     each stamp pixel relative to a center of zero.
+
+    Attributes
+    ----------
+    stamp_radius : ``int``
+        The radius of a stamp.
+    m01_thresh : ``float``
+        The threshold for the j=0, k=1 moment.
+    m10_thresh : ``float``
+        The threshold for the j=1, k=0 moment.
+    m11_thresh : ``float``
+        The threshold for the j=1, k=1 moment.
+    m02_thresh : ``float``
+        The threshold for the j=0, k=2 moment.
+    m20_thresh : ``float``
+        The threshold for the j=2, k=0 moment.
     """
 
     def __init__(
         self, stamp_radius, m01_thresh, m10_thresh, m11_thresh, m02_thresh, m20_thresh, *args, **kwargs
     ):
-        """Create a StampMomentsFilter.
-
-        Parameters
-        ----------
-        stamp_radius : ``int``
-            The radius of a stamp.
-        m01_thresh : ``float``
-            The threshold for the j=0, k=1 moment.
-        m10_thresh : ``float``
-            The threshold for the j=1, k=0 moment.
-        m11_thresh : ``float``
-            The threshold for the j=1, k=1 moment.
-        m02_thresh : ``float``
-            The threshold for the j=0, k=2 moment.
-        m20_thresh : ``float``
-            The threshold for the j=2, k=0 moment.
-        """
+        """Create a StampMomentsFilter."""
         super().__init__(stamp_radius, *args, **kwargs)
         self.m01_thresh = m01_thresh
         self.m10_thresh = m10_thresh
@@ -193,21 +194,20 @@ class StampCenterFilter(BaseStampFilter):
     """A filter on whether the center of the stamp is a local
     maxima and the percentage of the stamp's total flux in this
     pixel.
+
+    Attributes
+    ----------
+    stamp_radius : ``int``
+        The radius of a stamp.
+    local_max : ``bool``
+        Require the central pixel to be a local maximum.
+    flux_thresh : ``float``
+        The fraction of the stamp's total flux that needs to be in
+        the center pixel [0.0, 1.0].
     """
 
     def __init__(self, stamp_radius, local_max, flux_thresh, *args, **kwargs):
-        """Create a StampCenterFilter.
-
-        Parameters
-        ----------
-        stamp_radius : ``int``
-            The radius of a stamp.
-        local_max : ``bool``
-            Require the central pixel to be a local maximum.
-        flux_thresh : ``float``
-            The fraction of the stamp's total flux that needs to be in
-            the center pixel [0.0, 1.0].
-        """
+        """Create a StampCenterFilter."""
         super().__init__(stamp_radius, *args, **kwargs)
         self.local_max = local_max
         self.flux_thresh = flux_thresh

--- a/src/kbmod/filters/stamp_filters.py
+++ b/src/kbmod/filters/stamp_filters.py
@@ -187,7 +187,7 @@ class StampCenterFilter(Filter):
         super().__init__(*args, **kwargs)
 
         if stamp_radius <= 0:
-            raise ValueError("Invalid stamp radius {stamp_radius}.")
+            raise ValueError(f"Invalid stamp radius {stamp_radius}.")
         self.stamp_radius = stamp_radius
 
         self.local_max = local_max

--- a/src/kbmod/filters/stamp_filters.py
+++ b/src/kbmod/filters/stamp_filters.py
@@ -151,7 +151,7 @@ class StampMomentsFilter(Filter):
         # Check the stamp's width is correct.
         width = 2 * self.stamp_radius + 1
         if len(row.stamp) != width * width:
-            raise ValueError("Expected stamp of size {width} by {width}.")
+            raise ValueError(f"Expected stamp of size {width} by {width}.")
 
         # Find the peack in the image.
         stamp = row.stamp.reshape([width, width])

--- a/src/kbmod/filters/stamp_filters.py
+++ b/src/kbmod/filters/stamp_filters.py
@@ -132,7 +132,7 @@ class StampMomentsFilter(Filter):
 
     def keep_row(self, row: ResultRow):
         """Determine whether to keep an individual row based on
-        the offset of the stamp's peak.
+        how well the stamp's moments match that of a Gaussian.
 
         Parameters
         ----------

--- a/src/kbmod/filters/stamp_filters.py
+++ b/src/kbmod/filters/stamp_filters.py
@@ -108,7 +108,7 @@ class StampMomentsFilter(Filter):
         super().__init__(*args, **kwargs)
 
         if stamp_radius <= 0:
-            raise ValueError("Invalid stamp radius {stamp_radius}.")
+            raise ValueError(f"Invalid stamp radius {stamp_radius}.")
         self.stamp_radius = stamp_radius
 
         self.m01_thresh = m01_thresh

--- a/src/kbmod/filters/stats_filters.py
+++ b/src/kbmod/filters/stats_filters.py
@@ -1,5 +1,3 @@
-import abc
-
 from kbmod.filters.base_filter import *
 from kbmod.search import *
 from kbmod.result_list import *

--- a/tests/test_stamp_filters.py
+++ b/tests/test_stamp_filters.py
@@ -15,6 +15,9 @@ class test_stamp_filters(unittest.TestCase):
         row.stamp = np.array(stamp.get_all_pixels())
         return row
 
+    def test_peak_filtering_name(self):
+        self.assertEqual(StampPeakFilter(5, 1.0, 2.0).get_filter_name(), "StampPeakFilter_1.0_2.0")
+
     def test_peak_filtering(self):
         stamp = raw_image(11, 11)
         stamp.set_all(1.0)
@@ -40,6 +43,89 @@ class test_stamp_filters(unittest.TestCase):
         self.assertFalse(StampPeakFilter(4, 2, 1).keep_row(row))
         self.assertFalse(StampPeakFilter(4, 4, 4).keep_row(row))
         self.assertFalse(StampPeakFilter(4, 3, 5).keep_row(row))
+
+    def test_central_moments_filtering_name(self):
+        self.assertEqual(
+            StampMomentsFilter(5, 1.0, 2.0, 3.0, 4.0, 5.0).get_filter_name(),
+            "StampMomentsFilter_m01_1.0_m10_2.0_m11_3.0_m02_4.0_m20_5.0",
+        )
+
+    def test_central_moments_filtering(self):
+        stamp = raw_image(11, 11)
+        stamp.set_all(0.0)
+        row = self._create_row(stamp)
+
+        # An empty image should have zero moments.
+        self.assertTrue(StampMomentsFilter(5, 0.001, 0.001, 0.001, 0.001, 0.001).keep_row(row))
+
+        # A single peak pixel should have zero moments.
+        stamp.set_pixel(5, 5, 10.0)
+        row = self._create_row(stamp)
+        self.assertTrue(StampMomentsFilter(5, 0.001, 0.001, 0.001, 0.001, 0.001).keep_row(row))
+
+        # A symmetric stamop should have zero first order moments and
+        # non-zero second order moments.
+        stamp.set_pixel(5, 4, 5.0)
+        stamp.set_pixel(4, 5, 5.0)
+        stamp.set_pixel(5, 6, 5.0)
+        stamp.set_pixel(6, 5, 5.0)
+        row = self._create_row(stamp)
+        self.assertFalse(StampMomentsFilter(5, 0.001, 0.001, 0.001, 0.001, 0.001).keep_row(row))
+        self.assertTrue(StampMomentsFilter(5, 0.001, 0.001, 0.001, 0.5, 0.5).keep_row(row))
+
+        # A non symmetric stamp will not pass the filter.
+        stamp.set_pixel(0, 0, 50.0)
+        stamp.set_pixel(3, 0, 10.0)
+        stamp.set_pixel(1, 2, 50.0)
+        row = self._create_row(stamp)
+        self.assertFalse(StampMomentsFilter(5, 1.0, 1.0, 1.0, 1.0, 1.0).keep_row(row))
+
+    def test_center_filtering_name(self):
+        self.assertEqual(
+            StampCenterFilter(5, True, 0.05).get_filter_name(),
+            "StampCenterFilter_True_0.05",
+        )
+
+    def test_center_filtering(self):
+        stamp = raw_image(7, 7)
+        stamp.set_all(0.0)
+        row = self._create_row(stamp)
+
+        # An empty image should fail.
+        self.assertFalse(StampCenterFilter(3, True, 0.01).keep_row(row))
+
+        # No local maxima (should fail).
+        stamp = raw_image(7, 7)
+        stamp.set_all(0.01)
+        row = self._create_row(stamp)
+        self.assertFalse(StampCenterFilter(3, True, 0.01).keep_row(row))
+
+        # Single strong central peak
+        stamp = raw_image(7, 7)
+        stamp.set_all(0.05)
+        stamp.set_pixel(3, 3, 10.0)
+        row = self._create_row(stamp)
+        self.assertTrue(StampCenterFilter(3, True, 0.5).keep_row(row))
+        self.assertFalse(StampCenterFilter(3, True, 1.0).keep_row(row))
+
+        # Less than 50% in the center pixel.
+        stamp = raw_image(7, 7)
+        stamp.set_all(0.05)
+        stamp.set_pixel(3, 3, 10.0)
+        stamp.set_pixel(3, 4, 9.0)
+        row = self._create_row(stamp)
+        self.assertFalse(StampCenterFilter(3, True, 0.5).keep_row(row))
+        self.assertTrue(StampCenterFilter(3, True, 0.4).keep_row(row))
+
+        # Center is not the maximum value.
+        stamp = raw_image(7, 7)
+        stamp.set_all(0.05)
+        stamp.set_pixel(1, 2, 10.0)
+        stamp.set_pixel(3, 3, 9.0)
+        row = self._create_row(stamp)
+        self.assertFalse(StampCenterFilter(3, True, 0.5).keep_row(row))
+        self.assertFalse(StampCenterFilter(3, True, 0.4).keep_row(row))
+        self.assertTrue(StampCenterFilter(3, False, 0.2).keep_row(row))
 
 
 if __name__ == "__main__":

--- a/tests/test_stamp_filters.py
+++ b/tests/test_stamp_filters.py
@@ -18,6 +18,16 @@ class test_stamp_filters(unittest.TestCase):
     def test_peak_filtering_name(self):
         self.assertEqual(StampPeakFilter(5, 1.0, 2.0).get_filter_name(), "StampPeakFilter_1.0_2.0")
 
+    def test_skip_invalid_stamp(self):
+        # No stamp
+        row = ResultRow(trajectory(), self.num_times)
+        self.assertFalse(StampPeakFilter(5, 100, 100).keep_row(row))
+
+        # Wrong sized stamp
+        stamp = raw_image(5, 5)
+        row = self._create_row(stamp)
+        self.assertFalse(StampPeakFilter(5, 100, 100).keep_row(row))
+
     def test_peak_filtering(self):
         stamp = raw_image(11, 11)
         stamp.set_all(1.0)


### PR DESCRIPTION
This PR adds the existing stamp filters as `Filter` subclasses. All of these filters already exist in `image_kernels.cu` and reuse that code in their core. Adding these filters as `Filter` subclasses will allow users more flexibility to run the stamp filtering in different order or multiple times with different parameters.