### PR TITLE
WorkUnit Prefactoring

### DIFF
--- a/src/kbmod/analysis_utils.py
+++ b/src/kbmod/analysis_utils.py
@@ -368,6 +368,7 @@ class PostProcess:
 
 # Additional math utilities -----------
 
+
 def invert_Gaussian_CDF(z):
     if z < 0.5:
         sign = -1
@@ -375,6 +376,7 @@ def invert_Gaussian_CDF(z):
         sign = 1
     x = sign * np.sqrt(2) * erfinv(sign * (2 * z - 1))  # mpmath.erfinv(sign * (2 * z - 1))
     return float(x)
+
 
 def find_sigmaG_coeff(percentiles):
     z1 = percentiles[0] / 100
@@ -384,4 +386,3 @@ def find_sigmaG_coeff(percentiles):
     x2 = invert_Gaussian_CDF(z2)
     coeff = 1 / (x2 - x1)
     return coeff
-

--- a/src/kbmod/analysis_utils.py
+++ b/src/kbmod/analysis_utils.py
@@ -144,7 +144,7 @@ class PostProcess:
                 self.percentiles = self.sigmaG_lims
             else:
                 self.percentiles = [25, 75]
-            self.coeff = self._find_sigmaG_coeff(self.percentiles)
+            self.coeff = find_sigmaG_coeff(self.percentiles)
 
         if self.num_cores > 1:
             zipped_curves = result_list.zip_phi_psi_idx()
@@ -169,25 +169,6 @@ class PostProcess:
         print("{:.2f}s elapsed".format(time_elapsed))
         print("Completed filtering.", flush=True)
         print("---------------------------------------")
-
-    def _find_sigmaG_coeff(self, percentiles):
-        z1 = percentiles[0] / 100
-        z2 = percentiles[1] / 100
-
-        x1 = self._invert_Gaussian_CDF(z1)
-        x2 = self._invert_Gaussian_CDF(z2)
-        coeff = 1 / (x2 - x1)
-        print("sigmaG limits: [{},{}]".format(percentiles[0], percentiles[1]))
-        print("sigmaG coeff: {:.4f}".format(coeff), flush=True)
-        return coeff
-
-    def _invert_Gaussian_CDF(self, z):
-        if z < 0.5:
-            sign = -1
-        else:
-            sign = 1
-        x = sign * np.sqrt(2) * erfinv(sign * (2 * z - 1))  # mpmath.erfinv(sign * (2 * z - 1))
-        return float(x)
 
     def _clipped_sigmaG(self, psi_curve, phi_curve, index, n_sigma=2):
         """This function applies a clipped median filter to a set of likelihood
@@ -383,3 +364,24 @@ class PostProcess:
             cluster_params["mjd"],
         )
         result_list.apply_batch_filter(f)
+
+
+# Additional math utilities -----------
+
+def invert_Gaussian_CDF(z):
+    if z < 0.5:
+        sign = -1
+    else:
+        sign = 1
+    x = sign * np.sqrt(2) * erfinv(sign * (2 * z - 1))  # mpmath.erfinv(sign * (2 * z - 1))
+    return float(x)
+
+def find_sigmaG_coeff(percentiles):
+    z1 = percentiles[0] / 100
+    z2 = percentiles[1] / 100
+
+    x1 = invert_Gaussian_CDF(z1)
+    x2 = invert_Gaussian_CDF(z2)
+    coeff = 1 / (x2 - x1)
+    return coeff
+

--- a/src/kbmod/data_interface.py
+++ b/src/kbmod/data_interface.py
@@ -10,136 +10,127 @@ from .file_utils import *
 from .filters.stats_filters import *
 
 
-class Interface:
-    """This class manages is responsible for loading in data from .fits
-    and auxiliary files.
+def load_input_from_individual_files(
+    im_filepath,
+    time_file,
+    psf_file,
+    mjd_lims,
+    default_psf,
+    verbose=False,
+):
+    """This function loads images and ingests them into an ImageStack.
+
+    Parameters
+    ----------
+    im_filepath : `str`
+        Image file path from which to load images.
+    time_file : `str`
+        File name containing image times.
+    psf_file : `str`
+        File name containing the image-specific PSFs.
+        If set to None the code will use the provided default psf for
+        all images.
+    mjd_lims : `list` of ints
+        Optional MJD limits on the images to search.
+    default_psf : `PSF`
+        The default PSF in case no image-specific PSF is provided.
+    verbose : `bool`
+        Use verbose output (mainly for debugging).
+
+    Returns
+    -------
+    stack : `kbmod.ImageStack`
+        The stack of images loaded.
+    wcs_list : `list`
+        A list of `astropy.wcs.WCS` objects for each image.
+    visit_times : `list`
+        A list of MJD times.
     """
