### PR TITLE
developer instructions for building local documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ cmake --build src/kbmod --clean-first
 ```
 To rebuild, it is sufficient to just re-run the `cmake --build` command. Optionally, invoke the cmake generated `Makefile` as `make clean && make` from the `src/kbmod` directory.
 
+If you want to buid the documentation you must have pandoc which seems not installable by pip.
+See [Pandoc](https://pandoc.org/installing.html), or if you are using conda:
+```
+conda install pandoc
+```
+Building the documentation in docs/build/html
+```
+pip install .[docs]
+cd docs
+make clean html
+```
 ## Usage
 
 A short example injecting a simulated object into a stack of images, and then recovering it. This example is also included in `tests/test_readme_example.py`.

--- a/README.md
+++ b/README.md
@@ -72,9 +72,13 @@ See [Pandoc](https://pandoc.org/installing.html), or if you are using conda:
 ```
 conda install pandoc
 ```
-Building the documentation in docs/build/html
+Building the documentation in docs/build/html using sphinx:
 ```
 pip install .[docs]
+sphinx-build -t html docs/source docs/build
+```
+Or you can use the make to call sphinx:
+```
 cd docs
 make clean html
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,12 @@ docs =
     numpydoc
     pydata_sphinx_theme
     nbsphinx
-    pandoc
+    # See https://pandoc.org/installing.html
+    # Also this works:
+    #   conda install pandoc
+    # Neither of the following pypi packages actually installs the pandoc binary
+    #   pandoc
+    #   pypandoc-binary
     ipython
 tests =
     black[jupyter]


### PR DESCRIPTION
the required pandoc does not actually get installed with the dependency in setup.cfg so removed that dependency and added documentation to README.md for local documentation build.
