### PR TITLE
Add input/output options for configuration

### DIFF
--- a/src/kbmod/configuration.py
+++ b/src/kbmod/configuration.py
@@ -182,7 +182,6 @@ class SearchConfiguration:
         params = {col.name: safe_load(col.value[0]) for col in t.values()}
         return SearchConfiguration.from_dict(params)
 
-
     @classmethod
     def from_yaml(cls, config, strict=True):
         """Load a configuration from a YAML file.
@@ -234,9 +233,12 @@ class SearchConfiguration:
         hdu : `astropy.io.fits.BinTableHDU`
             The HDU with the configuration information.
         """
-        serialized_dict = {key: dump(val, default_flow_style=True)
-                           for key, val in self._params.items()}
-        t = Table(rows=[serialized_dict, ])
+        serialized_dict = {key: dump(val, default_flow_style=True) for key, val in self._params.items()}
+        t = Table(
+            rows=[
+                serialized_dict,
+            ]
+        )
         return fits.table_to_hdu(t)
 
     def to_yaml(self):

--- a/src/kbmod/configuration.py
+++ b/src/kbmod/configuration.py
@@ -245,14 +245,9 @@ class SearchConfiguration:
         return config
 
     @classmethod
-    def from_file(cls, filename, extension=0, strict=True):
-        if filename.endswith("yaml"):
-            with open(filename) as ff:
-                return SearchConfiguration.from_yaml(ff.read())
-        elif ".fits" in filename:
-            with fits.open(filename) as ff:
-                return SearchConfiguration.from_hdu(ff[extension])
-        raise ValueError("Configuration file suffix unrecognized.")
+    def from_file(cls, filename, strict=True):
+        with open(filename) as ff:
+            return SearchConfiguration.from_yaml(ff.read(), strict)
 
     def to_hdu(self):
         """Create a fits HDU with all the configuration parameters.
@@ -273,7 +268,17 @@ class SearchConfiguration:
                 t[col] = [val]
         return fits.table_to_hdu(t)
 
-    def save_to_yaml_file(self, filename, overwrite=False):
+    def to_yaml(self):
+        """Save a configuration file with the parameters.
+
+        Returns
+        -------
+        result : `str`
+            The serialized YAML string.
+        """
+        return dump(self._params)
+
+    def to_file(self, filename, overwrite=False):
         """Save a configuration file with the parameters.
 
         Parameters
@@ -288,4 +293,4 @@ class SearchConfiguration:
             return
 
         with open(filename, "w") as file:
-            file.write(dump(self._params))
+            file.write(self.to_yaml())

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -13,7 +13,7 @@ from numpy.linalg import lstsq
 import kbmod.search as kb
 
 from .analysis_utils import Interface, PostProcess