+    print("---------------------------------------")
+    print("Loading Images")
+    print("---------------------------------------")
 
-    def __init__(self):
-        return
+    # Load a mapping from visit numbers to the visit times. This dictionary stays
+    # empty if no time file is specified.
+    image_time_dict = FileUtils.load_time_dictionary(time_file)
+    if verbose:
+        print(f"Loaded {len(image_time_dict)} time stamps.")
 
-    def load_images(
-        self,
-        im_filepath,
-        time_file,
-        psf_file,
-        mjd_lims,
-        default_psf,
-        verbose=False,
-    ):
-        """This function loads images and ingests them into a search object.
+    # Load a mapping from visit numbers to PSFs. This dictionary stays
+    # empty if no time file is specified.
+    image_psf_dict = FileUtils.load_psf_dictionary(psf_file)
+    if verbose:
+        print(f"Loaded {len(image_psf_dict)} image PSFs stamps.")
 
-        Parameters
-        ----------
-        im_filepath : string
-            Image file path from which to load images.
-        time_file : string
-            File name containing image times.
-        psf_file : string
-            File name containing the image-specific PSFs.
-            If set to None the code will use the provided default psf for
-            all images.
-        mjd_lims : list of ints
-            Optional MJD limits on the images to search.
-        default_psf : `psf`
-            The default PSF in case no image-specific PSF is provided.
-        verbose : bool
-            Use verbose output (mainly for debugging).
+    # Retrieve the list of visits (file names) in the data directory.
+    patch_visits = sorted(os.listdir(im_filepath))
 
-        Returns
-        -------
-            stack : `kbmod.ImageStack`
-                The stack of images loaded.
-            wcs_list : `list`
-                 A list of `astropy.wcs.WCS` objects for each image.
-            visit_times : `list`
-                A list of MJD times.
-        """
-        print("---------------------------------------")
-        print("Loading Images")
-        print("---------------------------------------")
-
-        # Load a mapping from visit numbers to the visit times. This dictionary stays
-        # empty if no time file is specified.
-        image_time_dict = FileUtils.load_time_dictionary(time_file)
-        if verbose:
-            print(f"Loaded {len(image_time_dict)} time stamps.")
-
-        # Load a mapping from visit numbers to PSFs. This dictionary stays
-        # empty if no time file is specified.
-        image_psf_dict = FileUtils.load_psf_dictionary(psf_file)
-        if verbose:
-            print(f"Loaded {len(image_psf_dict)} image PSFs stamps.")
-
-        # Retrieve the list of visits (file names) in the data directory.
-        patch_visits = sorted(os.listdir(im_filepath))
-
-        # Load the images themselves.
-        images = []
-        visit_times = []
-        wcs_list = []
-        for visit_file in np.sort(patch_visits):
-            # Skip non-fits files.
-            if not ".fits" in visit_file:
-                if verbose:
-                    print(f"Skipping non-FITS file {visit_file}")
-                continue
-
-            # Compute the full file path for loading.
-            full_file_path = os.path.join(im_filepath, visit_file)
-
-            # Try loading information from the FITS header.
-            visit_id = None
-            with fits.open(full_file_path) as hdu_list:
-                curr_wcs = WCS(hdu_list[1].header)
-
-                # If the visit ID is in header (using Rubin tags), use for the visit ID.
-                # Otherwise extract it from the filename.
-                if "IDNUM" in hdu_list[0].header:
-                    visit_id = str(hdu_list[0].header["IDNUM"])
-                else:
-                    name = os.path.split(full_file_path)[-1]
-                    visit_id = FileUtils.visit_from_file_name(name)
-
-            # Skip files without a valid visit ID.
-            if visit_id is None:
-                if verbose:
-                    print(f"WARNING: Unable to extract visit ID for {visit_file}.")
-                continue
-
-            # Check if the image has a specific PSF.
-            psf = default_psf
-            if visit_id in image_psf_dict:
-                psf = kb.PSF(image_psf_dict[visit_id])
-
-            # Load the image file and set its time.
+    # Load the images themselves.
+    images = []
+    visit_times = []
+    wcs_list = []
+    for visit_file in np.sort(patch_visits):
+        # Skip non-fits files.
+        if not ".fits" in visit_file:
             if verbose:
