### PR TITLE
Add end to end tests

### DIFF
--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -236,7 +236,7 @@ class run_search:
             KBMOD and searched over.
         self.config.res_filepath : string
             Path to the folder that will contain the results from the search.
-            If ``None`` the program skips outputing the files.
+            If ``None`` the program skips outputting the files.
         self.config.out_suffix : string
             Suffix to append to the output files. Used to differentiate
             between different searches over the same stack of images.

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -120,8 +120,6 @@ class run_search:
         self.config = defaults
         if self.config["im_filepath"] is None:
             raise ValueError("Image filepath not set")
-        if self.config["res_filepath"] is None:
-            raise ValueError("Results filepath not set")
         return
 
     def do_gpu_search(self, search, img_info, suggested_angle, post_process):
@@ -238,6 +236,7 @@ class run_search:
             KBMOD and searched over.
         self.config.res_filepath : string
             Path to the folder that will contain the results from the search.
+            If ``None`` the program skips outputing the files.
         self.config.out_suffix : string
             Suffix to append to the output files. Used to differentiate
             between different searches over the same stack of images.
@@ -257,6 +256,11 @@ class run_search:
         self.config.average_angle : float
             Overrides the ecliptic angle calculation and instead centers
             the average search around average_angle.
+
+        Returns
+        -------
+        keep : ResultList
+            The results.
         """
         start = time.time()
         kb_interface = Interface()
@@ -333,11 +337,14 @@ class run_search:
         del search
 
         # Save the results
-        keep.save_to_files(self.config["res_filepath"], self.config["output_suffix"])
+        print(f"Found {keep.num_results()} potential trajectories.")
+        if self.config["res_filepath"] is not None:
+            keep.save_to_files(self.config["res_filepath"], self.config["output_suffix"])
 
         end = time.time()
-        del keep
         print("Time taken for patch: ", end - start)
+
+        return keep
 
     def _count_known_matches(self, result_list, img_info, search):
         """Look up the known objects that overlap the images and count how many

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,70 @@
+import unittest
+
+import numpy as np
+from kbmod.search import *
+from kbmod.run_search import *
+
+
+class test_end_to_end(unittest.TestCase):
+    def setUp(self):
+        # Define the path for the data.
+        im_filepath = "../data/demo"
+
+        # The demo data has an object moving at x_v=10 px/day
+        # and y_v = 0 px/day. So we search velocities [0, 20]
+        # and angles [-0.5, 0.5].
+        v_arr = [0, 20, 21]
+        ang_arr = [0.5, 0.5, 11]
+
+        self.input_parameters = {
+            # Required
+            "im_filepath": im_filepath,
+            "res_filepath": None,
+            "time_file": None,
+            "output_suffix": "DEMO",
+            "v_arr": v_arr,
+            "ang_arr": ang_arr,
+            # Important
+            "num_obs": 7,
+            "do_mask": True,
+            "lh_level": 10.0,
+            "gpu_filter": True,
+            # Fine tuning
+            "sigmaG_lims": [15, 60],
+            "mom_lims": [37.5, 37.5, 1.5, 1.0, 1.0],
+            "peak_offset": [3.0, 3.0],
+            "chunk_size": 1000000,
+            "stamp_type": "cpp_median",
+            "eps": 0.03,
+            "clip_negative": True,
+            "mask_num_images": 10,
+            "cluster_type": "position",
+            # Override the ecliptic angle for the demo data since we
+            # know the true angle in pixel space.
+            "average_angle": 0.0,
+        }
+
+    def test_demo_defaults(self):
+        rs = run_search(self.input_parameters)
+        keep = rs.run_search()
+        self.assertGreaterEqual(keep.num_results(), 1)
+        self.assertEqual(keep.results[0].stamp.size, 441)
+
+    def test_demo_stamp_size(self):
+        self.input_parameters["stamp_radius"] = 15
+        self.input_parameters["mom_lims"] = [80.0, 80.0, 50.0, 20.0, 20.0]
+
+        rs = run_search(self.input_parameters)
+        keep = rs.run_search()
+        self.assertGreaterEqual(keep.num_results(), 1)
+
+        self.assertIsNotNone(keep.results[0].stamp)
+        self.assertEqual(keep.results[0].stamp.size, 961)
+
+        self.assertIsNotNone(keep.results[0].all_stamps)
+        for s in keep.results[0].all_stamps:
+            self.assertEqual(s.size, 961)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR makes multiple changes:
1) It adds an end-to-end test corresponding to the demo notebook.
2) It makes the output directory optional. If the directory name is set to `None`, it skips the output.
3) It has run_search return the result list directly to facilitate testing and (in the future) allow interactive filtering.
4) It adds an end-to-end test with a bigger stamp size to confirm that `stamp_radius` is fully customizable.