### PR TITLE
Create CPU versions of several functions

### DIFF
--- a/src/kbmod/search/KBMOSearch.cpp
+++ b/src/kbmod/search/KBMOSearch.cpp
@@ -343,19 +343,20 @@ bool KBMOSearch::filterStamp(const RawImage& img, const stampParameters& params)
     pixelPos pos = img.findPeak(true);
     if ((abs(pos.x - params.radius) >= params.peak_offset_x) ||
         (abs(pos.y - params.radius) >= params.peak_offset_y)) {
-        return false;
+        return true;
     }
 
     // Filter on the percentage of flux in the central pixel.
     if (params.center_thresh > 0.0) {
         const std::vector<float>& pixels = img.getPixels();
-        float center_val = current[(int)pos.y * stamp_width + (int)pos.x];
+        float center_val = pixels[(int)pos.y * stamp_width + (int)pos.x];
         float pixel_sum = 0.0;
         for (int p = 0; p < stamp_ppi; ++p) {
-            pixel_sum += current[p];
+            pixel_sum += pixels[p];
         }
+
         if (center_val / pixel_sum < params.center_thresh) {
-            return false;
+            return true;
         }
     }
 
@@ -366,10 +367,10 @@ bool KBMOSearch::filterStamp(const RawImage& img, const stampParameters& params)
         (fabs(moments.m11) >= params.m11_limit) ||
         (moments.m02 >= params.m02_limit) ||
         (moments.m20 >= params.m20_limit)) {
-        return false;
+        return true;
     }
 
-    return true;
+    return false;
 }
 
 std::vector<RawImage> KBMOSearch::coaddedScienceStampsGPU(std::vector<trajectory>& t_array,

--- a/src/kbmod/search/KBMOSearch.h
+++ b/src/kbmod/search/KBMOSearch.h
@@ -77,6 +77,9 @@ public:
                                                   std::vector<std::vector<bool> >& use_index_vect,
                                                   const stampParameters& params);
 
+    // Function to do the actual stamp filtering.
+    bool filterStamp(const RawImage& img, const stampParameters& params);
+
     // Getters for the Psi and Phi data.
     std::vector<RawImage>& getPsiImages();
     std::vector<RawImage>& getPhiImages();

--- a/src/kbmod/search/PointSpreadFunc.h
+++ b/src/kbmod/search/PointSpreadFunc.h
@@ -39,9 +39,10 @@ public:
     PointSpreadFunc& operator=(const PointSpreadFunc& other);  // Copy assignment
     PointSpreadFunc& operator=(PointSpreadFunc&& other);       // Move assignment
 
-    // Getter functions.
+    // Getter functions (inlined)
     float getStdev() const { return width; }
     float getSum() const { return sum; }
+    float getValue(int x, int y) const { return kernel[y * dim + x]; }
     int getDim() const { return dim; }
     int getRadius() const { return radius; }
     int getSize() const { return kernel.size(); }

