### PR TITLE
missing dependency for unit test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ install_requires =
     koffi>=0.1.1
     jplephem
     PyYAML>=6.0
+    chardet
 
 [options.extras_require]
 analysis =


### PR DESCRIPTION
I ran in a new environment and this turned up missing  for test_wcs_utils so I added to setup.cfg

But I do not understand the root cause and am suspicious that this is not the best resolution.
The module chardet has been around for a long time and the file that I think triggered the error (compat.py)
has not changed since 3.8 and the fallback is charset and it is present.

Anyway, I'll leave this here for visibility.
