### PR TITLE
Cleanup RawImage and LayeredImage getter functions

### DIFF
--- a/src/kbmod/search/LayeredImage.h
+++ b/src/kbmod/search/LayeredImage.h
@@ -42,7 +42,7 @@ public:
     std::string getName() const { return fileName; }
     unsigned getWidth() const { return width; }
     unsigned getHeight() const { return height; }
-    unsigned getPPI() const { return pixelsPerImage; }
+    unsigned getPPI() const { return width * height; }
     double getTime() const { return captureTime; }
 
     // Basic setter functions.
@@ -97,7 +97,6 @@ private:
     std::string fileName;
     unsigned width;
     unsigned height;
-    unsigned pixelsPerImage;
     double captureTime;
 
     PointSpreadFunc psf;

--- a/src/kbmod/search/RawImage.h
+++ b/src/kbmod/search/RawImage.h
@@ -46,11 +46,22 @@ public:
     // Basic getter functions for image data.
     unsigned getWidth() const { return width; }
     unsigned getHeight() const { return height; }
-    unsigned getPPI() const { return pixelsPerImage; }
-    float getPixel(int x, int y) const;
-    bool pixelHasData(int x, int y) const;
-    const std::vector<float>& getPixels() const;
-    float* getDataRef();  // Get pointer to pixels
+    unsigned getPPI() const { return width * height; }
+
+    // Inline pixel functions.
+    float getPixel(int x, int y) const {
+        return (x >= 0 && x < width && y >= 0 && y < height) ? pixels[y * width + x] : NO_DATA;
+    }
+
+    bool pixelHasData(int x, int y) const {
+        return (x >= 0 && x < width && y >= 0 && y < height) ? pixels[y * width + x] != NO_DATA : false;
+    }
+
+    void setPixel(int x, int y, float value) {
+        if (x >= 0 && x < width && y >= 0 && y < height) pixels[y * width + x] = value;
+    }
+    const std::vector<float>& getPixels() const { return pixels; }
+    float* getDataRef() { return pixels.data(); }  // Get pointer to pixels
 
     // Get the interpolated brightness of a real values point
     // using the four neighboring pixels.
@@ -67,7 +78,6 @@ public:
     void applyMask(int flags, const std::vector<int>& exceptions, const RawImage& mask);
 
     void setAllPix(float value);
-    void setPixel(int x, int y, float value);
     void addToPixel(float fx, float fy, float value);
     void addPixelInterp(float x, float y, float value);
     std::vector<float> bilinearInterp(float x, float y) const;
@@ -101,10 +111,8 @@ public:
     virtual ~RawImage(){};
 
 private:
-    void initDimensions(unsigned w, unsigned h);
     unsigned width;
     unsigned height;
-    unsigned pixelsPerImage;
     std::vector<float> pixels;
 };
 

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -24,6 +24,17 @@ class test_raw_image(unittest.TestCase):
                 self.assertTrue(self.img.pixel_has_data(x, y))
                 self.assertEqual(self.img.get_pixel(x, y), float(x + y * self.width))
 
+        # Pixels outside the image have no data.
+        self.assertFalse(self.img.pixel_has_data(-1, 5))
+        self.assertFalse(self.img.pixel_has_data(self.width, 5))
+        self.assertFalse(self.img.pixel_has_data(5, -1))
+        self.assertFalse(self.img.pixel_has_data(5, self.height))
+
+        self.assertEqual(self.img.get_pixel(-1, 5), KB_NO_DATA)
+        self.assertEqual(self.img.get_pixel(self.width, 5), KB_NO_DATA)
+        self.assertEqual(self.img.get_pixel(5, -1), KB_NO_DATA)
+        self.assertEqual(self.img.get_pixel(5, self.height), KB_NO_DATA)
+
     def test_copy(self):
         # Copy the image.
         img2 = raw_image(self.img)


### PR DESCRIPTION
This PR does a bunch of small cleanups that do not change behavior, including:
1) Remove `pixelsPerImage` as a class variable from `RawImage` and `LayeredImage`. The logic is simpler just keeping width and height and doing an occasional multiplication.
2) Inlining a bunch of setter and getter functions in `RawImage`.
3) Switching the order of x and y loops (since the index used is `y * width + x`).
4) Adding some out of bounds tests. 