### PR TITLE
Add helper constructors to C++ data structures

### DIFF
--- a/src/kbmod/search/LayeredImage.cpp
+++ b/src/kbmod/search/LayeredImage.cpp
@@ -22,6 +22,28 @@ LayeredImage::LayeredImage(std::string path, const PointSpreadFunc& psf) : psf(p
     loadLayers(path);
 }
 
+LayeredImage::LayeredImage(const RawImage& sci, const RawImage& var, const RawImage& msk,
+                           float time, const PointSpreadFunc& psf) : psf(psf), psfSQ(psf) {
+    // Get the dimensions of the science layer and check for consistency with
+    // the other two layers.
+    width = sci.getWidth();
+    height = sci.getHeight();
+    if (width != var.getWidth() or height != var.getHeight())
+        throw std::runtime_error("Science and Variance layers are not the same size.");
+    if (width != msk.getWidth() or height != msk.getHeight())
+        throw std::runtime_error("Science and Mask layers are not the same size.");
+
+    // Set the remaining variables.
+    pixelsPerImage = width * height;
+    captureTime = time;
+    psfSQ.squarePSF();
+
+    // Copy the image layers.
+    science = sci;
+    mask = msk;
+    variance = var;
+}
+
 LayeredImage::LayeredImage(std::string name, int w, int h, float noiseStDev, float pixelVariance, double time,
                            const PointSpreadFunc& psf)
         : LayeredImage(name, w, h, noiseStDev, pixelVariance, time, psf, -1) {}

--- a/src/kbmod/search/LayeredImage.cpp
+++ b/src/kbmod/search/LayeredImage.cpp
@@ -22,8 +22,9 @@ LayeredImage::LayeredImage(std::string path, const PointSpreadFunc& psf) : psf(p
     loadLayers(path);
 }
 
