### PR TITLE
Create a CPU version of Co-added Stamps

### DIFF
--- a/src/kbmod/analysis_utils.py
+++ b/src/kbmod/analysis_utils.py
@@ -473,7 +473,7 @@ class PostProcess:
             # Create and filter the results, using the GPU if there is one and enough
             # trajectories to make it worthwhile.
             stamps_slice = search.coadded_stamps(
-                trj_slice, bool_slice, params, HAS_GPU and len(trj_slice) > 100
+                trj_slice, bool_slice, params, kb.HAS_GPU and len(trj_slice) > 100
             )
             for ind, stamp in enumerate(stamps_slice):
                 if stamp.get_width() > 1:

--- a/src/kbmod/analysis_utils.py
+++ b/src/kbmod/analysis_utils.py
@@ -470,8 +470,11 @@ class PostProcess:
                 all_true = [True] * num_times
                 bool_slice = [all_true for _ in inds_to_use]
 
-            # Create and filter the results.
-            stamps_slice = search.gpu_coadded_stamps(trj_slice, bool_slice, params)
+            # Create and filter the results, using the GPU if there is one and enough
+            # trajectories to make it worthwhile.
+            stamps_slice = search.coadded_stamps(
+                trj_slice, bool_slice, params, HAS_GPU and len(trj_slice) > 100
+            )
             for ind, stamp in enumerate(stamps_slice):
                 if stamp.get_width() > 1:
                     result_list.results[ind + start_idx].stamp = np.array(stamp)