--- a/src/kbmod/search/RawImage.cpp
+++ b/src/kbmod/search/RawImage.cpp
@@ -117,13 +117,12 @@ RawImage RawImage::createStamp(float x, float y, int radius, bool interpolate, b
 
 void RawImage::convolve_cpu(const PointSpreadFunc& psf) {
     std::vector<float> result(width * height, 0.0);
-    const std::vector<float> kernel = psf.getKernel();
     const int psfRad = psf.getRadius();
-    const int psfDim = psf.getDim();
     const float psfTotal = psf.getSum();
 
     for (int y = 0; y < height; ++y) {
         for (int x = 0; x < width; ++x) {
+            // Pixels with NO_DATA remain NO_DATA.
             if (pixels[y * width + x] == NO_DATA) {
                 result[y * width + x] = NO_DATA;
                 continue;
@@ -136,7 +135,7 @@ void RawImage::convolve_cpu(const PointSpreadFunc& psf) {
                     if ((x + i >= 0) && (x + i < width) && (y + j >= 0) && (y + j < height)) {
                         float currentPixel = pixels[(y + j) * width + (x + i)];
                         if (currentPixel != NO_DATA) {
-                            float currentPSF = kernel[(j + psfRad) * psfDim + (i + psfRad)];
+                            float currentPSF = psf.getValue(j + psfRad, i + psfRad);
                             psfPortion += currentPSF;
                             sum += currentPixel * currentPSF;
                         }

--- a/src/kbmod/search/RawImage.cpp
+++ b/src/kbmod/search/RawImage.cpp
@@ -135,7 +135,7 @@ void RawImage::convolve_cpu(const PointSpreadFunc& psf) {
                     if ((x + i >= 0) && (x + i < width) && (y + j >= 0) && (y + j < height)) {
                         float currentPixel = pixels[(y + j) * width + (x + i)];
                         if (currentPixel != NO_DATA) {
-                            float currentPSF = psf.getValue(j + psfRad, i + psfRad);
+                            float currentPSF = psf.getValue(i + psfRad, j + psfRad);
                             psfPortion += currentPSF;
                             sum += currentPixel * currentPSF;
                         }

--- a/src/kbmod/search/RawImage.cpp
+++ b/src/kbmod/search/RawImage.cpp
@@ -337,7 +337,7 @@ std::array<float, 2> RawImage::computeBounds() const {
 }
 
 // The maximum value of the image and return the coordinates.
-pixelPos RawImage::findPeak(bool furthest_from_center) {
+pixelPos RawImage::findPeak(bool furthest_from_center) const {
     int c_x = width / 2;
     int c_y = height / 2;
 
@@ -375,7 +375,7 @@ pixelPos RawImage::findPeak(bool furthest_from_center) {
 // It computes the moments on the "normalized" image where the minimum
 // value has been shifted to zero and the sum of all elements is 1.0.
 // Elements with NO_DATA are treated as zero.
-imageMoments RawImage::findCentralMoments() {
+imageMoments RawImage::findCentralMoments() const {
     const int num_pixels = width * height;
     const int c_x = width / 2;
     const int c_y = height / 2;

--- a/src/kbmod/search/RawImage.h
+++ b/src/kbmod/search/RawImage.h
@@ -102,13 +102,13 @@ public:
     // The maximum value of the image and return the coordinates. The parameter
     // furthest_from_center indicates whether to break ties using the peak further
     // or closer to the center of the image.
-    pixelPos findPeak(bool furthest_from_center);
+    pixelPos findPeak(bool furthest_from_center) const;
 
     // Find the basic image moments in order to test if stamps have a gaussian shape.
     // It computes the moments on the "normalized" image where the minimum
     // value has been shifted to zero and the sum of all elements is 1.0.
     // Elements with NO_DATA are treated as zero.
-    imageMoments findCentralMoments();
+    imageMoments findCentralMoments() const;
 
     virtual ~RawImage(){};
 

--- a/src/kbmod/search/RawImage.h
+++ b/src/kbmod/search/RawImage.h
@@ -92,6 +92,7 @@ public:
 
     // Convolve the image with a point spread function.
     void convolve(PointSpreadFunc psf);
+    void convolve_cpu(const PointSpreadFunc& psf);
 
     // Create a "stamp" image of a give radius (width=2*radius+1)
     // about the given point.

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -24,7 +24,7 @@ using std::to_string;
 
 PYBIND11_MODULE(search, m) {
     m.attr("KB_NO_DATA") = pybind11::float_(search::NO_DATA);
-    m.attr("HAS_GPU") = pybind11::bool_(search::HAS_GPU);
+    m.attr("HAS_GPU") = pybind11::bool_(search::HAVE_GPU);
     py::enum_<search::StampType>(m, "StampType")
             .value("STAMP_SUM", search::StampType::STAMP_SUM)
             .value("STAMP_MEAN", search::StampType::STAMP_MEAN)

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -24,7 +24,7 @@ using std::to_string;
 
 PYBIND11_MODULE(search, m) {
     m.attr("KB_NO_DATA") = pybind11::float_(search::NO_DATA);
-    m.attr("KB_HAVE_GPU") = pybind11::bool_(search::HAVE_GPU);
+    m.attr("HAS_GPU") = pybind11::bool_(search::HAS_GPU);
     py::enum_<search::StampType>(m, "StampType")
             .value("STAMP_SUM", search::StampType::STAMP_SUM)
             .value("STAMP_MEAN", search::StampType::STAMP_MEAN)

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -203,6 +203,7 @@ PYBIND11_MODULE(search, m) {
                                          const search::stampParameters &)) &
                          ks::coaddedScienceStampsGPU)
             // For testing
+            .def("filter_stamp", &ks::filterStamp)
             .def("get_traj_pos", &ks::getTrajPos)
             .def("get_mult_traj_pos", &ks::getMultTrajPos)
             .def("psi_curves", (std::vector<float>(ks::*)(tj &)) & ks::psiCurves)

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -24,6 +24,7 @@ using std::to_string;
 
 PYBIND11_MODULE(search, m) {
     m.attr("KB_NO_DATA") = pybind11::float_(search::NO_DATA);
+    m.attr("KB_HAVE_GPU") = pybind11::bool_(search::HAVE_GPU);
     py::enum_<search::StampType>(m, "StampType")
             .value("STAMP_SUM", search::StampType::STAMP_SUM)
             .value("STAMP_MEAN", search::StampType::STAMP_MEAN)
@@ -103,6 +104,7 @@ PYBIND11_MODULE(search, m) {
             .def("get_pixel", &ri::getPixel, "Returns the value of a pixel.")
             .def("get_pixel_interp", &ri::getPixelInterp, "Get the interoplated value of a pixel.")
             .def("convolve", &ri::convolve, "Convolve the image with a PSF.")
+            .def("convolve_cpu", &ri::convolve_cpu, "Convolve the image with a PSF.")
             .def("save_fits", &ri::saveToFile, "Save the image to a FITS file.");
     m.def("create_median_image", &search::createMedianImage);
     m.def("create_summed_image", &search::createSummedImage);

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -72,6 +72,7 @@ PYBIND11_MODULE(search, m) {
             .def("get_radius", &pf::getRadius, "Returns the radius of the PSF")
             .def("get_size", &pf::getSize, "Returns the number of elements in the PSFs kernel.")
             .def("get_kernel", &pf::getKernel, "Returns the PSF kernel.")
+            .def("get_value", &pf::getValue, "Returns the PSF kernel value at a specific point.")
             .def("square_psf", &pf::squarePSF,
                  "Squares, raises to the power of two, the elements of the PSF kernel.")
             .def("print_psf", &pf::printPSF, "Pretty-prints the PSF.");

--- a/src/kbmod/search/common.h
+++ b/src/kbmod/search/common.h
@@ -10,6 +10,12 @@
 
 namespace search {
 
+#ifdef HAVE_CUDA
+    constexpr bool HAVE_GPU = true;
+#else
+    constexpr bool HAVE_GPU = false;
+#endif
+
 constexpr unsigned int MAX_KERNEL_RADIUS = 15;
 constexpr unsigned short MAX_STAMP_EDGE = 64;
 constexpr unsigned short CONV_THREAD_DIM = 32;

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -197,6 +197,9 @@ class test_raw_image(unittest.TestCase):
                         self.assertTrue(img2.pixel_has_data(x, y))
 
     def test_convolve_psf_average(self):
+        # Mask out a single pixel.
+        self.img.set_pixel(6, 4, KB_NO_DATA)
+
         # Set up a simple "averaging" psf to convolve.
         psf_data = [[0.0 for _ in range(5)] for _ in range(5)]
         for x in range(1, 4):
@@ -227,7 +230,10 @@ class test_raw_image(unittest.TestCase):
                     ave = running_sum / count
 
                     # Compute the manually computed result with the convolution.
-                    self.assertAlmostEqual(img2.get_pixel(x, y), ave, delta=0.001)
+                    if x == 6 and y == 4:
+                        self.assertFalse(img2.pixel_has_data(x, y))
+                    else:
+                        self.assertAlmostEqual(img2.get_pixel(x, y), ave, delta=0.001)
 
     def test_convolve_psf_orientation(self):
         # Set up a non-symmetric psf where orientation matters.

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -204,8 +204,13 @@ class test_raw_image(unittest.TestCase):
         img2 = raw_image(self.img)
         img2.convolve_cpu(p)
 
-        # Check that the image is unchanged.
-        self.assertTrue(self.img.approx_equal(img2, 0.0001))
+        # Check that the same pixels are masked.
+        for x in range(self.width):
+            for y in range(self.height):
+                if (x == 5 and y == 6) or (x == 0 and y == 3) or (x == 5 and y == 7):
+                    self.assertFalse(img2.pixel_has_data(x, y))
+                else:
+                    self.assertTrue(img2.pixel_has_data(x, y))
 
     @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
     def test_convolve_psf_mask_gpu(self):
@@ -219,8 +224,13 @@ class test_raw_image(unittest.TestCase):
         img2 = raw_image(self.img)
         img2.convolve(p)
 
-        # Check that the image is unchanged.
-        self.assertTrue(self.img.approx_equal(img2, 0.0001))
+        # Check that the same pixels are masked.
+        for x in range(self.width):
+            for y in range(self.height):
+                if (x == 5 and y == 6) or (x == 0 and y == 3) or (x == 5 and y == 7):
+                    self.assertFalse(img2.pixel_has_data(x, y))
+                else:
+                    self.assertTrue(img2.pixel_has_data(x, y))
 
     def test_convolve_psf_average_cpu(self):
         # Mask out a single pixel.

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -15,24 +15,6 @@ class test_raw_image(unittest.TestCase):
             for y in range(self.height):
                 self.img.set_pixel(x, y, float(x + y * self.width))
 
-        self.test_gpu = [False]
-        if KB_HAVE_GPU:
-            self.test_gpu.append(True)
-
-    def _do_convolve(self, img, psf, use_gpu):
-        # Make a clean version of the image for the convolution.
-        img2 = raw_image(self.width, self.height)
-        for x in range(self.width):
-            for y in range(self.height):
-                img2.set_pixel(x, y, self.img.get_pixel(x, y))
-
-        if use_gpu:
-            img2.convolve(psf)
-        else:
-            img2.convolve_cpu(psf)
-
-        return img2
-
     def test_create(self):
         self.assertEqual(self.img.get_width(), self.width)
         self.assertEqual(self.img.get_height(), self.height)
@@ -188,21 +170,30 @@ class test_raw_image(unittest.TestCase):
         self.assertAlmostEqual(img_mom.m02, 1.01695, delta=1e-4)
         self.assertAlmostEqual(img_mom.m20, 1.57627, delta=1e-4)
 
-    def test_convolve_psf_identity(self):
+    def test_convolve_psf_identity_cpu(self):
         psf_data = [[0.0 for _ in range(3)] for _ in range(3)]
         psf_data[1][1] = 1.0
         p = psf(np.array(psf_data))
 
-        for gpu in self.test_gpu:
-            img2 = self._do_convolve(self.img, p, gpu)
+        img2 = raw_image(self.img)
+        img2.convolve_cpu(p)
 
-            # Check that the image is unchanged.
-            for x in range(self.width):
-                for y in range(self.height):
-                    self.assertTrue(img2.pixel_has_data(x, y))
-                    self.assertEqual(img2.get_pixel(x, y), self.img.get_pixel(x, y))
+        # Check that the image is unchanged.
+        self.assertTrue(self.img.approx_equal(img2, 0.0001))
 
-    def test_convolve_psf_mask(self):
+    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    def test_convolve_psf_identity_gpu(self):
+        psf_data = [[0.0 for _ in range(3)] for _ in range(3)]
+        psf_data[1][1] = 1.0
+        p = psf(np.array(psf_data))
+
+        img2 = raw_image(self.img)
+        img2.convolve(p)
+
+        # Check that the image is unchanged.
+        self.assertTrue(self.img.approx_equal(img2, 0.0001))
+
+    def test_convolve_psf_mask_cpu(self):
         p = psf(1.0)
 
         # Mask out three pixels.
@@ -210,18 +201,28 @@ class test_raw_image(unittest.TestCase):
         self.img.set_pixel(0, 3, KB_NO_DATA)
         self.img.set_pixel(5, 7, KB_NO_DATA)
 
-        for gpu in self.test_gpu:
-            img2 = self._do_convolve(self.img, p, gpu)
+        img2 = raw_image(self.img)
+        img2.convolve_cpu(p)
 
-            # Check that the image is unchanged.
-            for x in range(self.width):
-                for y in range(self.height):
-                    if (x == 5 and y == 6) or (x == 0 and y == 3) or (x == 5 and y == 7):
-                        self.assertFalse(img2.pixel_has_data(x, y))
-                    else:
-                        self.assertTrue(img2.pixel_has_data(x, y))
+        # Check that the image is unchanged.
+        self.assertTrue(self.img.approx_equal(img2, 0.0001))
 
-    def test_convolve_psf_average(self):
+    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    def test_convolve_psf_mask_gpu(self):
+        p = psf(1.0)
+
+        # Mask out three pixels.
+        self.img.set_pixel(5, 6, KB_NO_DATA)
+        self.img.set_pixel(0, 3, KB_NO_DATA)
+        self.img.set_pixel(5, 7, KB_NO_DATA)
+
+        img2 = raw_image(self.img)
+        img2.convolve(p)
+
+        # Check that the image is unchanged.
+        self.assertTrue(self.img.approx_equal(img2, 0.0001))
+
+    def test_convolve_psf_average_cpu(self):
         # Mask out a single pixel.
         self.img.set_pixel(6, 4, KB_NO_DATA)
 
@@ -233,55 +234,119 @@ class test_raw_image(unittest.TestCase):
         p = psf(np.array(psf_data))
         self.assertAlmostEqual(p.get_sum(), 1.0, delta=0.00001)
 
-        for gpu in self.test_gpu:
-            img2 = self._do_convolve(self.img, p, gpu)
+        img2 = raw_image(self.img)
+        img2.convolve_cpu(p)
 
-            for x in range(self.width):
-                for y in range(self.height):
-                    # Compute the weighted average around (x, y)
-                    # in the original image.
-                    running_sum = 0.0
-                    count = 0.0
-                    for i in range(-2, 3):
-                        for j in range(-2, 3):
-                            value = self.img.get_pixel(x + i, y + j)
-                            psf_value = 0.1111111
-                            if i == -2 or i == 2 or j == -2 or j == 2:
-                                psf_value = 0.0
+        for x in range(self.width):
+            for y in range(self.height):
+                # Compute the weighted average around (x, y)
+                # in the original image.
+                running_sum = 0.0
+                count = 0.0
+                for i in range(-2, 3):
+                    for j in range(-2, 3):
+                        value = self.img.get_pixel(x + i, y + j)
+                        psf_value = 0.1111111
+                        if i == -2 or i == 2 or j == -2 or j == 2:
+                            psf_value = 0.0
 
-                            if value != KB_NO_DATA:
-                                running_sum += psf_value * value
-                                count += psf_value
-                    ave = running_sum / count
+                        if value != KB_NO_DATA:
+                            running_sum += psf_value * value
+                            count += psf_value
+                ave = running_sum / count
 
-                    # Compute the manually computed result with the convolution.
-                    if x == 6 and y == 4:
-                        self.assertFalse(img2.pixel_has_data(x, y))
-                    else:
-                        self.assertAlmostEqual(img2.get_pixel(x, y), ave, delta=0.001)
+                # Compute the manually computed result with the convolution.
+                if x == 6 and y == 4:
+                    self.assertFalse(img2.pixel_has_data(x, y))
+                else:
+                    self.assertAlmostEqual(img2.get_pixel(x, y), ave, delta=0.001)
 
-    def test_convolve_psf_orientation(self):
+    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    def test_convolve_psf_average_gpu(self):
+        # Mask out a single pixel.
+        self.img.set_pixel(6, 4, KB_NO_DATA)
+
+        # Set up a simple "averaging" psf to convolve.
+        psf_data = [[0.0 for _ in range(5)] for _ in range(5)]
+        for x in range(1, 4):
+            for y in range(1, 4):
+                psf_data[x][y] = 0.1111111
+        p = psf(np.array(psf_data))
+        self.assertAlmostEqual(p.get_sum(), 1.0, delta=0.00001)
+
+        img2 = raw_image(self.img)
+        img2.convolve(p)
+
+        for x in range(self.width):
+            for y in range(self.height):
+                # Compute the weighted average around (x, y)
+                # in the original image.
+                running_sum = 0.0
+                count = 0.0
+                for i in range(-2, 3):
+                    for j in range(-2, 3):
+                        value = self.img.get_pixel(x + i, y + j)
+                        psf_value = 0.1111111
+                        if i == -2 or i == 2 or j == -2 or j == 2:
+                            psf_value = 0.0
+
+                        if value != KB_NO_DATA:
+                            running_sum += psf_value * value
+                            count += psf_value
+                ave = running_sum / count
+
+                # Compute the manually computed result with the convolution.
+                if x == 6 and y == 4:
+                    self.assertFalse(img2.pixel_has_data(x, y))
+                else:
+                    self.assertAlmostEqual(img2.get_pixel(x, y), ave, delta=0.001)
+
+    def test_convolve_psf_orientation_cpu(self):
         # Set up a non-symmetric psf where orientation matters.
         psf_data = [[0.0, 0.0, 0.0], [0.0, 0.5, 0.4], [0.0, 0.1, 0.0]]
         p = psf(np.array(psf_data))
 
-        for gpu in self.test_gpu:
-            img2 = self._do_convolve(self.img, p, gpu)
+        img2 = raw_image(self.img)
+        img2.convolve_cpu(p)
 
-            for x in range(self.width):
-                for y in range(self.height):
-                    running_sum = 0.5 * self.img.get_pixel(x, y)
-                    count = 0.5
-                    if self.img.pixel_has_data(x + 1, y):
-                        running_sum += 0.4 * self.img.get_pixel(x + 1, y)
-                        count += 0.4
-                    if self.img.pixel_has_data(x, y + 1):
-                        running_sum += 0.1 * self.img.get_pixel(x, y + 1)
-                        count += 0.1
-                    ave = running_sum / count
+        for x in range(self.width):
+            for y in range(self.height):
+                running_sum = 0.5 * self.img.get_pixel(x, y)
+                count = 0.5
+                if self.img.pixel_has_data(x + 1, y):
+                    running_sum += 0.4 * self.img.get_pixel(x + 1, y)
+                    count += 0.4
+                if self.img.pixel_has_data(x, y + 1):
+                    running_sum += 0.1 * self.img.get_pixel(x, y + 1)
+                    count += 0.1
+                ave = running_sum / count
 
-                    # Compute the manually computed result with the convolution.
-                    self.assertAlmostEqual(img2.get_pixel(x, y), ave, delta=0.001)
+                # Compute the manually computed result with the convolution.
+                self.assertAlmostEqual(img2.get_pixel(x, y), ave, delta=0.001)
+
+    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    def test_convolve_psf_orientation_gpu(self):
+        # Set up a non-symmetric psf where orientation matters.
+        psf_data = [[0.0, 0.0, 0.0], [0.0, 0.5, 0.4], [0.0, 0.1, 0.0]]
+        p = psf(np.array(psf_data))
+
+        img2 = raw_image(self.img)
+        img2.convolve(p)
+
+        for x in range(self.width):
+            for y in range(self.height):
+                running_sum = 0.5 * self.img.get_pixel(x, y)
+                count = 0.5
+                if self.img.pixel_has_data(x + 1, y):
+                    running_sum += 0.4 * self.img.get_pixel(x + 1, y)
+                    count += 0.4
+                if self.img.pixel_has_data(x, y + 1):
+                    running_sum += 0.1 * self.img.get_pixel(x, y + 1)
+                    count += 0.1
+                ave = running_sum / count
+
+                # Compute the manually computed result with the convolution.
+                self.assertAlmostEqual(img2.get_pixel(x, y), ave, delta=0.001)
 
     def test_grow_mask(self):
         self.img.set_pixel(5, 7, KB_NO_DATA)

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -15,9 +15,9 @@ class test_raw_image(unittest.TestCase):
             for y in range(self.height):
                 self.img.set_pixel(x, y, float(x + y * self.width))
 
-       self.test_gpu = [False]
-       if KB_HAVE_GPU:
-           self.test_gpu.append(True)
+        self.test_gpu = [False]
+        if KB_HAVE_GPU:
+            self.test_gpu.append(True)
 
     def _do_convolve(self, img, psf, use_gpu):
         # Make a clean version of the image for the convolution.
@@ -194,7 +194,7 @@ class test_raw_image(unittest.TestCase):
                     if (x == 5 and y == 6) or (x == 0 and y == 3) or (x == 5 and y == 7):
                         self.assertFalse(img2.pixel_has_data(x, y))
                     else:
-                        self.assertEqual(img2.get_pixel(x, y), self.img.get_pixel(x, y))
+                        self.assertTrue(img2.pixel_has_data(x, y))
 
     def test_convolve_psf_average(self):
         # Set up a simple "averaging" psf to convolve.

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -422,7 +422,8 @@ class test_search(unittest.TestCase):
         stamp.set_pixel(5, 5, 100.0)
         self.assertFalse(self.search.filter_stamp(stamp, self.params))
 
-        # A little noise around the pixel does not hurt.
+        # A little noise around the pixel does not hurt as long as the shape is
+        # roughly Gaussian.
         stamp.set_pixel(4, 5, 15.0)
         stamp.set_pixel(5, 4, 10.0)
         stamp.set_pixel(6, 5, 10.0)
@@ -434,7 +435,7 @@ class test_search(unittest.TestCase):
         self.assertTrue(self.search.filter_stamp(stamp, self.params))
         stamp.set_pixel(1, 1, 1.0)
 
-        # A non-Gaussian PSF is also bad.
+        # A non-Gaussian bright spot is also bad. Blur to the -x direction.
         stamp.set_pixel(4, 5, 50.0)
         stamp.set_pixel(3, 5, 50.0)
         stamp.set_pixel(2, 5, 60.0)
@@ -445,6 +446,17 @@ class test_search(unittest.TestCase):
         stamp.set_pixel(3, 6, 55.0)
         stamp.set_pixel(2, 6, 65.0)        
         self.assertTrue(self.search.filter_stamp(stamp, self.params))
+
+        # A very dim peak at the center is invalid.
+        stamp.set_all(1.0)
+        stamp.set_pixel(5, 5, 1.0001)
+        self.assertTrue(self.search.filter_stamp(stamp, self.params))
+
+        # A slightly offset peak of sufficient brightness is okay.
+        stamp.set_pixel(5, 5, 15.0)
+        stamp.set_pixel(4, 5, 20.0)
+        self.assertFalse(self.search.filter_stamp(stamp, self.params))
+
 
     def test_coadd_gpu_simple(self):
         # Create an image set with three images.

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -73,6 +73,21 @@ class test_search(unittest.TestCase):
         self.stack = image_stack(self.imlist)
         self.search = stack_search(self.stack)
 
+        # Set the filtering parameters.
+        self.params = stamp_parameters()
+        self.params.radius = 5
+        self.params.do_filtering = True
+        self.params.stamp_type = StampType.STAMP_MEAN
+        self.params.center_thresh = 0.03
+        self.params.peak_offset_x = 1.5
+        self.params.peak_offset_y = 1.5
+        self.params.m01 = 0.6
+        self.params.m10 = 0.6
+        self.params.m11 = 2.0
+        self.params.m02 = 35.5
+        self.params.m20 = 35.5
+
+
     def test_psiphi(self):
         p = psf(0.00001)
 
@@ -395,6 +410,42 @@ class test_search(unittest.TestCase):
         # Check that we get the correct answer.
         self.assertAlmostEqual(pix_sum / pix_count, meanStamp.get_pixel(2, 2), delta=1e-5)
 
+    def test_filter_stamp(self):
+        stamp_width = 2 * self.params.radius + 1
+
+        # Test a stamp with nothing in it.
+        stamp = raw_image(stamp_width, stamp_width)
+        stamp.set_all(1.0)
+        self.assertTrue(self.search.filter_stamp(stamp, self.params))
+
+        # Test a stamp with a bright spot in the center.
+        stamp.set_pixel(5, 5, 100.0)
+        self.assertFalse(self.search.filter_stamp(stamp, self.params))
+
+        # A little noise around the pixel does not hurt.
+        stamp.set_pixel(4, 5, 15.0)
+        stamp.set_pixel(5, 4, 10.0)
+        stamp.set_pixel(6, 5, 10.0)
+        stamp.set_pixel(5, 6, 20.0)        
+        self.assertFalse(self.search.filter_stamp(stamp, self.params))
+
+        # A bright peak far from the center is bad.
+        stamp.set_pixel(1, 1, 500.0)
+        self.assertTrue(self.search.filter_stamp(stamp, self.params))
+        stamp.set_pixel(1, 1, 1.0)
+
+        # A non-Gaussian PSF is also bad.
+        stamp.set_pixel(4, 5, 50.0)
+        stamp.set_pixel(3, 5, 50.0)
+        stamp.set_pixel(2, 5, 60.0)
+        stamp.set_pixel(4, 4, 45.0)
+        stamp.set_pixel(3, 4, 45.0)
+        stamp.set_pixel(2, 4, 55.0)
+        stamp.set_pixel(4, 6, 55.0)
+        stamp.set_pixel(3, 6, 55.0)
+        stamp.set_pixel(2, 6, 65.0)        
+        self.assertTrue(self.search.filter_stamp(stamp, self.params))
+
     def test_coadd_gpu_simple(self):
         # Create an image set with three images.
         imlist = []
@@ -576,29 +627,15 @@ class test_search(unittest.TestCase):
         trj4.x_v = self.trj.x_v
         trj4.y_v = self.trj.y_v
 
-        # Set the filtering parameters.
-        params = stamp_parameters()
-        params.radius = 5
-        params.do_filtering = True
-        params.stamp_type = StampType.STAMP_MEAN
-        params.center_thresh = 0.03
-        params.peak_offset_x = 1.5
-        params.peak_offset_y = 1.5
-        params.m01 = 0.6
-        params.m10 = 0.6
-        params.m11 = 2.0
-        params.m02 = 35.5
-        params.m20 = 35.5
-
         # Compute the stacked science from a single trajectory.
         all_valid_vect = [(self.all_valid) for i in range(4)]
-        meanStamps = self.search.gpu_coadded_stamps([self.trj, trj2, trj3, trj4], all_valid_vect, params)
+        meanStamps = self.search.gpu_coadded_stamps([self.trj, trj2, trj3, trj4], all_valid_vect, self.params)
 
         # The first and last are unfiltered
-        self.assertEqual(meanStamps[0].get_width(), 2 * params.radius + 1)
-        self.assertEqual(meanStamps[0].get_height(), 2 * params.radius + 1)
-        self.assertEqual(meanStamps[3].get_width(), 2 * params.radius + 1)
-        self.assertEqual(meanStamps[3].get_height(), 2 * params.radius + 1)
+        self.assertEqual(meanStamps[0].get_width(), 2 * self.params.radius + 1)
+        self.assertEqual(meanStamps[0].get_height(), 2 * self.params.radius + 1)
+        self.assertEqual(meanStamps[3].get_width(), 2 * self.params.radius + 1)
+        self.assertEqual(meanStamps[3].get_height(), 2 * self.params.radius + 1)
 
         # The second and third are filtered.
         self.assertEqual(meanStamps[1].get_width(), 1)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -87,7 +87,6 @@ class test_search(unittest.TestCase):
         self.params.m02 = 35.5
         self.params.m20 = 35.5
 
-
     def test_psiphi(self):
         p = psf(0.00001)
 
@@ -427,7 +426,7 @@ class test_search(unittest.TestCase):
         stamp.set_pixel(4, 5, 15.0)
         stamp.set_pixel(5, 4, 10.0)
         stamp.set_pixel(6, 5, 10.0)
-        stamp.set_pixel(5, 6, 20.0)        
+        stamp.set_pixel(5, 6, 20.0)
         self.assertFalse(self.search.filter_stamp(stamp, self.params))
 
         # A bright peak far from the center is bad.
@@ -444,7 +443,7 @@ class test_search(unittest.TestCase):
         stamp.set_pixel(2, 4, 55.0)
         stamp.set_pixel(4, 6, 55.0)
         stamp.set_pixel(3, 6, 55.0)
-        stamp.set_pixel(2, 6, 65.0)        
+        stamp.set_pixel(2, 6, 65.0)
         self.assertTrue(self.search.filter_stamp(stamp, self.params))
 
         # A very dim peak at the center is invalid.
@@ -456,7 +455,6 @@ class test_search(unittest.TestCase):
         stamp.set_pixel(5, 5, 15.0)
         stamp.set_pixel(4, 5, 20.0)
         self.assertFalse(self.search.filter_stamp(stamp, self.params))
-
 
     def test_coadd_gpu_simple(self):
         # Create an image set with three images.


### PR DESCRIPTION
This PR is step #2 in making KBMOD run on non-GPU systems. It does a bunch of things.
- Create a version of `RawImage` convolution that runs on CPU. Add logic to pick which version to use a compile time (so it will automatically use the CPU version on systems without a GPU).
- Modify the convolution tests so that they run the CPU versions on CPU-only systems and **both** CPU and GPU versions on GPU-equipped systems.
- Moves `findPeak`, `findCentralMoments`, and `filterStamps` out of CUDA code. These functions were only called from the host and didn't use the GPU anyway. This allows them to be directly testable on both CPU and GPU systems (and perform exactly the same). The existing tests all still apply to the new locations.
- Adds independent tests for `filterStamps`. Now that it is not in the CUDA code, we can test the stamp filtering in isolation to improve coverage.
- Add an inline getter for PSF values.

There are still more GPU functions that will need to be converted over, so this is step 2 of several.