### PR TITLE
Move Stamp Creation Methods Into a Utility Class

### DIFF
--- a/src/kbmod/analysis_utils.py
+++ b/src/kbmod/analysis_utils.py
@@ -122,7 +122,7 @@ class PostProcess:
         """
         stamp_edge = stamp_radius * 2 + 1
         for row in result_list.results:
-            stamps = search.get_stamps(row.trajectory, stamp_radius)
+            stamps = kb.StampCreator.get_stamps(search.get_imagestack(), row.trajectory, stamp_radius)
             row.all_stamps = np.array([np.array(stamp).reshape(stamp_edge, stamp_edge) for stamp in stamps])
 
     def apply_clipped_sigmaG(self, result_list):

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -7,6 +7,7 @@
 #include "layered_image.cpp"
 #include "image_stack.cpp"
 #include "stack_search.cpp"
+#include "stamp_creator.cpp"
 #include "filtering.cpp"
 #include "common.h"
 
@@ -26,6 +27,7 @@ PYBIND11_MODULE(search, m) {
     search::layered_image_bindings(m);
     search::image_stack_bindings(m);
     search::stack_search_bindings(m);
+    search::stamp_creator_bindings(m);
     search::trajectory_bindings(m);
     search::pixel_pos_bindings(m);
     search::image_moments_bindings(m);

--- a/src/kbmod/search/pydocs/stack_search_docs.h
+++ b/src/kbmod/search/pydocs/stack_search_docs.h
@@ -62,22 +62,6 @@ namespace pydocs {
   todo
   )doc";
 
-  static const auto DOC_StackSearch_get_stamps = R"doc(
-  todo
-  )doc";
-
-  static const auto DOC_StackSearch_get_median_stamp = R"doc(
-  todo
-  )doc";
-
-  static const auto DOC_StackSearch_get_mean_stamp = R"doc(
-  todo
-  )doc";
-
-  static const auto DOC_StackSearch_get_summed_stamp = R"doc(
-  todo
-  )doc";
-
   static const auto DOC_StackSearch_get_coadded_stamps = R"doc(
   todo
   )doc";

--- a/src/kbmod/search/pydocs/stamp_creator_docs.h
+++ b/src/kbmod/search/pydocs/stamp_creator_docs.h
@@ -1,0 +1,11 @@
+#ifndef STAMP_CREATOR_DOCS
+#define STAMP_CREATOR_DOCS
+
+namespace pydocs {
+  static const auto DOC_StampCreator = R"doc(
+  todo
+  )doc";
+
+} /* pydocs */
+
+#endif /* STAMP_CREATOR_DOCS */

--- a/src/kbmod/search/pydocs/stamp_creator_docs.h
+++ b/src/kbmod/search/pydocs/stamp_creator_docs.h
@@ -6,6 +6,22 @@ namespace pydocs {
   todo
   )doc";
 
+  static const auto DOC_StampCreator_get_stamps = R"doc(
+  todo
+  )doc";
+
+  static const auto DOC_StampCreator_get_median_stamp = R"doc(
+  todo
+  )doc";
+
+  static const auto DOC_StampCreator_get_mean_stamp = R"doc(
+  todo
+  )doc";
+
+  static const auto DOC_StampCreator_get_summed_stamp = R"doc(
+  todo
+  )doc";
+
 } /* pydocs */
 
 #endif /* STAMP_CREATOR_DOCS */

--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -264,37 +264,6 @@ void StackSearch::fill_psi_phi(const std::vector<RawImage>& psi_imgs, const std:
     }
 }
 
-// For stamps used for visualization we interpolate the pixel values, replace
-// NO_DATA tages with zeros, and return all the stamps (regardless of whether
-// individual timesteps have been filtered).
-std::vector<RawImage> StackSearch::get_stamps(const Trajectory& t, int radius) {
-    std::vector<bool> empty_vect;
-    return stamp_creator.create_stamps(get_imagestack(), t, radius, true /*=interpolate*/, false /*=keep_no_data*/, empty_vect);
-}
-
-// For creating coadded stamps, we do not interpolate the pixel values and keep
-// NO_DATA tagged (so we can filter it out of mean/median).
-RawImage StackSearch::get_median_stamp(const Trajectory& trj, int radius,
-                                       const std::vector<bool>& use_index) {
-    return create_median_image(
-            stamp_creator.create_stamps(get_imagestack(), trj, radius, false /*=interpolate*/, true /*=keep_no_data*/, use_index));
-}
-
-// For creating coadded stamps, we do not interpolate the pixel values and keep
-// NO_DATA tagged (so we can filter it out of mean/median).
-RawImage StackSearch::get_mean_stamp(const Trajectory& trj, int radius, const std::vector<bool>& use_index) {
-    return create_mean_image(
-            stamp_creator.create_stamps(get_imagestack(), trj, radius, false /*=interpolate*/, true /*=keep_no_data*/, use_index));
-}
-
-// For creating summed stamps, we do not interpolate the pixel values and replace NO_DATA
-// with zero (which is the same as filtering it out for the sum).
-RawImage StackSearch::get_summed_stamp(const Trajectory& trj, int radius,
-                                       const std::vector<bool>& use_index) {
-    return create_summed_image(
-            stamp_creator.create_stamps(get_imagestack(), trj, radius, false /*=interpolate*/, false /*=keep_no_data*/, use_index));
-}
-
 bool StackSearch::filter_stamp(const RawImage& img, const StampParameters& params) {
     // Allocate space for the coadd information and initialize to zero.
     const int stamp_width = 2 * params.radius + 1;
@@ -560,10 +529,6 @@ static void stack_search_bindings(py::module& m) {
             .def("get_imagestack", &ks::get_imagestack, py::return_value_policy::reference_internal,
                  pydocs::DOC_StackSearch_get_imagestack)
             // Science Stamp Functions
-            .def("get_stamps", &ks::get_stamps, pydocs::DOC_StackSearch_get_stamps)
-            .def("get_median_stamp", &ks::get_median_stamp, pydocs::DOC_StackSearch_get_median_stamp)
-            .def("get_mean_stamp", &ks::get_mean_stamp, pydocs::DOC_StackSearch_get_mean_stamp)
-            .def("get_summed_stamp", &ks::get_summed_stamp, pydocs::DOC_StackSearch_get_summed_stamp)
             .def("get_coadded_stamps",  // wth is happening here
                  (std::vector<ri>(ks::*)(std::vector<tj>&, std::vector<std::vector<bool>>&,
                                          const search::StampParameters&, bool)) &

--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -325,7 +325,7 @@ std::vector<RawImage> StackSearch::get_coadded_stamps_cpu(std::vector<Trajectory
 
     for (int i = 0; i < num_trajectories; ++i) {
         std::vector<RawImage> stamps =
-                stamp_creator.create_stamps(get_imagestack(), t_array[i], params.radius, false, true, use_index_vect[i]);
+                StampCreator::create_stamps(get_imagestack(), t_array[i], params.radius, false, true, use_index_vect[i]);
 
         RawImage coadd(1, 1);
         switch (params.stamp_type) {

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -15,6 +15,7 @@
 #include "image_stack.h"
 #include "psf.h"
 #include "pydocs/stack_search_docs.h"
+#include "stamp_creator.h"
 
 namespace search {
 class StackSearch {
@@ -55,8 +56,6 @@ public:
     // or replace them with zero, and what indices to use.
     // The indices to use are indicated by use_index: a vector<bool> indicating whether to use
     // each time step. An empty (size=0) vector will use all time steps.
-    std::vector<RawImage> create_stamps(const Trajectory& trj, int radius, bool interpolate,
-                                        bool keep_no_data, const std::vector<bool>& use_index);
     std::vector<RawImage> get_stamps(const Trajectory& t, int radius);
     RawImage get_median_stamp(const Trajectory& trj, int radius, const std::vector<bool>& use_index);
     RawImage get_mean_stamp(const Trajectory& trj, int radius, const std::vector<bool>& use_index);
@@ -103,11 +102,6 @@ protected:
     std::vector<scaleParameters> compute_image_scaling(const std::vector<RawImage>& vect,
                                                        int encoding_bytes) const;
 
-    // Functions to create and access stamps around proposed trajectories or
-    // regions. Used to visualize the results.
-    // This function replaces NO_DATA with a value of 0.0.
-    std::vector<RawImage> create_stamps(Trajectory t, int radius, const std::vector<RawImage*>& imgs,
-                                        bool interpolate);
 
     // Creates list of trajectories to search.
     void create_search_list(int angle_steps, int velocity_steps, float min_ang, float max_ang, float min_vel,
@@ -124,6 +118,7 @@ protected:
     bool psi_phi_generated;
     bool debug_info;
     ImageStack stack;
+    StampCreator stamp_creator;
     std::vector<Trajectory> search_list;
     std::vector<RawImage> psi_images;
     std::vector<RawImage> phi_images;

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -15,6 +15,7 @@
 #include "image_stack.h"
 #include "psf.h"
 #include "pydocs/stack_search_docs.h"
+#include "stamp_creator.h"
 
 namespace search {
 class StackSearch {

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -15,7 +15,6 @@
 #include "image_stack.h"
 #include "psf.h"
 #include "pydocs/stack_search_docs.h"
-#include "stamp_creator.h"
 
 namespace search {
 class StackSearch {
@@ -118,7 +117,6 @@ protected:
     bool psi_phi_generated;
     bool debug_info;
     ImageStack stack;
-    StampCreator stamp_creator;
     std::vector<Trajectory> search_list;
     std::vector<RawImage> psi_images;
     std::vector<RawImage> phi_images;

--- a/src/kbmod/search/stamp_creator.cpp
+++ b/src/kbmod/search/stamp_creator.cpp
@@ -1,0 +1,58 @@
+#include "stamp_creator.h"
+
+
+namespace search {
+
+  StampCreator::StampCreator() {}
+
+
+  std::vector<RawImage> StampCreator::create_stamps(ImageStack stack, const Trajectory& trj, int radius, bool interpolate,
+                                                   bool keep_no_data, const std::vector<bool>& use_index) {
+    if (use_index.size() > 0 && use_index.size() != stack.img_count()) {
+      throw std::runtime_error("Wrong size use_index passed into create_stamps()");
+    }
+    bool use_all_stamps = use_index.size() == 0;
+
+    std::vector<RawImage> stamps;
+    int num_times = stack.img_count();
+    for (int i = 0; i < num_times; ++i) {
+      if (use_all_stamps || use_index[i]) {
+        float time = stack.get_zeroed_time(i);
+        PixelPos pos = {trj.x + time * trj.vx, trj.y + time * trj.vy};
+        //PixelPos pos = get_trajectory_position(trj, i);
+        RawImage& img = stack.get_single_image(i).get_science();
+        stamps.push_back(img.create_stamp(pos.x, pos.y, radius, interpolate, keep_no_data));
+      }
+    }
+    return stamps;
+  }
+
+
+  std::vector<RawImage> StampCreator::create_stamps(ImageStack stack, Trajectory t, int radius, const std::vector<RawImage*>& imgs,
+                                                   bool interpolate) {
+    if (radius < 0) throw std::runtime_error("stamp radius must be at least 0");
+    std::vector<RawImage> stamps;
+    for (int i = 0; i < imgs.size(); ++i) {
+      float time = stack.get_zeroed_time(i);
+      PixelPos pos = {t.x + time * t.vx, t.y + time * t.vy};
+      //PixelPos pos = get_trajectory_position(t, i);
+      stamps.push_back(imgs[i]->create_stamp(pos.x, pos.y, radius, interpolate, false));
+    }
+    return stamps;
+  }
+
+#ifdef Py_PYTHON_H
+  static void stamp_creator_bindings(py::module &m) {
+    using tj = search::Trajectory;
+    using pf = search::PSF;
+    using ri = search::RawImage;
+    using is = search::ImageStack;
+    using sc = search::StampCreator;
+    using ks = search::StackSearch;
+
+    py::class_<sc>(m, "StampCreator", pydocs::DOC_StampCreator)
+      .def(py::init<>());
+  }
+#endif /* Py_PYTHON_H */
+
+} /* namespace search */

--- a/src/kbmod/search/stamp_creator.cpp
+++ b/src/kbmod/search/stamp_creator.cpp
@@ -1,12 +1,9 @@
 #include "stamp_creator.h"
-
-
 namespace search {
 
-  StampCreator::StampCreator() {}
+StampCreator::StampCreator() {}
 
-
-  std::vector<RawImage> StampCreator::create_stamps(ImageStack stack, const Trajectory& trj, int radius, bool interpolate,
+std::vector<RawImage> StampCreator::create_stamps(ImageStack stack, const Trajectory& trj, int radius, bool interpolate,
                                                    bool keep_no_data, const std::vector<bool>& use_index) {
     if (use_index.size() > 0 && use_index.size() != stack.img_count()) {
       throw std::runtime_error("Wrong size use_index passed into create_stamps()");
@@ -17,9 +14,9 @@ namespace search {
     int num_times = stack.img_count();
     for (int i = 0; i < num_times; ++i) {
       if (use_all_stamps || use_index[i]) {
+        // Calculate the trajectory position.
         float time = stack.get_zeroed_time(i);
         PixelPos pos = {trj.x + time * trj.vx, trj.y + time * trj.vy};
-        //PixelPos pos = get_trajectory_position(trj, i);
         RawImage& img = stack.get_single_image(i).get_science();
         stamps.push_back(img.create_stamp(pos.x, pos.y, radius, interpolate, keep_no_data));
       }
@@ -27,31 +24,47 @@ namespace search {
     return stamps;
   }
 
+// For stamps used for visualization we interpolate the pixel values, replace
+// NO_DATA tages with zeros, and return all the stamps (regardless of whether
+// individual timesteps have been filtered).
+std::vector<RawImage> StampCreator::get_stamps(ImageStack stack, const Trajectory& t, int radius) {
+    std::vector<bool> empty_vect;
+    return create_stamps(stack, t, radius, true /*=interpolate*/, false /*=keep_no_data*/, empty_vect);
+}
 
-  std::vector<RawImage> StampCreator::create_stamps(ImageStack stack, Trajectory t, int radius, const std::vector<RawImage*>& imgs,
-                                                   bool interpolate) {
-    if (radius < 0) throw std::runtime_error("stamp radius must be at least 0");
-    std::vector<RawImage> stamps;
-    for (int i = 0; i < imgs.size(); ++i) {
-      float time = stack.get_zeroed_time(i);
-      PixelPos pos = {t.x + time * t.vx, t.y + time * t.vy};
-      //PixelPos pos = get_trajectory_position(t, i);
-      stamps.push_back(imgs[i]->create_stamp(pos.x, pos.y, radius, interpolate, false));
-    }
-    return stamps;
-  }
+// For creating coadded stamps, we do not interpolate the pixel values and keep
+// NO_DATA tagged (so we can filter it out of mean/median).
+RawImage StampCreator::get_median_stamp(ImageStack stack, const Trajectory& trj, int radius,
+                                       const std::vector<bool>& use_index) {
+    return create_median_image(
+            create_stamps(stack, trj, radius, false /*=interpolate*/, true /*=keep_no_data*/, use_index));
+}
+
+// For creating coadded stamps, we do not interpolate the pixel values and keep
+// NO_DATA tagged (so we can filter it out of mean/median).
+RawImage StampCreator::get_mean_stamp(ImageStack stack, const Trajectory& trj, int radius, const std::vector<bool>& use_index) {
+    return create_mean_image(
+            create_stamps(stack, trj, radius, false /*=interpolate*/, true /*=keep_no_data*/, use_index));
+}
+
+// For creating summed stamps, we do not interpolate the pixel values and replace NO_DATA
+// with zero (which is the same as filtering it out for the sum).
+RawImage StampCreator::get_summed_stamp(ImageStack stack, const Trajectory& trj, int radius,
+                                       const std::vector<bool>& use_index) {
+    return create_summed_image(
+            create_stamps(stack, trj, radius, false /*=interpolate*/, false /*=keep_no_data*/, use_index));
+}
 
 #ifdef Py_PYTHON_H
   static void stamp_creator_bindings(py::module &m) {
-    using tj = search::Trajectory;
-    using pf = search::PSF;
-    using ri = search::RawImage;
-    using is = search::ImageStack;
     using sc = search::StampCreator;
-    using ks = search::StackSearch;
 
     py::class_<sc>(m, "StampCreator", pydocs::DOC_StampCreator)
-      .def(py::init<>());
+      .def(py::init<>())
+      .def_static("get_stamps", &sc::get_stamps, pydocs::DOC_StampCreator_get_stamps)
+      .def_static("get_median_stamp", &sc::get_median_stamp, pydocs::DOC_StampCreator_get_median_stamp)
+      .def_static("get_mean_stamp", &sc::get_mean_stamp, pydocs::DOC_StampCreator_get_mean_stamp)
+      .def_static("get_summed_stamp", &sc::get_summed_stamp, pydocs::DOC_StampCreator_get_summed_stamp);
   }
 #endif /* Py_PYTHON_H */
 

--- a/src/kbmod/search/stamp_creator.h
+++ b/src/kbmod/search/stamp_creator.h
@@ -1,0 +1,30 @@
+#ifndef STAMPCREATOR_H_
+#define STAMPCREATOR_H_
+
+#include "common.h"
+#include "image_stack.h"
+#include "pydocs/stamp_creator_docs.h"
+
+namespace search {
+class StampCreator {
+public:
+    StampCreator();
+
+    // Functions for creating science stamps for filtering, visualization, etc. User can specify
+    // the radius of the stamp, whether to interpolate among pixels, whether to keep NO_DATA values
+    // or replace them with zero, and what indices to use.
+    // The indices to use are indicated by use_index: a vector<bool> indicating whether to use
+    // each time step. An empty (size=0) vector will use all time steps.
+    std::vector<RawImage> create_stamps(ImageStack stack, const Trajectory& trj, int radius, bool interpolate,
+                                        bool keep_no_data, const std::vector<bool>& use_index);
+
+    
+    std::vector<RawImage> create_stamps(ImageStack stack, Trajectory t, int radius, const std::vector<RawImage*>& imgs,
+                                                   bool interpolate);
+
+    virtual ~StampCreator(){};
+};
+
+} /* namespace search */
+
+#endif /* STAMPCREATOR_H_ */

--- a/src/kbmod/search/stamp_creator.h
+++ b/src/kbmod/search/stamp_creator.h
@@ -6,21 +6,29 @@
 #include "pydocs/stamp_creator_docs.h"
 
 namespace search {
+/**
+ * Utility class for functions used for creating science stamps for 
+ * filtering, visualization, etc.
+ */
 class StampCreator {
 public:
     StampCreator();
 
-    // Functions for creating science stamps for filtering, visualization, etc. User can specify
+    // Functions science stamps for filtering, visualization, etc. User can specify
     // the radius of the stamp, whether to interpolate among pixels, whether to keep NO_DATA values
     // or replace them with zero, and what indices to use.
     // The indices to use are indicated by use_index: a vector<bool> indicating whether to use
     // each time step. An empty (size=0) vector will use all time steps.
-    std::vector<RawImage> create_stamps(ImageStack stack, const Trajectory& trj, int radius, bool interpolate,
+    static std::vector<RawImage> create_stamps(ImageStack stack, const Trajectory& trj, int radius, bool interpolate,
                                         bool keep_no_data, const std::vector<bool>& use_index);
 
-    
-    std::vector<RawImage> create_stamps(ImageStack stack, Trajectory t, int radius, const std::vector<RawImage*>& imgs,
-                                                   bool interpolate);
+    static std::vector<RawImage> get_stamps(ImageStack stack, const Trajectory& t, int radius);
+
+    static RawImage get_median_stamp(ImageStack stack, const Trajectory& trj, int radius, const std::vector<bool>& use_index);
+
+    static RawImage get_mean_stamp(ImageStack stack, const Trajectory& trj, int radius, const std::vector<bool>& use_index);
+
+    static RawImage get_summed_stamp(ImageStack stack, const Trajectory& trj, int radius, const std::vector<bool>& use_index);
 
     virtual ~StampCreator(){};
 };

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -251,7 +251,7 @@ class test_search(unittest.TestCase):
         self.assertAlmostEqual(best.vy / trj.vy, 1, delta=self.velocity_error)
 
     def test_sci_viz_stamps(self):
-        sci_stamps = self.search.get_stamps(self.trj, 2)
+        sci_stamps = StampCreator.get_stamps(self.search.get_imagestack(), self.trj, 2)
         self.assertEqual(len(sci_stamps), self.imCount)
 
         times = self.stack.build_zeroed_times()
@@ -273,7 +273,7 @@ class test_search(unittest.TestCase):
 
     def test_stacked_sci(self):
         # Compute the stacked science from a single Trajectory.
-        sci = self.search.get_summed_stamp(self.trj, 2, [])
+        sci = StampCreator.get_summed_stamp(self.search.get_imagestack(), self.trj, 2, [])
         self.assertEqual(sci.get_width(), 5)
         self.assertEqual(sci.get_height(), 5)
 
@@ -300,11 +300,11 @@ class test_search(unittest.TestCase):
         goodIdx[1][5] = 0
         goodIdx[1][9] = 0
 
-        medianStamps0 = self.search.get_median_stamp(self.trj, 2, goodIdx[0])
+        medianStamps0 = StampCreator.get_median_stamp(self.search.get_imagestack(), self.trj, 2, goodIdx[0])
         self.assertEqual(medianStamps0.get_width(), 5)
         self.assertEqual(medianStamps0.get_height(), 5)
 
-        medianStamps1 = self.search.get_median_stamp(self.trj, 2, goodIdx[1])
+        medianStamps1 = StampCreator.get_median_stamp(self.search.get_imagestack(), self.trj, 2, goodIdx[1])
         self.assertEqual(medianStamps1.get_width(), 5)
         self.assertEqual(medianStamps1.get_height(), 5)
 
@@ -337,7 +337,7 @@ class test_search(unittest.TestCase):
         trj.vy = 0
 
         # Compute the stacked science from a single Trajectory.
-        medianStamp = self.search.get_median_stamp(trj, 2, self.all_valid)
+        medianStamp = StampCreator.get_median_stamp(self.search.get_imagestack(), trj, 2, self.all_valid)
         self.assertEqual(medianStamp.get_width(), 5)
         self.assertEqual(medianStamp.get_height(), 5)
 
@@ -359,11 +359,11 @@ class test_search(unittest.TestCase):
         goodIdx[1][5] = 0
         goodIdx[1][9] = 0
 
-        meanStamp0 = self.search.get_mean_stamp(self.trj, 2, goodIdx[0])
+        meanStamp0 = StampCreator.get_mean_stamp(self.search.get_imagestack(), self.trj, 2, goodIdx[0])
         self.assertEqual(meanStamp0.get_width(), 5)
         self.assertEqual(meanStamp0.get_height(), 5)
 
-        meanStamp1 = self.search.get_mean_stamp(self.trj, 2, goodIdx[1])
+        meanStamp1 = StampCreator.get_mean_stamp(self.search.get_imagestack(), self.trj, 2, goodIdx[1])
         self.assertEqual(meanStamp1.get_width(), 5)
         self.assertEqual(meanStamp1.get_height(), 5)
 
@@ -400,7 +400,7 @@ class test_search(unittest.TestCase):
         trj.vy = 0
 
         # Compute the stacked science from a single Trajectory.
-        meanStamp = self.search.get_mean_stamp(trj, 2, self.all_valid)
+        meanStamp = StampCreator.get_mean_stamp(self.search.get_imagestack(), trj, 2, self.all_valid)
         self.assertEqual(meanStamp.get_width(), 5)
         self.assertEqual(meanStamp.get_height(), 5)
 

--- a/tests/test_stamp_parity.py
+++ b/tests/test_stamp_parity.py
@@ -96,8 +96,8 @@ class test_search(unittest.TestCase):
         # Check the summed stamps. Note summed stamp does not use goodIdx.
         params.stamp_type = StampType.STAMP_SUM
         stamps_old = [
-            self.search.get_summed_stamp(self.trj, radius, all_valid),
-            self.search.get_summed_stamp(self.trj, radius, all_valid),
+            StampCreator.get_summed_stamp(self.search.get_imagestack(), self.trj, radius, all_valid),
+            StampCreator.get_summed_stamp(self.search.get_imagestack(), self.trj, radius, all_valid),
         ]
         stamps_gpu = self.search.get_coadded_stamps(results, [all_valid, all_valid], params, True)
         stamps_cpu = self.search.get_coadded_stamps(results, [all_valid, all_valid], params, False)
@@ -108,8 +108,8 @@ class test_search(unittest.TestCase):
         # Check the mean stamps.
         params.stamp_type = StampType.STAMP_MEAN
         stamps_old = [
-            self.search.get_mean_stamp(self.trj, radius, goodIdx[0]),
-            self.search.get_mean_stamp(self.trj, radius, goodIdx[1]),
+            StampCreator.get_mean_stamp(self.search.get_imagestack(), self.trj, radius, goodIdx[0]),
+            StampCreator.get_mean_stamp(self.search.get_imagestack(), self.trj, radius, goodIdx[1]),
         ]
         stamps_gpu = self.search.get_coadded_stamps(results, goodIdx, params, True)
         stamps_cpu = self.search.get_coadded_stamps(results, goodIdx, params, False)
@@ -120,8 +120,8 @@ class test_search(unittest.TestCase):
         # Check the median stamps.
         params.stamp_type = StampType.STAMP_MEDIAN
         stamps_old = [
-            self.search.get_median_stamp(self.trj, radius, goodIdx[0]),
-            self.search.get_median_stamp(self.trj, radius, goodIdx[1]),
+            StampCreator.get_median_stamp(self.search.get_imagestack(), self.trj, radius, goodIdx[0]),
+            StampCreator.get_median_stamp(self.search.get_imagestack(), self.trj, radius, goodIdx[1]),
         ]
         stamps_gpu = self.search.get_coadded_stamps(results, goodIdx, params, True)
         stamps_cpu = self.search.get_coadded_stamps(results, goodIdx, params, False)


### PR DESCRIPTION
Since scientific stamp creation no longer depends on the barycentric correction coefficients, we can move those methods from the core search code into a `StampCreator` utility class. 

Since these methods only need the `ImageStack`, they've been implemented as static to be a more convenient interface. 

This PR provides no changes to functionality and closes #362