-                print(f"Loading file: {full_file_path}")
-            img = kb.LayeredImage(full_file_path, psf)
-            time_stamp = img.get_obstime()
+                print(f"Skipping non-FITS file {visit_file}")
+            continue
 
-            # Overload the header's time stamp if needed.
-            if visit_id in image_time_dict:
-                time_stamp = image_time_dict[visit_id]
-                img.set_obstime(time_stamp)
+        # Compute the full file path for loading.
+        full_file_path = os.path.join(im_filepath, visit_file)
 
-            if time_stamp <= 0.0:
-                if verbose:
-                    print(f"WARNING: No valid timestamp provided for {visit_file}.")
-                continue
+        # Try loading information from the FITS header.
+        visit_id = None
+        with fits.open(full_file_path) as hdu_list:
+            curr_wcs = WCS(hdu_list[1].header)
 
-            # Check if we should filter the record based on the time bounds.
-            if mjd_lims is not None and (time_stamp < mjd_lims[0] or time_stamp > mjd_lims[1]):
-                if verbose:
-                    print(f"Pruning file {visit_file} by timestamp={time_stamp}.")
-                continue
+            # If the visit ID is in header (using Rubin tags), use for the visit ID.
+            # Otherwise extract it from the filename.
+            if "IDNUM" in hdu_list[0].header:
+                visit_id = str(hdu_list[0].header["IDNUM"])
+            else:
+                name = os.path.split(full_file_path)[-1]
+                visit_id = FileUtils.visit_from_file_name(name)
 
-            # Save image, time, and WCS information.
-            visit_times.append(time_stamp)
-            images.append(img)
-            wcs_list.append(curr_wcs)
+        # Skip files without a valid visit ID.
+        if visit_id is None:
+            if verbose:
+                print(f"WARNING: Unable to extract visit ID for {visit_file}.")
+            continue
 
-        print(f"Loaded {len(images)} images")
-        stack = kb.ImageStack(images)
+        # Check if the image has a specific PSF.
+        psf = default_psf
+        if visit_id in image_psf_dict:
+            psf = kb.PSF(image_psf_dict[visit_id])
 
-        return (stack, wcs_list, visit_times)
+        # Load the image file and set its time.
+        if verbose:
+            print(f"Loading file: {full_file_path}")
+        img = kb.LayeredImage(full_file_path, psf)
+        time_stamp = img.get_obstime()
+
+        # Overload the header's time stamp if needed.
+        if visit_id in image_time_dict:
+            time_stamp = image_time_dict[visit_id]
+            img.set_obstime(time_stamp)
+
+        if time_stamp <= 0.0:
+            if verbose:
+                print(f"WARNING: No valid timestamp provided for {visit_file}.")
+            continue
+
+        # Check if we should filter the record based on the time bounds.
+        if mjd_lims is not None and (time_stamp < mjd_lims[0] or time_stamp > mjd_lims[1]):
+            if verbose:
+                print(f"Pruning file {visit_file} by timestamp={time_stamp}.")
+            continue
+
+        # Save image, time, and WCS information.
+        visit_times.append(time_stamp)
+        images.append(img)
+        wcs_list.append(curr_wcs)
+
+    print(f"Loaded {len(images)} images")
+    stack = kb.ImageStack(images)
+
+    return (stack, wcs_list, visit_times)

