### PR TITLE
Remove the on-GPU grow mask option

### DIFF
--- a/src/kbmod/masking.py
+++ b/src/kbmod/masking.py
@@ -222,5 +222,5 @@ class GrowMask(ImageMasker):
         stack : `kbmod.image_stack`
             The same stack object to allow chaining.
         """
-        stack.grow_mask(self.num_pixels, True)
+        stack.grow_mask(self.num_pixels)
         return stack

--- a/src/kbmod/search/ImageStack.cpp
+++ b/src/kbmod/search/ImageStack.cpp
@@ -110,8 +110,8 @@ void ImageStack::applyMaskThreshold(float thresh) {
     for (auto& i : images) i.applyMaskThreshold(thresh);
 }
 
-void ImageStack::growMask(int steps, bool on_gpu) {
-    for (auto& i : images) i.growMask(steps, on_gpu);
+void ImageStack::growMask(int steps) {
+    for (auto& i : images) i.growMask(steps);
 }
 
 void ImageStack::createGlobalMask(int flags, int threshold) {

--- a/src/kbmod/search/ImageStack.h
+++ b/src/kbmod/search/ImageStack.h
@@ -43,7 +43,7 @@ public:
     void applyGlobalMask(int flags, int threshold);
     void applyMaskFlags(int flags, const std::vector<int>& exceptions);
     void applyMaskThreshold(float thresh);
-    void growMask(int steps, bool on_gpu);
+    void growMask(int steps);
     const RawImage& getGlobalMask() const;
 
     void convolvePSF();

--- a/src/kbmod/search/LayeredImage.cpp
+++ b/src/kbmod/search/LayeredImage.cpp
@@ -143,9 +143,9 @@ void LayeredImage::addObject(float x, float y, float flux) {
     }
 }
 
-void LayeredImage::growMask(int steps, bool on_gpu) {
-    science.growMask(steps, on_gpu);
-    variance.growMask(steps, on_gpu);
+void LayeredImage::growMask(int steps) {
+    science.growMask(steps);
+    variance.growMask(steps);
 }
 
 void LayeredImage::convolvePSF() {

--- a/src/kbmod/search/LayeredImage.h
+++ b/src/kbmod/search/LayeredImage.h
@@ -62,7 +62,7 @@ public:
     void applyMaskFlags(int flag, const std::vector<int>& exceptions);
     void applyGlobalMask(const RawImage& globalMask);
     void applyMaskThreshold(float thresh);
-    void growMask(int steps, bool on_gpu);
+    void growMask(int steps);
 
     // Subtracts a template image from the science layer.
     void subtractTemplate(const RawImage& subTemplate);

--- a/src/kbmod/search/RawImage.cpp
+++ b/src/kbmod/search/RawImage.cpp
@@ -142,12 +142,7 @@ void RawImage::applyMask(int flags, const std::vector<int>& exceptions, const Ra
    (which is how the code is generally used. If you are only
    growing the mask by 1, the extra copy will be a little slower.
 */
-void RawImage::growMask(int steps, bool on_gpu) {
-    if (on_gpu) {
-        deviceGrowMask(width, height, pixels.data(), pixels.data(), steps);
-        return;
-    }
-
+void RawImage::growMask(int steps) {
     const int num_pixels = width * height;
 
     // Set up the initial masked vector that stores the number of steps

--- a/src/kbmod/search/RawImage.h
+++ b/src/kbmod/search/RawImage.h
@@ -83,7 +83,7 @@ public:
     std::vector<float> bilinearInterp(float x, float y) const;
 
     // Grow the area of masked pixels.
-    void growMask(int steps, bool on_gpu);
+    void growMask(int steps);
 
     // Save the RawImage to a file. Append indicates whether to append
     // or create a new file.

--- a/tests/test_layered_image.py
+++ b/tests/test_layered_image.py
@@ -205,7 +205,7 @@ class test_layered_image(unittest.TestCase):
         mask.set_pixel(10, 13, 1)
         self.image.set_mask(mask)
         self.image.apply_mask_flags(1, [])
-        self.image.grow_mask(1, False)
+        self.image.grow_mask(1)
 
         # Check that the mask has grown to all adjacent pixels.
         science = self.image.get_science()
@@ -224,7 +224,7 @@ class test_layered_image(unittest.TestCase):
         mask.set_pixel(10, 12, 1)
         self.image.set_mask(mask)
         self.image.apply_mask_flags(1, [])
-        self.image.grow_mask(3, True)
+        self.image.grow_mask(3)
 
         # Check that the mask has grown to all applicable pixels.
         science = self.image.get_science()

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -254,17 +254,7 @@ class test_raw_image(unittest.TestCase):
                 should_mask = (x == 3 and y == 7) or (x == 5 and y == 7)
                 self.assertEqual(self.img.pixel_has_data(x, y), not should_mask)
 
-        self.img.grow_mask(1, False)
-        for y in range(self.img.get_height()):
-            for x in range(self.img.get_width()):
-                dist = min([abs(3 - x) + abs(7 - y), abs(5 - x) + abs(7 - y)])
-                self.assertEqual(self.img.pixel_has_data(x, y), dist > 1)
-
-    def test_grow_mask_1_gpu(self):
-        self.img.set_pixel(5, 7, KB_NO_DATA)
-        self.img.set_pixel(3, 7, KB_NO_DATA)
-
-        self.img.grow_mask(1, True)
+        self.img.grow_mask(1)
         for y in range(self.img.get_height()):
             for x in range(self.img.get_width()):
                 dist = min([abs(3 - x) + abs(7 - y), abs(5 - x) + abs(7 - y)])
@@ -275,18 +265,7 @@ class test_raw_image(unittest.TestCase):
         self.img.set_pixel(3, 7, KB_NO_DATA)
         self.img.set_pixel(1, 0, KB_NO_DATA)
 
-        self.img.grow_mask(3, False)
-        for y in range(self.img.get_height()):
-            for x in range(self.img.get_width()):
-                dist = min([abs(3 - x) + abs(7 - y), abs(5 - x) + abs(7 - y), abs(1 - x) + abs(0 - y)])
-                self.assertEqual(self.img.pixel_has_data(x, y), dist > 3)
-
-    def test_grow_mask_3_gpu(self):
-        self.img.set_pixel(5, 7, KB_NO_DATA)
-        self.img.set_pixel(3, 7, KB_NO_DATA)
-        self.img.set_pixel(1, 0, KB_NO_DATA)
-
-        self.img.grow_mask(3, True)
+        self.img.grow_mask(3)
         for y in range(self.img.get_height()):
             for x in range(self.img.get_width()):
                 dist = min([abs(3 - x) + abs(7 - y), abs(5 - x) + abs(7 - y), abs(1 - x) + abs(0 - y)])


### PR DESCRIPTION
More detailed profiling shows that growing the mask on GPU is not providing a significant speedup. Keeping two implementations adds complexity and maintenance overhead. Use the CPU implementation as that is simpler and more portable (no GPU required).