### PR TITLE
Update trajectory object during row updates

### DIFF
--- a/src/kbmod/result_list.py
+++ b/src/kbmod/result_list.py
@@ -209,8 +209,12 @@ class ResultRow:
 
         if phi_sum <= 0.0:
             self.final_likelihood = 0.0
+            self.trajectory.lh = 0.0
+            self.trajectory.flux = 0.0
         else:
             self.final_likelihood = psi_sum / math.sqrt(phi_sum)
+            self.trajectory.lh = psi_sum / math.sqrt(phi_sum)
+            self.trajectory.flux = psi_sum / phi_sum
 
 
 class ResultList:

--- a/src/kbmod/result_list.py
+++ b/src/kbmod/result_list.py
@@ -185,6 +185,9 @@ class ResultRow:
         self.valid_indices = [self.valid_indices[i] for i in indices_to_keep]
         self._update_likelihood()
 
+        # Update the count of valid observations in the trajectory object.
+        self.trajectory.obs_count = len(self.valid_indices)
+
     def _update_likelihood(self):
         """Update the likelihood based on the result's psi and phi curves
         and the list of current valid indices.

--- a/tests/test_result_list.py
+++ b/tests/test_result_list.py
@@ -31,11 +31,17 @@ class test_result_data_row(unittest.TestCase):
         self.assertEqual(self.rdr.valid_indices, [0, 1, 2, 3])
         self.assertEqual(self.rdr.valid_times(self.times), [1.0, 2.0, 3.0, 4.0])
         self.assertEqual(self.rdr.trajectory.obs_count, 4)
+        self.assertAlmostEqual(self.rdr.trajectory.flux, 1.15)
+        self.assertAlmostEqual(self.rdr.trajectory.lh, 2.3)
 
         self.rdr.filter_indices([0, 2, 3])
         self.assertEqual(self.rdr.valid_indices, [0, 2, 3])
         self.assertEqual(self.rdr.valid_times(self.times), [1.0, 3.0, 4.0])
+
+        # The values within the trajectory object *should* change.
         self.assertEqual(self.rdr.trajectory.obs_count, 3)
+        self.assertAlmostEqual(self.rdr.trajectory.flux, 1.1666667, delta=1e-5)
+        self.assertAlmostEqual(self.rdr.trajectory.lh, 2.020725, delta=1e-5)
 
         # The curves and stamps should not change.
         self.assertEqual(self.rdr.psi_curve, [1.0, 1.1, 1.2, 1.3])

--- a/tests/test_result_list.py
+++ b/tests/test_result_list.py
@@ -13,6 +13,7 @@ from kbmod.search import *
 class test_result_data_row(unittest.TestCase):
     def setUp(self):
         self.trj = trajectory()
+        self.trj.obs_count = 4
 
         self.times = [1.0, 2.0, 3.0, 4.0]
         self.num_times = len(self.times)
@@ -27,9 +28,14 @@ class test_result_data_row(unittest.TestCase):
         self.assertEqual(self.rdr.valid_indices_as_booleans(), [False, True, True, False])
 
     def test_filter(self):
+        self.assertEqual(self.rdr.valid_indices, [0, 1, 2, 3])
+        self.assertEqual(self.rdr.valid_times(self.times), [1.0, 2.0, 3.0, 4.0])
+        self.assertEqual(self.rdr.trajectory.obs_count, 4)
+
         self.rdr.filter_indices([0, 2, 3])
         self.assertEqual(self.rdr.valid_indices, [0, 2, 3])
         self.assertEqual(self.rdr.valid_times(self.times), [1.0, 3.0, 4.0])
+        self.assertEqual(self.rdr.trajectory.obs_count, 3)
 
         # The curves and stamps should not change.
         self.assertEqual(self.rdr.psi_curve, [1.0, 1.1, 1.2, 1.3])


### PR DESCRIPTION
This change probably requires some discussion. 

Previously KBMOD passes through the trajectory object as set during the on-GPU search. This means that if there is later filtering of observations by the sigmaG filter (lh, num_obs, and flux) these are NOT output to the `results_` file. This can lead to numbers in the `results_` file that are not the same as those derived from the other files (e.g. `lc_index_`). This is not a problem if all files are used, but might cause confusion down the line.

This change updates the trajectory to stay consistent with the rest of the values in the row.

A consequence is that this PR changes the results of the diff_test and may impact other analysis scripts.