### PR TITLE
A few small fixes to the stamp generation code

### DIFF
--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -325,7 +325,7 @@ std::vector<RawImage> StackSearch::get_coadded_stamps_cpu(std::vector<Trajectory
 
     for (int i = 0; i < num_trajectories; ++i) {
         std::vector<RawImage> stamps =
-                StampCreator::create_stamps(get_imagestack(), t_array[i], params.radius, false, true, use_index_vect[i]);
+                StampCreator::create_stamps(stack, t_array[i], params.radius, false, true, use_index_vect[i]);
 
         RawImage coadd(1, 1);
         switch (params.stamp_type) {

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -104,7 +104,6 @@ protected:
     std::vector<scaleParameters> compute_image_scaling(const std::vector<RawImage>& vect,
                                                        int encoding_bytes) const;
 
-
     // Creates list of trajectories to search.
     void create_search_list(int angle_steps, int velocity_steps, float min_ang, float max_ang, float min_vel,
                             float max_vel);

--- a/src/kbmod/search/stamp_creator.cpp
+++ b/src/kbmod/search/stamp_creator.cpp
@@ -3,69 +3,71 @@ namespace search {
 
 StampCreator::StampCreator() {}
 
-std::vector<RawImage> StampCreator::create_stamps(ImageStack stack, const Trajectory& trj, int radius, bool interpolate,
-                                                   bool keep_no_data, const std::vector<bool>& use_index) {
+std::vector<RawImage> StampCreator::create_stamps(ImageStack& stack, const Trajectory& trj, int radius,
+                                                  bool interpolate, bool keep_no_data,
+                                                  const std::vector<bool>& use_index) {
     if (use_index.size() > 0 && use_index.size() != stack.img_count()) {
-      throw std::runtime_error("Wrong size use_index passed into create_stamps()");
+        throw std::runtime_error("Wrong size use_index passed into create_stamps()");
     }
     bool use_all_stamps = use_index.size() == 0;
 
     std::vector<RawImage> stamps;
     int num_times = stack.img_count();
     for (int i = 0; i < num_times; ++i) {
-      if (use_all_stamps || use_index[i]) {
-        // Calculate the trajectory position.
-        float time = stack.get_zeroed_time(i);
-        PixelPos pos = {trj.x + time * trj.vx, trj.y + time * trj.vy};
-        RawImage& img = stack.get_single_image(i).get_science();
-        stamps.push_back(img.create_stamp(pos.x, pos.y, radius, interpolate, keep_no_data));
-      }
+        if (use_all_stamps || use_index[i]) {
+            // Calculate the trajectory position.
+            float time = stack.get_zeroed_time(i);
+            PixelPos pos = {trj.x + time * trj.vx, trj.y + time * trj.vy};
+            RawImage& img = stack.get_single_image(i).get_science();
+            stamps.push_back(img.create_stamp(pos.x, pos.y, radius, interpolate, keep_no_data));
+        }
     }
     return stamps;
-  }
+}
 
 // For stamps used for visualization we interpolate the pixel values, replace
 // NO_DATA tages with zeros, and return all the stamps (regardless of whether
 // individual timesteps have been filtered).
-std::vector<RawImage> StampCreator::get_stamps(ImageStack stack, const Trajectory& t, int radius) {
+std::vector<RawImage> StampCreator::get_stamps(ImageStack& stack, const Trajectory& t, int radius) {
     std::vector<bool> empty_vect;
     return create_stamps(stack, t, radius, true /*=interpolate*/, false /*=keep_no_data*/, empty_vect);
 }
 
 // For creating coadded stamps, we do not interpolate the pixel values and keep
 // NO_DATA tagged (so we can filter it out of mean/median).
-RawImage StampCreator::get_median_stamp(ImageStack stack, const Trajectory& trj, int radius,
-                                       const std::vector<bool>& use_index) {
+RawImage StampCreator::get_median_stamp(ImageStack& stack, const Trajectory& trj, int radius,
+                                        const std::vector<bool>& use_index) {
     return create_median_image(
             create_stamps(stack, trj, radius, false /*=interpolate*/, true /*=keep_no_data*/, use_index));
 }
 
 // For creating coadded stamps, we do not interpolate the pixel values and keep
 // NO_DATA tagged (so we can filter it out of mean/median).
-RawImage StampCreator::get_mean_stamp(ImageStack stack, const Trajectory& trj, int radius, const std::vector<bool>& use_index) {
+RawImage StampCreator::get_mean_stamp(ImageStack& stack, const Trajectory& trj, int radius,
+                                      const std::vector<bool>& use_index) {
     return create_mean_image(
             create_stamps(stack, trj, radius, false /*=interpolate*/, true /*=keep_no_data*/, use_index));
 }
 
 // For creating summed stamps, we do not interpolate the pixel values and replace NO_DATA
 // with zero (which is the same as filtering it out for the sum).
-RawImage StampCreator::get_summed_stamp(ImageStack stack, const Trajectory& trj, int radius,
-                                       const std::vector<bool>& use_index) {
+RawImage StampCreator::get_summed_stamp(ImageStack& stack, const Trajectory& trj, int radius,
+                                        const std::vector<bool>& use_index) {
     return create_summed_image(
             create_stamps(stack, trj, radius, false /*=interpolate*/, false /*=keep_no_data*/, use_index));
 }
 
 #ifdef Py_PYTHON_H
-  static void stamp_creator_bindings(py::module &m) {
+static void stamp_creator_bindings(py::module& m) {
     using sc = search::StampCreator;
 
     py::class_<sc>(m, "StampCreator", pydocs::DOC_StampCreator)
-      .def(py::init<>())
-      .def_static("get_stamps", &sc::get_stamps, pydocs::DOC_StampCreator_get_stamps)
-      .def_static("get_median_stamp", &sc::get_median_stamp, pydocs::DOC_StampCreator_get_median_stamp)
-      .def_static("get_mean_stamp", &sc::get_mean_stamp, pydocs::DOC_StampCreator_get_mean_stamp)
-      .def_static("get_summed_stamp", &sc::get_summed_stamp, pydocs::DOC_StampCreator_get_summed_stamp);
-  }
+            .def(py::init<>())
+            .def_static("get_stamps", &sc::get_stamps, pydocs::DOC_StampCreator_get_stamps)
+            .def_static("get_median_stamp", &sc::get_median_stamp, pydocs::DOC_StampCreator_get_median_stamp)
+            .def_static("get_mean_stamp", &sc::get_mean_stamp, pydocs::DOC_StampCreator_get_mean_stamp)
+            .def_static("get_summed_stamp", &sc::get_summed_stamp, pydocs::DOC_StampCreator_get_summed_stamp);
+}
 #endif /* Py_PYTHON_H */
 
 } /* namespace search */

--- a/src/kbmod/search/stamp_creator.h
+++ b/src/kbmod/search/stamp_creator.h
@@ -7,7 +7,7 @@
 
 namespace search {
 /**
- * Utility class for functions used for creating science stamps for 
+ * Utility class for functions used for creating science stamps for
  * filtering, visualization, etc.
  */
 class StampCreator {
@@ -19,16 +19,20 @@ public:
     // or replace them with zero, and what indices to use.
     // The indices to use are indicated by use_index: a vector<bool> indicating whether to use
     // each time step. An empty (size=0) vector will use all time steps.
-    static std::vector<RawImage> create_stamps(ImageStack stack, const Trajectory& trj, int radius, bool interpolate,
-                                        bool keep_no_data, const std::vector<bool>& use_index);
+    static std::vector<RawImage> create_stamps(ImageStack& stack, const Trajectory& trj, int radius,
+                                               bool interpolate, bool keep_no_data,
+                                               const std::vector<bool>& use_index);
 
-    static std::vector<RawImage> get_stamps(ImageStack stack, const Trajectory& t, int radius);
+    static std::vector<RawImage> get_stamps(ImageStack& stack, const Trajectory& t, int radius);
 
-    static RawImage get_median_stamp(ImageStack stack, const Trajectory& trj, int radius, const std::vector<bool>& use_index);
+    static RawImage get_median_stamp(ImageStack& stack, const Trajectory& trj, int radius,
+                                     const std::vector<bool>& use_index);
 
-    static RawImage get_mean_stamp(ImageStack stack, const Trajectory& trj, int radius, const std::vector<bool>& use_index);
+    static RawImage get_mean_stamp(ImageStack& stack, const Trajectory& trj, int radius,
+                                   const std::vector<bool>& use_index);
 
-    static RawImage get_summed_stamp(ImageStack stack, const Trajectory& trj, int radius, const std::vector<bool>& use_index);
+    static RawImage get_summed_stamp(ImageStack& stack, const Trajectory& trj, int radius,
+                                     const std::vector<bool>& use_index);
 
     virtual ~StampCreator(){};
 };


### PR DESCRIPTION
Pass the `ImageStack` by reference for efficiency.  Also applies clag-format to the files.