-from .configuration import KBMODConfig
+from .configuration import SearchConfiguration
 from .masking import (
     BitVectorMasker,
     DictionaryMasker,
@@ -33,22 +33,22 @@ class run_search:
     ----------
     input_parameters : ``dict``
         Additional parameters. Merged with (and checked against) the loaded input file and
-        the defaults provided in the KBMODConfig class.
+        the defaults provided in the SearchConfiguration class.
     config_file : ``str`` (optional)
         The name and path of the configuration file.
 
     Attributes
     ----------
-    config : ``KBMODConfig``
+    config : ``SearchConfiguration``
         Search parameters.
     """
 
     def __init__(self, input_parameters, config_file=None):
-        self.config = KBMODConfig()
+        self.config = SearchConfiguration()
 
         # Load parameters from a file.
         if config_file != None:
-            self.config.load_from_file(config_file)
+            self.config.load_from_yaml_file(config_file)
 
         # Load any additional parameters (overwriting what is there).
         if len(input_parameters) > 0:
@@ -301,7 +301,7 @@ class run_search:
             config_filename = os.path.join(
                 self.config["res_filepath"], f"config_{self.config['output_suffix']}.yml"
             )
-            self.config.save_configuration(config_filename, overwrite=True)
+            self.config.save_to_yaml_file(config_filename, overwrite=True)
 
         end = time.time()
         print("Time taken for patch: ", end - start)

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -44,15 +44,16 @@ class run_search:
     """
 
     def __init__(self, input_parameters, config_file=None):
-        self.config = SearchConfiguration()
-
         # Load parameters from a file.
         if config_file != None:
-            self.config.load_from_yaml_file(config_file)
+            self.config = SearchConfiguration.from_file(config_file)
+        else:
+            self.config = SearchConfiguration()
 
         # Load any additional parameters (overwriting what is there).
         if len(input_parameters) > 0:
-            self.config.set_from_dict(input_parameters)
+            for key, value in input_parameters.items():
+                self.config.set(key, value)
 
         # Validate the configuration.
         self.config.validate()
@@ -301,7 +302,7 @@ class run_search:
             config_filename = os.path.join(
                 self.config["res_filepath"], f"config_{self.config['output_suffix']}.yml"
             )
-            self.config.save_to_yaml_file(config_filename, overwrite=True)
+            self.config.to_file(config_filename, overwrite=True)
 
         end = time.time()
         print("Time taken for patch: ", end - start)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -106,7 +106,6 @@ class test_configuration(unittest.TestCase):
         config.set("output_suffix", "csv")
         config.set("mask_grow", 7)
         config.set("mask_bits_dict", {"bit1": 1, "bit2": 2})
-        print(config)
 
         with tempfile.TemporaryDirectory() as dir_name:
             file_path = f"{dir_name}/test.fits"

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,16 +1,15 @@
+from astropy.io import fits
+from astropy.table import Table
 import tempfile
 import unittest
 from pathlib import Path
 
-from kbmod.configuration import KBMODConfig
+from kbmod.configuration import SearchConfiguration
 
 
 class test_configuration(unittest.TestCase):
     def test_validate(self):
-        config = KBMODConfig()
-
-        # Without the im_filepath, validate raises an error.
-        self.assertRaises(ValueError, config.validate)
+        config = SearchConfiguration()
 
         # Add the minimal parameter and check it passes.
         config.set("im_filepath", "Here")
@@ -19,8 +18,8 @@ class test_configuration(unittest.TestCase):
         except ValueError:
             self.fail("validate() raised ValueError.")
 
-    def test_setting(self):
-        config = KBMODConfig()
+    def test_set(self):
+        config = SearchConfiguration()
         self.assertIsNone(config["im_filepath"])
         self.assertEqual(config["encode_psi_bytes"], -1)
 
@@ -32,8 +31,41 @@ class test_configuration(unittest.TestCase):
         # The set should fail when using unknown parameters and strict checking.
         self.assertRaises(KeyError, config.set, "My_new_param", 100, strict=True)
 
-    def test_save_and_load(self):
-        config = KBMODConfig()
+    def test_set_from_dict(self):
+        # Everything starts at its default.
+        config = SearchConfiguration()
+        self.assertIsNone(config["im_filepath"])
+        self.assertEqual(config["num_obs"], 10)
+
+        d = {"im_filepath": "Here2", "num_obs": 5}
+        config.set_from_dict(d)
+        self.assertEqual(config["im_filepath"], "Here2")
+        self.assertEqual(config["num_obs"], 5)
+
+    def test_set_from_table(self):
+        # Everything starts at its default.
+        config = SearchConfiguration()
+        self.assertIsNone(config["im_filepath"])
+        self.assertEqual(config["num_obs"], 10)
+
+        t = Table([["Here3"], [7]], names=("im_filepath", "num_obs"))
+        config.set_from_table(t)
+        self.assertEqual(config["im_filepath"], "Here3")
+        self.assertEqual(config["num_obs"], 7)
+
+    def test_to_table(self):
+        # Everything starts at its default.
+        config = SearchConfiguration()
+        d = {"im_filepath": "Here2", "num_obs": 5}
+        config.set_from_dict(d)
+
+        t = config.to_table()
+        self.assertEqual(len(t), 1)
+        self.assertEqual(t["im_filepath"][0], "Here2")
+        self.assertEqual(t["num_obs"][0], 5)
+
+    def test_save_and_load_yaml(self):
+        config = SearchConfiguration()
         num_defaults = len(config._params)
 
         # Overwrite some defaults.
@@ -46,16 +78,16 @@ class test_configuration(unittest.TestCase):
             self.assertFalse(Path(file_path).is_file())
 
             # Unable to load non-existent file.
-            config2 = KBMODConfig()
-            self.assertRaises(ValueError, config2.load_from_file, file_path)
+            config2 = SearchConfiguration()
+            self.assertRaises(ValueError, config2.load_from_yaml_file, file_path)
 
             # Correctly saves file.
-            config.save_configuration(file_path)
+            config.save_to_yaml_file(file_path)
             self.assertTrue(Path(file_path).is_file())
 
             # Correctly loads file.
             try:
-                config2.load_from_file(file_path)
+                config2.load_from_yaml_file(file_path)
             except ValueError:
                 self.fail("load_configuration() raised ValueError.")
 
@@ -64,6 +96,49 @@ class test_configuration(unittest.TestCase):
             self.assertEqual(config2["res_filepath"], None)
             self.assertEqual(config2["mask_grow"], 5)
             self.assertEqual(config2["output_suffix"], "txt")
+
+    def test_save_and_load_fits(self):
+        config = SearchConfiguration()
+        num_defaults = len(config._params)
+
+        # Overwrite some defaults.
+        config.set("im_filepath", "Here2")
+        config.set("output_suffix", "csv")
+        config.set("mask_grow", 7)
+        config.set("mask_bits_dict", {"bit1": 1, "bit2": 2})
+        print(config)
+
+        with tempfile.TemporaryDirectory() as dir_name:
+            file_path = f"{dir_name}/test.fits"
+            self.assertFalse(Path(file_path).is_file())
+
+            # Unable to load non-existent file.
+            config2 = SearchConfiguration()
+            self.assertRaises(ValueError, config2.load_from_fits_file, file_path)
+
+            # Generate measningless data for table 0 and the configuration for table 1.
+            t0 = Table([[1] * 10, [2] * 10, [3] * 10], names=("A", "B", "C"))
+            t0.write(file_path)
+            self.assertTrue(Path(file_path).is_file())
+
+            # Append the FITS data to extension=1
+            config.append_to_fits(file_path)
+            self.assertTrue(Path(file_path).is_file())
+
+            # Correctly loads file.
+            try:
+                config2.load_from_fits_file(file_path, layer=2)
+            except ValueError:
+                self.fail("load_from_fits_file() raised ValueError.")
+
+            self.assertEqual(len(config2._params), num_defaults)
+            self.assertEqual(config2["im_filepath"], "Here2")
+            self.assertEqual(config2["mask_grow"], 7)
+            self.assertEqual(config2["output_suffix"], "csv")
+
+            # Check that we correctly parse dictionaries and Nones.
+            self.assertEqual(len(config2["mask_bits_dict"]), 2)
+            self.assertIsNone(config2["res_filepath"])
 
 
 if __name__ == "__main__":

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -39,12 +39,23 @@ class test_configuration(unittest.TestCase):
         self.assertEqual(config["num_obs"], 5)
 
     def test_from_hdu(self):
-        t = Table([["Here3"], [7], ["__NONE__"]], names=("im_filepath", "num_obs", "cluster_type"))
+        t = Table(
+            [
+                ["Here3"],
+                ["7"],
+                ["null"],
+                [
+                    "[1, 2]",
+                ],
+            ],
+            names=("im_filepath", "num_obs", "cluster_type", "ang_arr"),
+        )
         hdu = fits.table_to_hdu(t)
 
         config = SearchConfiguration.from_hdu(hdu)
         self.assertEqual(config["im_filepath"], "Here3")
         self.assertEqual(config["num_obs"], 7)
+        self.assertEqual(config["ang_arr"], [1, 2])
         self.assertIsNone(config["cluster_type"])
 
     def test_to_hdu(self):
@@ -60,14 +71,12 @@ class test_configuration(unittest.TestCase):
         config = SearchConfiguration.from_dict(d)
         hdu = config.to_hdu()
 
-        self.assertEqual(hdu.data["im_filepath"][0], "Here2")
-        self.assertEqual(hdu.data["num_obs"][0], 5)
-        self.assertEqual(hdu.data["cluster_type"][0], "__NONE__")
-        self.assertEqual(hdu.data["__DICT__mask_bits_dict"][0], "{'bit1': 1, 'bit2': 2}")
-        self.assertEqual(hdu.data["res_filepath"][0], "There")
-        self.assertEqual(hdu.data["ang_arr"][0][0], 1.0)
-        self.assertEqual(hdu.data["ang_arr"][0][1], 2.0)
-        self.assertEqual(hdu.data["ang_arr"][0][2], 3.0)
+        self.assertEqual(hdu.data["im_filepath"][0], "Here2\n...")
+        self.assertEqual(hdu.data["num_obs"][0], "5\n...")
+        self.assertEqual(hdu.data["cluster_type"][0], "null\n...")
+        self.assertEqual(hdu.data["mask_bits_dict"][0], "{bit1: 1, bit2: 2}")
+        self.assertEqual(hdu.data["res_filepath"][0], "There\n...")
+        self.assertEqual(hdu.data["ang_arr"][0], "[1.0, 2.0, 3.0]")
 
     def test_to_yaml(self):
         d = {


### PR DESCRIPTION
Rename the `KBMODConfig` to `SearchConfiguration` since this will be the configuration for the core search algorithm (and we will be adding configuration for retrieving images, etc.). Adds the ability to read a `SearchConfiguration` from or write it to either an astropy table or a FITS file (with some admittedly hacky support for `None` and `dict`).  This will allow us to include the core search configuration information as another table in the singular work unit for distributed KBMOD.

Also removes `im_filepath` as a required entry in preparation for reading in the data from alternate sources.