--- a/src/kbmod/data_interface.py
+++ b/src/kbmod/data_interface.py
@@ -160,6 +160,6 @@ def load_input_from_config(config, verbose=False):
         config["time_file"],
         config["psf_file"],
         config["mjd_lims"],
-        kb.PSF(self.config["psf_val"]),  # Default PSF.
+        kb.PSF(config["psf_val"]),  # Default PSF.
         verbose=verbose,
     )

--- a/src/kbmod/data_interface.py
+++ b/src/kbmod/data_interface.py
@@ -6,8 +6,8 @@ import numpy as np
 
 import kbmod.search as kb
 
-from .file_utils import *
-from .filters.stats_filters import *
+from kbmod.configuration import SearchConfiguration
+from kbmod.file_utils import *
 
 
 def load_input_from_individual_files(
@@ -134,3 +134,32 @@ def load_input_from_individual_files(
     stack = kb.ImageStack(images)
 
     return (stack, wcs_list, visit_times)
+
+
+def load_input_from_config(config, verbose=False):
+    """This function loads images and ingests them into an ImageStack.
+
+    Parameters
+    ----------
+    config : `SearchConfiguration`
+        The configuration with the individual file information.
+    verbose : `bool`, optional
+        Use verbose output (mainly for debugging).
+
+    Returns
+    -------
+    stack : `kbmod.ImageStack`
+        The stack of images loaded.
+    wcs_list : `list`
+        A list of `astropy.wcs.WCS` objects for each image.
+    visit_times : `list`
+        A list of MJD times.
+    """
+    return load_input_from_individual_files(
+        config["im_filepath"],
+        config["time_file"],
+        config["psf_file"],
+        config["mjd_lims"],
+        kb.PSF(self.config["psf_val"]),  # Default PSF.
+        verbose=verbose,
+    )

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -13,7 +13,7 @@ from numpy.linalg import lstsq
 import kbmod.search as kb
 
 from .analysis_utils import find_sigmaG_coeff, PostProcess
-from .data_interface import load_input_from_individual_files
+from .data_interface import load_input_from_config
 from .configuration import SearchConfiguration
 from .masking import (
     BitVectorMasker,

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -12,7 +12,7 @@ from numpy.linalg import lstsq
 
 import kbmod.search as kb
 
-from .analysis_utils import PostProcess
+from .analysis_utils import find_sigmaG_coeff, PostProcess
 from .data_interface import Interface
 from .configuration import SearchConfiguration
 from .masking import (
@@ -134,16 +134,9 @@ class run_search:
         search_start = time.time()
         print("Starting Search")
         print("---------------------------------------")
-        param_headers = (
-            "Ecliptic Angle",
-            "Min. Search Angle",
-            "Max Search Angle",
-            "Min Velocity",
-            "Max Velocity",
-        )
-        param_values = (suggested_angle, *search_params["ang_lims"], *search_params["vel_lims"])
-        for header, val in zip(param_headers, param_values):
-            print("%s = %.4f" % (header, val))
+        print(f"Ecliptic Angle = {self.config['average_angle']}")
+        print(f"Search Angle Limits = {search_params['ang_lims']}")
+        print(f"Velocity Limits = {search_params['vel_lims']}")
 
         # If we are using gpu_filtering, enable it and set the parameters.
         if self.config["gpu_filter"]:
@@ -230,7 +223,7 @@ class run_search:
         # segment parallel to the ecliptic is seen under from the image origin.
         if self.config["average_angle"] == None:
             center_pixel = (stack.get_width() / 2, stack.get_height() / 2)
-            self.config["average_angle"] = self._calc_suggested_angle(wcs_list[0], center_pixel)
+            self.config.set("average_angle", self._calc_suggested_angle(wcs_list[0], center_pixel))
 
         # Set up the post processing data structure.
         kb_post_process = PostProcess(self.config, mjds)

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -13,7 +13,7 @@ from numpy.linalg import lstsq
 import kbmod.search as kb
 
 from .analysis_utils import find_sigmaG_coeff, PostProcess
-from .data_interface import Interface
+from .data_interface import load_input_from_individual_files
 from .configuration import SearchConfiguration
 from .masking import (
     BitVectorMasker,
@@ -134,7 +134,7 @@ class run_search:
         search_start = time.time()
         print("Starting Search")
         print("---------------------------------------")
-        print(f"Ecliptic Angle = {self.config['average_angle']}")
+        print(f"Average Angle = {self.config['average_angle']}")
         print(f"Search Angle Limits = {search_params['ang_lims']}")
         print(f"Velocity Limits = {search_params['vel_lims']}")
 
@@ -207,10 +207,9 @@ class run_search:
             The results.
         """
         start = time.time()
-        kb_interface = Interface()
 
         # Load images to search
-        stack, wcs_list, mjds = kb_interface.load_images(
+        stack, wcs_list, mjds = load_input_from_individual_files(
             self.config["im_filepath"],
             self.config["time_file"],
             self.config["psf_file"],

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -209,14 +209,7 @@ class run_search:
         start = time.time()
 
         # Load images to search
-        stack, wcs_list, mjds = load_input_from_individual_files(
-            self.config["im_filepath"],
-            self.config["time_file"],
-            self.config["psf_file"],
-            self.config["mjd_lims"],
-            kb.PSF(self.config["psf_val"]),  # Default PSF.
-            verbose=self.config["debug"],
-        )
+        stack, wcs_list, mjds = load_input_from_config(self.config, verbose=self.config["debug"])
 
         # Compute the suggested search angle from the images. This is a 12 arcsecond
         # segment parallel to the ecliptic is seen under from the image origin.

--- a/tests/test_analysis_utils.py
+++ b/tests/test_analysis_utils.py
@@ -1,7 +1,6 @@
 import unittest
 
 from kbmod.analysis_utils import *
-from kbmod.data_interface import Interface
 from kbmod.fake_data_creator import add_fake_object
 from kbmod.result_list import *
 from kbmod.search import *

--- a/tests/test_data_interface.py
+++ b/tests/test_data_interface.py
@@ -1,7 +1,9 @@
-from kbmod.data_interface import load_input_from_individual_files
 import unittest
-from utils.utils_for_tests import get_absolute_data_path
+
+from kbmod.configuration import SearchConfiguration
+from kbmod.data_interface import load_input_from_individual_files
 from kbmod.search import *
+from utils.utils_for_tests import get_absolute_data_path
 
 
 class test_data_interface(unittest.TestCase):
@@ -36,6 +38,26 @@ class test_data_interface(unittest.TestCase):
             p,
             verbose=False,
         )
+        self.assertEqual(stack.img_count(), 4)
+
+        # Check that each image loaded corrected.
+        true_times = [57130.2, 57130.21, 57130.22, 57162.0]
+        psfs_std = [1.0, 1.0, 1.3, 1.0]
+        for i in range(stack.img_count()):
+            img = stack.get_single_image(i)
+            self.assertEqual(img.get_width(), 64)
+            self.assertEqual(img.get_height(), 64)
+            self.assertAlmostEqual(img.get_obstime(), true_times[i], delta=0.005)
+            self.assertAlmostEqual(psfs_std[i], img.get_psf().get_std())
+
+    def test_file_load_config(self):
+        config = SearchConfiguration()
+        config.set("im_filepath", get_absolute_data_path("fake_images")),
+        config.set("time_file", get_absolute_data_path("fake_times.dat")),
+        config.set("psf_file", get_absolute_data_path("fake_psfs.dat")),
+        config.set("psf_val", 1.0)
+
+        stack, wcs_list, mjds = load_input_from_config(config, verbose=False)
         self.assertEqual(stack.img_count(), 4)
 
         # Check that each image loaded corrected.

--- a/tests/test_data_interface.py
+++ b/tests/test_data_interface.py
@@ -1,4 +1,4 @@
-from kbmod.data_interface import Interface
+from kbmod.data_interface import load_input_from_individual_files
 import unittest
 from utils.utils_for_tests import get_absolute_data_path
 from kbmod.search import *
@@ -6,8 +6,7 @@ from kbmod.search import *
 
 class test_data_interface(unittest.TestCase):
     def test_file_load_basic(self):
-        loader = Interface()
-        stack, wcs_list, mjds = loader.load_images(
+        stack, wcs_list, mjds = load_input_from_individual_files(
             get_absolute_data_path("fake_images"),
             None,
             None,
@@ -29,8 +28,7 @@ class test_data_interface(unittest.TestCase):
     def test_file_load_extra(self):
         p = PSF(1.0)
 
-        loader = Interface()
-        stack, wcs_list, mjds = loader.load_images(
+        stack, wcs_list, mjds = load_input_from_individual_files(
             get_absolute_data_path("fake_images"),
             get_absolute_data_path("fake_times.dat"),
             get_absolute_data_path("fake_psfs.dat"),

--- a/tests/test_data_interface.py
+++ b/tests/test_data_interface.py
@@ -1,7 +1,10 @@
 import unittest
 
 from kbmod.configuration import SearchConfiguration
-from kbmod.data_interface import load_input_from_individual_files
+from kbmod.data_interface import (
+    load_input_from_individual_files,
+    load_input_from_config,
+)
 from kbmod.search import *
 from utils.utils_for_tests import get_absolute_data_path
 

--- a/tests/test_fake_data_creator.py
+++ b/tests/test_fake_data_creator.py
@@ -4,6 +4,7 @@ import unittest
 from kbmod.fake_data_creator import *
 from kbmod.file_utils import *
 from kbmod.search import *
+from kbmod.work_unit import WorkUnit
 
 
 class test_fake_image_creator(unittest.TestCase):
@@ -63,12 +64,12 @@ class test_fake_image_creator(unittest.TestCase):
                 self.assertFalse(Path(name).exists())
 
             # Save the data and check the data now exists.
-            ds.save_fake_data(dir_name)
+            ds.save_fake_data_to_dir(dir_name)
             for name in filenames:
                 self.assertTrue(Path(name).exists())
 
             # Clean the data and check the data no longer exists.
-            ds.delete_fake_data(dir_name)
+            ds.delete_fake_data_dir(dir_name)
             for name in filenames:
                 self.assertFalse(Path(name).exists())
 
@@ -83,6 +84,22 @@ class test_fake_image_creator(unittest.TestCase):
 
             time_load = FileUtils.load_time_dictionary(file_name)
             self.assertEqual(len(time_load), 50)
+
+    def test_save_work_unit(self):
+        num_images = 25
+        ds = FakeDataSet(15, 10, num_images)
+
+        with tempfile.TemporaryDirectory() as dir_name:
+            file_name = f"{dir_name}/fake_work_unit.fits"
+            ds.save_fake_data_to_work_unit(file_name)
+            self.assertTrue(Path(file_name).exists())
+
+            work2 = WorkUnit.from_fits(file_name)
+            self.assertEqual(work2.im_stack.img_count(), num_images)
+            for i in range(num_images):
+                li = work2.im_stack.get_single_image(i)
+                self.assertEqual(li.get_width(), 15)
+                self.assertEqual(li.get_height(), 10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR does a bunch of prep work before making `run_search.py` take a `WorkUnit` as an option. The goal here is to make that later PR simpler and more readable.

Changes include:
- Remove `Interface` class from `data_interface.py` and add an option to load directly from the configuration file.
- Add the ability for the `FakeDataSet` to save to a `WorkUnit`
- Remove a bunch of unneeded parameters being passed to `do_gpu_search`
- Instead of computing (and then possibly overwriting) `suggested_angle` keep the data in the configuration’s `average_angle` parameter and only overwrite if needed.
- Move  `find_sigmaG_coeff` out of `PostProcess` class and make it a standalone function.

Most of the diff lines are the result of removing the `Interface` class and the resulting changes in indentation.