### PR TITLE
Small cleanups of KBMOD

### DIFF
--- a/src/kbmod/search/KBMOSearch.cpp
+++ b/src/kbmod/search/KBMOSearch.cpp
@@ -134,8 +134,8 @@ void KBMOSearch::search(int aSteps, int vSteps, float minAngle, float maxAngle, 
     }
 
     // Allocate a vector for the results.
-    int num_search_pixels = ((params.x_start_max - params.x_start_min) *
-                             (params.y_start_max - params.y_start_min));
+    int num_search_pixels =
+            ((params.x_start_max - params.x_start_min) * (params.y_start_max - params.y_start_min));
     int max_results = num_search_pixels * RESULTS_PER_PIXEL;
     if (debugInfo) {
         std::cout << "Searching X=[" << params.x_start_min << ", " << params.x_start_max << "]"
@@ -151,8 +151,7 @@ void KBMOSearch::search(int aSteps, int vSteps, float minAngle, float maxAngle, 
     // Do the actual search on the GPU.
     startTimer("Searching");
     deviceSearchFilter(stack.imgCount(), stack.getWidth(), stack.getHeight(), psiVect.data(), phiVect.data(),
-                       img_data, params, searchList.size(), searchList.data(),
-                       max_results, results.data());
+                       img_data, params, searchList.size(), searchList.data(), max_results, results.data());
     endTimer();
 
     startTimer("Sorting results");
@@ -257,12 +256,12 @@ void KBMOSearch::fillPsiAndPhiVects(const std::vector<RawImage>& psiImgs,
     assert(num_images > 0);
     assert(phiImgs.size() == num_images);
 
-    int num_pixels = psiImgs[0].getPPI();  
+    int num_pixels = psiImgs[0].getPPI();
     for (int i = 0; i < num_images; ++i) {
         assert(psiImgs[i].getPPI() == num_pixels);
         assert(phiImgs[i].getPPI() == num_pixels);
     }
-  
+
     psiVect->clear();
     psiVect->reserve(num_images * num_pixels);
     phiVect->clear();
@@ -284,7 +283,7 @@ std::vector<RawImage> KBMOSearch::scienceStamps(const trajectory& trj, int radiu
         throw std::runtime_error("Wrong size use_index passed into scienceStamps()");
     }
     bool use_all_stamps = use_index.size() == 0;
-    
+
     std::vector<RawImage> stamps;
     int num_times = stack.imgCount();
     for (int i = 0; i < num_times; ++i) {
@@ -309,33 +308,23 @@ std::vector<RawImage> KBMOSearch::scienceStampsForViz(const trajectory& t, int r
 // NO_DATA tagged (so we can filter it out of mean/median).
 RawImage KBMOSearch::medianScienceStamp(const trajectory& trj, int radius,
                                         const std::vector<bool>& use_index) {
-    return createMedianImage(scienceStamps(trj,
-                                           radius,
-                                           false /*=interpolate*/,
-                                           true /*=keep_no_data*/,
-                                           use_index));
+    return createMedianImage(
+            scienceStamps(trj, radius, false /*=interpolate*/, true /*=keep_no_data*/, use_index));
 }
 
 // For creating coadded stamps, we do not interpolate the pixel values and keep
 // NO_DATA tagged (so we can filter it out of mean/median).
-RawImage KBMOSearch::meanScienceStamp(const trajectory& trj, int radius,
-                                        const std::vector<bool>& use_index) {
-    return createMeanImage(scienceStamps(trj,
-                                         radius,
-                                         false /*=interpolate*/,
-                                         true /*=keep_no_data*/,
-                                         use_index));
+RawImage KBMOSearch::meanScienceStamp(const trajectory& trj, int radius, const std::vector<bool>& use_index) {
+    return createMeanImage(
+            scienceStamps(trj, radius, false /*=interpolate*/, true /*=keep_no_data*/, use_index));
 }
 
 // For creating summed stamps, we do not interpolate the pixel values and replace NO_DATA
 // with zero (which is the same as filtering it out for the sum).
 RawImage KBMOSearch::summedScienceStamp(const trajectory& trj, int radius,
                                         const std::vector<bool>& use_index) {
-    return createSummedImage(scienceStamps(trj,
-                                           radius,
-                                           false /*=interpolate*/,
-                                           false /*=keep_no_data*/,
-                                           use_index));
+    return createSummedImage(
+            scienceStamps(trj, radius, false /*=interpolate*/, false /*=keep_no_data*/, use_index));
 }
 
 std::vector<RawImage> KBMOSearch::coaddedScienceStampsGPU(std::vector<trajectory>& t_array,
@@ -450,20 +439,6 @@ std::vector<float> KBMOSearch::createCurves(trajectory t, const std::vector<RawI
     return lightcurve;
 }
 
-std::vector<RawImage> KBMOSearch::psiStamps(trajectory& t, int radius) {
-    preparePsiPhi();
-    std::vector<RawImage*> imgs;
-    for (auto& im : psiImages) imgs.push_back(&im);
-    return createStamps(t, radius, imgs, true);
-}
-
-std::vector<RawImage> KBMOSearch::phiStamps(trajectory& t, int radius) {
-    preparePsiPhi();
-    std::vector<RawImage*> imgs;
-    for (auto& im : phiImages) imgs.push_back(&im);
-    return createStamps(t, radius, imgs, true);
-}
-
 std::vector<float> KBMOSearch::psiCurves(trajectory& t) {
     /*Generate a psi lightcurve for further analysis
      *  INPUT-
@@ -519,22 +494,6 @@ std::vector<trajectory> KBMOSearch::getResults(int start, int count) {
 
 // This function is used only for testing by injecting known result trajectories.
 void KBMOSearch::setResults(const std::vector<trajectory>& new_results) { results = new_results; }
-
-void KBMOSearch::saveResults(const std::string& path, float portion) {
-    std::ofstream file(path.c_str());
-    if (file.is_open()) {
-        file << "# x y xv yv likelihood flux obs_count\n";
-        int writeCount = int(portion * float(results.size()));
-        for (int i = 0; i < writeCount; ++i) {
-            trajectory r = results[i];
-            file << r.x << " " << r.y << " " << r.xVel << " " << r.yVel << " " << r.lh << " " << r.flux << " "
-                 << r.obsCount << "\n";
-        }
-        file.close();
-    } else {
-        std::cout << "Unable to open results file";
-    }
-}
 
 void KBMOSearch::startTimer(const std::string& message) {
     if (debugInfo) {

--- a/src/kbmod/search/KBMOSearch.h
+++ b/src/kbmod/search/KBMOSearch.h
@@ -60,7 +60,7 @@ public:
 
     // Functions for creating science stamps for filtering, visualization, etc. User can specify
     // the radius of the stamp, whether to interpolate among pixels, whether to keep NO_DATA values
-    // or replace them with zero, and what indices to use. 
+    // or replace them with zero, and what indices to use.
     // The indices to use are indicated by use_index: a vector<bool> indicating whether to use
     // each time step. An empty (size=0) vector will use all time steps.
     std::vector<RawImage> scienceStamps(const trajectory& trj, int radius, bool interpolate,
@@ -78,16 +78,13 @@ public:
                                                   std::vector<std::vector<bool> >& use_index_vect,
                                                   const stampParameters& params);
 
-    // Getters for the Psi and Phi data, including stamped versions.
+    // Getters for the Psi and Phi data.
     std::vector<RawImage>& getPsiImages();
     std::vector<RawImage>& getPhiImages();
-    std::vector<RawImage> psiStamps(trajectory& t, int radius);
-    std::vector<RawImage> phiStamps(trajectory& t, int radius);
     std::vector<float> psiCurves(trajectory& t);
     std::vector<float> phiCurves(trajectory& t);
 
-    // Save results or internal data products to a file.
-    void saveResults(const std::string& path, float fraction);
+    // Save internal data products to a file.
     void savePsiPhi(const std::string& path);
 
     // Helper functions for computing Psi and Phi.
@@ -95,7 +92,7 @@ public:
 
     // Helper functions for testing.
     void setResults(const std::vector<trajectory>& new_results);
-    
+
     virtual ~KBMOSearch(){};
 
 protected:

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -72,7 +72,8 @@ PYBIND11_MODULE(search, m) {
             .def("get_radius", &pf::getRadius, "Returns the radius of the PSF")
             .def("get_size", &pf::getSize, "Returns the number of elements in the PSFs kernel.")
             .def("get_kernel", &pf::getKernel, "Returns the PSF kernel.")
-            .def("square_psf", &pf::squarePSF, "Squares, raises to the power of two, the elements of the PSF kernel.")
+            .def("square_psf", &pf::squarePSF,
+                 "Squares, raises to the power of two, the elements of the PSF kernel.")
             .def("print_psf", &pf::printPSF, "Pretty-prints the PSF.");
 
     py::class_<ri>(m, "raw_image", py::buffer_protocol())
@@ -189,16 +190,13 @@ PYBIND11_MODULE(search, m) {
             // For testing
             .def("get_traj_pos", &ks::getTrajPos)
             .def("get_mult_traj_pos", &ks::getMultTrajPos)
-            .def("psi_stamps", (std::vector<ri>(ks::*)(tj &, int)) & ks::psiStamps, "set2")
-            .def("phi_stamps", (std::vector<ri>(ks::*)(tj &, int)) & ks::phiStamps, "set3")
             .def("psi_curves", (std::vector<float>(ks::*)(tj &)) & ks::psiCurves)
             .def("phi_curves", (std::vector<float>(ks::*)(tj &)) & ks::phiCurves)
             .def("prepare_psi_phi", &ks::preparePsiPhi)
             .def("get_psi_images", &ks::getPsiImages)
             .def("get_phi_images", &ks::getPhiImages)
             .def("get_results", &ks::getResults)
-            .def("set_results", &ks::setResults)
-            .def("save_results", &ks::saveResults);
+            .def("set_results", &ks::setResults);
     py::class_<tj>(m, "trajectory", R"pbdoc(
             A trajectory structure holding basic information about potential results.
             )pbdoc")
@@ -210,27 +208,23 @@ PYBIND11_MODULE(search, m) {
             .def_readwrite("x", &tj::x)
             .def_readwrite("y", &tj::y)
             .def_readwrite("obs_count", &tj::obsCount)
-            .def("__repr__", [](const tj &t) {
-                return "lh: " + to_string(t.lh) + " flux: " + to_string(t.flux) + " x: " + to_string(t.x) +
-                       " y: " + to_string(t.y) + " x_v: " + to_string(t.xVel) + " y_v: " + to_string(t.yVel) +
-                       " obs_count: " + to_string(t.obsCount);
-            })
+            .def("__repr__",
+                 [](const tj &t) {
+                     return "lh: " + to_string(t.lh) + " flux: " + to_string(t.flux) +
+                            " x: " + to_string(t.x) + " y: " + to_string(t.y) + " x_v: " + to_string(t.xVel) +
+                            " y_v: " + to_string(t.yVel) + " obs_count: " + to_string(t.obsCount);
+                 })
             .def(py::pickle(
-                [](const tj &p) { // __getstate__
-                    return py::make_tuple(p.xVel, p.yVel, p.lh, p.flux, p.x, p.y, p.obsCount);
-                },
-                [](py::tuple t) { // __setstate__
-                    if (t.size() != 7)
-                        throw std::runtime_error("Invalid state!");
-                    tj trj = {t[0].cast<float>(),
-                              t[1].cast<float>(),
-                              t[2].cast<float>(),
-                              t[3].cast<float>(),
-                              t[4].cast<short>(),
-                              t[5].cast<short>(),
-                              t[6].cast<short>()};
-                    return trj;
-                }));
+                    [](const tj &p) {  // __getstate__
+                        return py::make_tuple(p.xVel, p.yVel, p.lh, p.flux, p.x, p.y, p.obsCount);
+                    },
+                    [](py::tuple t) {  // __setstate__
+                        if (t.size() != 7) throw std::runtime_error("Invalid state!");
+                        tj trj = {t[0].cast<float>(), t[1].cast<float>(), t[2].cast<float>(),
+                                  t[3].cast<float>(), t[4].cast<short>(), t[5].cast<short>(),
+                                  t[6].cast<short>()};
+                        return trj;
+                    }));
     py::class_<pp>(m, "pixel_pos")
             .def(py::init<>())
             .def_readwrite("x", &pp::x)


### PR DESCRIPTION
Removes three unused functions: `psiStamps`, `phiStamps`, and `saveResults`. The last is particularly important as we are consolidating all result output through the Python `ResultList` class.

Also applies clang-format.