--- a/src/kbmod/search/KBMOSearch.cpp
+++ b/src/kbmod/search/KBMOSearch.cpp
@@ -392,6 +392,7 @@ std::vector<RawImage> KBMOSearch::coaddedScienceStampsCPU(std::vector<trajectory
                                                           const stampParameters& params) {
     const int num_trajectories = t_array.size();
     std::vector<RawImage> results(num_trajectories);
+    std::vector<float> empty_pixels(1, NO_DATA);
 
     for (int i = 0; i < num_trajectories; ++i) {
         std::vector<RawImage> stamps = scienceStamps(t_array[i], params.radius, false, true, use_index_vect[i]);
@@ -412,10 +413,10 @@ std::vector<RawImage> KBMOSearch::coaddedScienceStampsCPU(std::vector<trajectory
         }
 
         // Do the filtering if needed.
-        if (params.do_filtering && filterStamp(current_image, params)) {
-            results[t] = RawImage(1, 1, empty_pixels);
+        if (params.do_filtering && filterStamp(coadd, params)) {
+            results[i] = RawImage(1, 1, empty_pixels);
         } else {
-            results[t] = RawImage(stamp_width, stamp_width, current_pixels);
+            results[i] = coadd;
         }
     }
 

--- a/src/kbmod/search/KBMOSearch.cpp
+++ b/src/kbmod/search/KBMOSearch.cpp
@@ -373,6 +373,55 @@ bool KBMOSearch::filterStamp(const RawImage& img, const stampParameters& params)
     return false;
 }
 
+std::vector<RawImage> KBMOSearch::coaddedScienceStamps(std::vector<trajectory>& t_array,
+                                                       std::vector<std::vector<bool> >& use_index_vect,
+                                                       const stampParameters& params,
+                                                       bool use_gpu) {
+    if (use_gpu) {
+        #ifdef HAVE_CUDA
+            return coaddedScienceStampsGPU(t_array, use_index_vect, params);
+        #else
+            print("WARNING: GPU is not enabled. Performing co-adds on the CPU.");
+        #endif
+    }
+    return coaddedScienceStampsCPU(t_array, use_index_vect, params);
+}
+
+std::vector<RawImage> KBMOSearch::coaddedScienceStampsCPU(std::vector<trajectory>& t_array,
+                                                          std::vector<std::vector<bool> >& use_index_vect,
+                                                          const stampParameters& params) {
+    const int num_trajectories = t_array.size();
+    std::vector<RawImage> results(num_trajectories);
+
+    for (int i = 0; i < num_trajectories; ++i) {
+        std::vector<RawImage> stamps = scienceStamps(t_array[i], params.radius, false, true, use_index_vect[i]);
+
+        RawImage coadd(1, 1);
+        switch (params.stamp_type) {
+            case STAMP_MEDIAN:
+                coadd = createMedianImage(stamps);
+                break;
+            case STAMP_MEAN:
+                coadd = createMeanImage(stamps);
+                break;
+            case STAMP_SUM:
+                coadd = createSummedImage(stamps);
+                break;
+            default:
+                throw std::runtime_error("Invalid stamp coadd type.");
+        }
+
+        // Do the filtering if needed.
+        if (params.do_filtering && filterStamp(current_image, params)) {
+            results[t] = RawImage(1, 1, empty_pixels);
+        } else {
+            results[t] = RawImage(stamp_width, stamp_width, current_pixels);
+        }
+    }
+
+    return results;
+}
+
 std::vector<RawImage> KBMOSearch::coaddedScienceStampsGPU(std::vector<trajectory>& t_array,
                                                           std::vector<std::vector<bool> >& use_index_vect,
                                                           const stampParameters& params) {

--- a/src/kbmod/search/KBMOSearch.h
+++ b/src/kbmod/search/KBMOSearch.h
@@ -69,13 +69,14 @@ public:
     RawImage meanScienceStamp(const trajectory& trj, int radius, const std::vector<bool>& use_index);
     RawImage summedScienceStamp(const trajectory& trj, int radius, const std::vector<bool>& use_index);
 
-    // Compute a mean or summed stamp for each trajectory on the GPU. This is slower than the
-    // above for small numbers of trajectories (< 500), but performs relatively better as the
-    // number of trajectories increases. If filtering is applied then will use a 1x1 image with
-    // NO_DATA to represent filtered images.
-    std::vector<RawImage> coaddedScienceStampsGPU(std::vector<trajectory>& t_array,
-                                                  std::vector<std::vector<bool> >& use_index_vect,
-                                                  const stampParameters& params);
+    // Compute a mean or summed stamp for each trajectory on the GPU or CPU.
+    // The GPU implementation is slower for small numbers of trajectories (< 500), but performs
+    // relatively better as the number of trajectories increases. If filtering is applied then
+    // the code will return a 1x1 image with NO_DATA to represent each filtered image.
+    std::vector<RawImage> coaddedScienceStamps(std::vector<trajectory>& t_array,
+                                               std::vector<std::vector<bool> >& use_index_vect,
+                                               const stampParameters& params,
+                                               bool use_cpu);
 
     // Function to do the actual stamp filtering.
     bool filterStamp(const RawImage& img, const stampParameters& params);
@@ -120,6 +121,13 @@ protected:
     void createSearchList(int angleSteps, int veloctiySteps, float minAngle, float maxAngle,
                           float minVelocity, float maxVelocity);
 
+    std::vector<RawImage> coaddedScienceStampsGPU(std::vector<trajectory>& t_array,
+                                                  std::vector<std::vector<bool> >& use_index_vect,
+                                                  const stampParameters& params);
+
+    std::vector<RawImage> coaddedScienceStampsCPU(std::vector<trajectory>& t_array,
+                                                  std::vector<std::vector<bool> >& use_index_vect,
+                                                  const stampParameters& params);
     // Helper functions for timing operations of the search.
     void startTimer(const std::string& message);
     void endTimer();

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -200,9 +200,9 @@ PYBIND11_MODULE(search, m) {
             .def("median_sci_stamp", &ks::medianScienceStamp)
             .def("mean_sci_stamp", &ks::meanScienceStamp)
             .def("summed_sci_stamp", &ks::summedScienceStamp)
-            .def("gpu_coadded_stamps",
+            .def("coadded_stamps",
                  (std::vector<ri>(ks::*)(std::vector<tj> &, std::vector<std::vector<bool>> &,
-                                         const search::stampParameters &)) &
+                                         const search::stampParameters &, bool)) &
                          ks::coaddedScienceStampsGPU)
             // For testing
             .def("filter_stamp", &ks::filterStamp)

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -203,7 +203,7 @@ PYBIND11_MODULE(search, m) {
             .def("coadded_stamps",
                  (std::vector<ri>(ks::*)(std::vector<tj> &, std::vector<std::vector<bool>> &,
                                          const search::stampParameters &, bool)) &
-                         ks::coaddedScienceStampsGPU)
+                         ks::coaddedScienceStamps)
             // For testing
             .def("filter_stamp", &ks::filterStamp)
             .def("get_traj_pos", &ks::getTrajPos)

--- a/tests/test_stamp_parity.py
+++ b/tests/test_stamp_parity.py
@@ -109,8 +109,8 @@ class test_search(unittest.TestCase):
             self.search.mean_sci_stamp(self.trj, radius, goodIdx[0]),
             self.search.mean_sci_stamp(self.trj, radius, goodIdx[1]),
         ]
-        stamps_gpu = self.search.coadded_stamps(results, [all_valid, all_valid], params, True)
-        stamps_cpu = self.search.coadded_stamps(results, [all_valid, all_valid], params, False)
+        stamps_gpu = self.search.coadded_stamps(results, goodIdx, params, True)
+        stamps_cpu = self.search.coadded_stamps(results, goodIdx, params, False)
         for r in range(2):
             self.assertTrue(stamps_old[r].approx_equal(stamps_gpu[r], 1e-5))
             self.assertTrue(stamps_old[r].approx_equal(stamps_cpu[r], 1e-5))
@@ -121,8 +121,8 @@ class test_search(unittest.TestCase):
             self.search.median_sci_stamp(self.trj, radius, goodIdx[0]),
             self.search.median_sci_stamp(self.trj, radius, goodIdx[1]),
         ]
-        stamps_gpu = self.search.coadded_stamps(results, [all_valid, all_valid], params, True)
-        stamps_cpu = self.search.coadded_stamps(results, [all_valid, all_valid], params, False)
+        stamps_gpu = self.search.coadded_stamps(results, goodIdx, params, True)
+        stamps_cpu = self.search.coadded_stamps(results, goodIdx, params, False)
         for r in range(2):
             self.assertTrue(stamps_old[r].approx_equal(stamps_gpu[r], 1e-5))
             self.assertTrue(stamps_old[r].approx_equal(stamps_cpu[r], 1e-5))


### PR DESCRIPTION
Fixes #338 

Create a CPU version of the coadded stamp creation for two reasons: 1) it is faster with a smaller number of trajectories and 2) it allows us to build and test on non-GPU systems. This reuses the existing CPU-based coadd infrastructure, so we do not need to reimplement the algorithms themselves. I'm intentionally going with the `#ifdef` approach as opposed to the `template`-based approach discussed in the review of #337 because I think it is cleaner and easier to read in this case.

Also updates all the tests (and adds more).