-LayeredImage::LayeredImage(const RawImage& sci, const RawImage& var, const RawImage& msk,
-                           float time, const PointSpreadFunc& psf) : psf(psf), psfSQ(psf) {
+LayeredImage::LayeredImage(const RawImage& sci, const RawImage& var, const RawImage& msk, float time,
+                           const PointSpreadFunc& psf)
+        : psf(psf), psfSQ(psf) {
     // Get the dimensions of the science layer and check for consistency with
     // the other two layers.
     width = sci.getWidth();

--- a/src/kbmod/search/LayeredImage.h
+++ b/src/kbmod/search/LayeredImage.h
@@ -26,6 +26,8 @@ namespace search {
 class LayeredImage {
 public:
     LayeredImage(std::string path, const PointSpreadFunc& psf);
+    LayeredImage(const RawImage& sci, const RawImage& var, const RawImage& msk,
+                 float time, const PointSpreadFunc& psf);
     LayeredImage(std::string name, int w, int h, float noiseStDev, float pixelVariance, double time,
                  const PointSpreadFunc& psf);
     LayeredImage(std::string name, int w, int h, float noiseStDev, float pixelVariance, double time,

--- a/src/kbmod/search/LayeredImage.h
+++ b/src/kbmod/search/LayeredImage.h
@@ -25,13 +25,13 @@ namespace search {
 
 class LayeredImage {
 public:
-    LayeredImage(std::string path, const PointSpreadFunc& psf);
-    LayeredImage(const RawImage& sci, const RawImage& var, const RawImage& msk,
-                 float time, const PointSpreadFunc& psf);
-    LayeredImage(std::string name, int w, int h, float noiseStDev, float pixelVariance, double time,
-                 const PointSpreadFunc& psf);
-    LayeredImage(std::string name, int w, int h, float noiseStDev, float pixelVariance, double time,
-                 const PointSpreadFunc& psf, int seed);
+    explicit LayeredImage(std::string path, const PointSpreadFunc& psf);
+    explicit LayeredImage(const RawImage& sci, const RawImage& var, const RawImage& msk, float time,
+                          const PointSpreadFunc& psf);
+    explicit LayeredImage(std::string name, int w, int h, float noiseStDev, float pixelVariance, double time,
+                          const PointSpreadFunc& psf);
+    explicit LayeredImage(std::string name, int w, int h, float noiseStDev, float pixelVariance, double time,
+                          const PointSpreadFunc& psf, int seed);
 
     // Set an image specific point spread function.
     void setPSF(const PointSpreadFunc& psf);

--- a/src/kbmod/search/PointSpreadFunc.cpp
+++ b/src/kbmod/search/PointSpreadFunc.cpp
@@ -43,12 +43,43 @@ PointSpreadFunc::PointSpreadFunc(float stdev) {
     calcSum();
 }
 
+// Copy constructor.
 PointSpreadFunc::PointSpreadFunc(const PointSpreadFunc& other) {
-    kernel = other.getKernel();
-    dim = other.getDim();
-    radius = other.getRadius();
-    width = other.getStdev();
-    calcSum();
+    kernel = other.kernel;
+    dim = other.dim;
+    radius = other.radius;
+    width = other.width;
+    sum = other.sum;
+}
+
+// Copy assignment.
+PointSpreadFunc& PointSpreadFunc::operator=(const PointSpreadFunc& other) {
+    kernel = other.kernel;
+    dim = other.dim;
+    radius = other.radius;
+    width = other.width;
+    sum = other.sum;
+    return *this;
+}
+
+// Move constructor.
+PointSpreadFunc::PointSpreadFunc(PointSpreadFunc&& other)
+        : kernel(std::move(other.kernel)),
+          dim(other.dim),
+          radius(other.radius),
+          width(other.width),
+          sum(other.sum) {}
+
+// Move assignment.
+PointSpreadFunc& PointSpreadFunc::operator=(PointSpreadFunc&& other) {
+    if (this != &other) {
+        kernel = std::move(other.kernel);
+        dim = other.dim;
+        radius = other.radius;
+        width = other.width;
+        sum = other.sum;
+    }
+    return *this;
 }
 
 #ifdef Py_PYTHON_H

--- a/src/kbmod/search/PointSpreadFunc.h
+++ b/src/kbmod/search/PointSpreadFunc.h
@@ -27,23 +27,32 @@ namespace search {
 class PointSpreadFunc {
 public:
     PointSpreadFunc(float stdev);
-    PointSpreadFunc(const PointSpreadFunc& other);
+    PointSpreadFunc(const PointSpreadFunc& other);  // Copy constructor
+    PointSpreadFunc(PointSpreadFunc&& other);       // Move constructor
 #ifdef Py_PYTHON_H
     PointSpreadFunc(pybind11::array_t<float> arr);
     void setArray(pybind11::array_t<float> arr);
 #endif
     virtual ~PointSpreadFunc(){};
+
+    // Assignment functions.
+    PointSpreadFunc& operator=(const PointSpreadFunc& other);  // Copy assignment
+    PointSpreadFunc& operator=(PointSpreadFunc&& other);       // Move assignment
+
+    // Getter functions.
     float getStdev() const { return width; }
-    void calcSum();
     float getSum() const { return sum; }
     int getDim() const { return dim; }
     int getRadius() const { return radius; }
     int getSize() const { return kernel.size(); }
     const std::vector<float>& getKernel() const { return kernel; };
     float* kernelData() { return kernel.data(); }
+
+    // Computation functions.
+    void calcSum();
     void squarePSF();
     std::string printPSF();
-    // void normalize(); ???
+
 private:
     std::vector<float> kernel;
     float width;

--- a/src/kbmod/search/RawImage.cpp
+++ b/src/kbmod/search/RawImage.cpp
@@ -27,11 +27,38 @@ RawImage::RawImage() {
     pixels = std::vector<float>();
 }
 
+// Copy constructor
 RawImage::RawImage(const RawImage& old) {
     initDimensions(old.getWidth(), old.getHeight());
     pixels = old.getPixels();
 }
-    
+
+// Copy assignment
+RawImage& RawImage::operator=(const RawImage& source) {
+    width = source.width;
+    height = source.height;
+    pixelsPerImage = source.pixelsPerImage;
+    pixels = source.pixels;
+    return *this;
+}
+
+// Move constructor
+RawImage::RawImage(RawImage&& source)
+        : width(source.width),
+          height(source.height),
+          pixelsPerImage(source.pixelsPerImage),
+          pixels(std::move(source.pixels)) {
+}
+
+// Move assignment
+RawImage& RawImage::operator=(RawImage&& source) {
+    width = source.width;
+    height = source.height;
+    pixelsPerImage = source.pixelsPerImage;
+    pixels = std::move(source.pixels);
+    return *this;
+}
+
 RawImage::RawImage(unsigned w, unsigned h) : pixels(w * h) { initDimensions(w, h); }
 
 RawImage::RawImage(unsigned w, unsigned h, const std::vector<float>& pix) : pixels(pix) {

--- a/src/kbmod/search/RawImage.cpp
+++ b/src/kbmod/search/RawImage.cpp
@@ -27,6 +27,11 @@ RawImage::RawImage() {
     pixels = std::vector<float>();
 }
 
+RawImage::RawImage(const RawImage& old) {
+    initDimensions(old.getWidth(), old.getHeight());
+    pixels = old.getPixels();
+}
+    
 RawImage::RawImage(unsigned w, unsigned h) : pixels(w * h) { initDimensions(w, h); }
 
 RawImage::RawImage(unsigned w, unsigned h, const std::vector<float>& pix) : pixels(pix) {

--- a/src/kbmod/search/RawImage.cpp
+++ b/src/kbmod/search/RawImage.cpp
@@ -47,15 +47,16 @@ RawImage::RawImage(RawImage&& source)
         : width(source.width),
           height(source.height),
           pixelsPerImage(source.pixelsPerImage),
-          pixels(std::move(source.pixels)) {
-}
+          pixels(std::move(source.pixels)) {}
 
 // Move assignment
 RawImage& RawImage::operator=(RawImage&& source) {
-    width = source.width;
-    height = source.height;
-    pixelsPerImage = source.pixelsPerImage;
-    pixels = std::move(source.pixels);
+    if (this != &source) {
+        width = source.width;
+        height = source.height;
+        pixelsPerImage = source.pixelsPerImage;
+        pixels = std::move(source.pixels);
+    }
     return *this;
 }
 

--- a/src/kbmod/search/RawImage.h
+++ b/src/kbmod/search/RawImage.h
@@ -31,13 +31,17 @@ namespace search {
 class RawImage {
 public:
     RawImage();
-    RawImage(const RawImage& old);
-    RawImage(unsigned w, unsigned h);
-    RawImage(unsigned w, unsigned h, const std::vector<float>& pix);
+    RawImage(const RawImage& old);  // Copy constructor
+    RawImage(RawImage&& source);  // Move constructor
+    explicit RawImage(unsigned w, unsigned h);
+    explicit RawImage(unsigned w, unsigned h, const std::vector<float>& pix);
 #ifdef Py_PYTHON_H
-    RawImage(pybind11::array_t<float> arr);
+    explicit RawImage(pybind11::array_t<float> arr);
     void setArray(pybind11::array_t<float>& arr);
 #endif
+
+    RawImage& operator=(const RawImage& source);  // Copy assignment
+    RawImage& operator=(RawImage&& source);  // Move assignment
 
     // Basic getter functions for image data.
     unsigned getWidth() const { return width; }

--- a/src/kbmod/search/RawImage.h
+++ b/src/kbmod/search/RawImage.h
@@ -32,7 +32,7 @@ class RawImage {
 public:
     RawImage();
     RawImage(const RawImage& old);  // Copy constructor
-    RawImage(RawImage&& source);  // Move constructor
+    RawImage(RawImage&& source);    // Move constructor
     explicit RawImage(unsigned w, unsigned h);
     explicit RawImage(unsigned w, unsigned h, const std::vector<float>& pix);
 #ifdef Py_PYTHON_H
@@ -41,7 +41,7 @@ public:
 #endif
 
     RawImage& operator=(const RawImage& source);  // Copy assignment
-    RawImage& operator=(RawImage&& source);  // Move assignment
+    RawImage& operator=(RawImage&& source);       // Move assignment
 
     // Basic getter functions for image data.
     unsigned getWidth() const { return width; }

--- a/src/kbmod/search/RawImage.h
+++ b/src/kbmod/search/RawImage.h
@@ -31,6 +31,7 @@ namespace search {
 class RawImage {
 public:
     RawImage();
+    RawImage(const RawImage& old);
     RawImage(unsigned w, unsigned h);
     RawImage(unsigned w, unsigned h, const std::vector<float>& pix);
 #ifdef Py_PYTHON_H

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -83,7 +83,7 @@ PYBIND11_MODULE(search, m) {
                                        {sizeof(float) * m.getWidth(), sizeof(float)});
             })
             .def(py::init<int, int>())
-            .def(py::init<const ri&>())
+            .def(py::init<const ri &>())
             .def(py::init<py::array_t<float>>())
             .def("get_height", &ri::getHeight, "Returns the image's height in pixels.")
             .def("get_width", &ri::getWidth, "Returns the image's width in pixels.")
@@ -110,7 +110,26 @@ PYBIND11_MODULE(search, m) {
     m.def("create_mean_image", &search::createMeanImage);
     py::class_<li>(m, "layered_image")
             .def(py::init<const std::string, pf &>())
-            .def(py::init<const ri&, const ri&, const ri&, float, pf &>())
+            .def(py::init<const ri &, const ri &, const ri &, float, pf &>(), R"pbdoc(
+            Creates a layered_image out of individual `raw_image` layers.
+
+            Parameters
+            ----------
+            sci : `raw_image`
+                The `raw_image` for the science layer.
+            var : `raw_image`
+                The `raw_image` for the cariance layer.
+            msk : `raw_image`
+                The `raw_image` for the mask layer.
+            time : `float`
+                The image time stamp.
+            p : `psf`
+                The PSF for the image.
+
+            Raises
+            ------
+            Raises an exception if the layers are not the same size.
+            )pbdoc")
             .def(py::init<std::string, int, int, double, float, float, pf &>())
             .def(py::init<std::string, int, int, double, float, float, pf &, int>())
             .def("set_psf", &li::setPSF, "Sets the PSF object.")

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -83,6 +83,7 @@ PYBIND11_MODULE(search, m) {
                                        {sizeof(float) * m.getWidth(), sizeof(float)});
             })
             .def(py::init<int, int>())
+            .def(py::init<const ri&>())
             .def(py::init<py::array_t<float>>())
             .def("get_height", &ri::getHeight, "Returns the image's height in pixels.")
             .def("get_width", &ri::getWidth, "Returns the image's width in pixels.")
@@ -109,6 +110,7 @@ PYBIND11_MODULE(search, m) {
     m.def("create_mean_image", &search::createMeanImage);
     py::class_<li>(m, "layered_image")
             .def(py::init<const std::string, pf &>())
+            .def(py::init<const ri&, const ri&, const ri&, float, pf &>())
             .def(py::init<std::string, int, int, double, float, float, pf &>())
             .def(py::init<std::string, int, int, double, float, float, pf &, int>())
             .def("set_psf", &li::setPSF, "Sets the PSF object.")

--- a/tests/test_image_info.py
+++ b/tests/test_image_info.py
@@ -86,6 +86,11 @@ class test_image_info(unittest.TestCase):
         self.assertEqual(img_info.image.get_width(), 64)
         self.assertEqual(img_info.image.get_height(), 64)
 
+    def test_load_image_no_psf(self):
+        img_info = ImageInfo()
+        with self.assertRaises(ValueError):
+            img_info.populate_from_fits_file("./data/fake_images/000000.fits", load_image=True)
+
     def test_load_files(self):
         with tempfile.TemporaryDirectory() as dir_name:
             # Create two fake files in the temporary directory.

--- a/tests/test_layered_image.py
+++ b/tests/test_layered_image.py
@@ -43,6 +43,35 @@ class test_layered_image(unittest.TestCase):
                 self.assertGreaterEqual(science.get_pixel(x, y), -100.0)
                 self.assertLessEqual(science.get_pixel(x, y), 100.0)
 
+    def test_create_from_layers(self):
+        sci = raw_image(30, 40)
+        for y in range(40):
+            for x in range(30):
+                sci.set_pixel(x, y, x + 30.0 * y)
+
+        var = raw_image(30, 40)
+        var.set_all(1.0)
+
+        mask = raw_image(30, 40)
+        mask.set_all(0.0)
+
+        # Create the layered image.
+        img2 = layered_image(sci, var, mask, 0.0, psf(2.0))
+        self.assertEqual(img2.get_width(), 30)
+        self.assertEqual(img2.get_height(), 40)
+        self.assertEqual(img2.get_ppi(), 30.0 * 40.0)
+        self.assertEqual(img2.get_time(), 0.0)
+
+        # Check the layers.
+        science = img2.get_science()
+        variance = img2.get_variance()
+        mask2 = img2.get_mask()
+        for y in range(img2.get_height()):
+            for x in range(img2.get_width()):
+                self.assertEqual(mask2.get_pixel(x, y), 0)
+                self.assertEqual(variance.get_pixel(x, y), 1.0)
+                self.assertAlmostEqual(science.get_pixel(x, y), x + 30.0 * y)
+
     def test_set_time(self):
         self.assertIsNotNone(self.image)
         self.assertEqual(self.image.get_time(), 10.0)

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -24,6 +24,22 @@ class test_raw_image(unittest.TestCase):
                 self.assertTrue(self.img.pixel_has_data(x, y))
                 self.assertEqual(self.img.get_pixel(x, y), float(x + y * self.width))
 
+    def test_copy(self):
+        # Copy the image.
+        img2 = raw_image(self.img)
+        self.assertEqual(img2.get_width(), self.width)
+        self.assertEqual(img2.get_height(), self.height)
+        self.assertEqual(img2.get_ppi(), self.width * self.height)
+
+        # Set the old image to all zeros.
+        self.img.set_all(0.0)
+
+        # Check the new image is still set correctly.
+        for x in range(self.width):
+            for y in range(self.height):
+                self.assertTrue(img2.pixel_has_data(x, y))
+                self.assertEqual(img2.get_pixel(x, y), float(x + y * self.width))
+
     def test_set_all(self):
         self.img.set_all(15.0)
         for x in range(self.width):


### PR DESCRIPTION
Add some helper constructors to the C++ data structures, including a copy constructor for `RawImage` and the ability to build a `LayeredImage` out of actual layers.

Also adds a missing test for `ImageInfo`.