### PR TITLE
A series of small cleanups

### DIFF
--- a/src/kbmod/masking.py
+++ b/src/kbmod/masking.py
@@ -63,14 +63,11 @@ class BitVectorMasker(ImageMasker):
     ----------
     flags : `int`
         A bit vector of masking flags to apply.
-    exception_list : `list`
-        A list of bit vectors to skip during flagging.
     """
 
-    def __init__(self, flags, exception_list, *args, **kwargs):
+    def __init__(self, flags, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.flags = flags
-        self.exception_list = exception_list
 
     def apply_mask(self, stack):
         """Apply the mask to an image stack.
@@ -86,7 +83,7 @@ class BitVectorMasker(ImageMasker):
             The same stack object to allow chaining.
         """
         if self.flags != 0:
-            stack.apply_mask_flags(self.flags, self.exception_list)
+            stack.apply_mask_flags(self.flags)
         return stack
 
 
@@ -113,7 +110,7 @@ class DictionaryMasker(BitVectorMasker):
             bitvector += 2 ** self.mask_bits_dict[bit]
 
         # Initialize the BitVectorMasker parameters.
-        super().__init__(bitvector, [0], *args, **kwargs)
+        super().__init__(bitvector, *args, **kwargs)
 
 
 class GlobalDictionaryMasker(ImageMasker):

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -52,7 +52,7 @@ class SearchRunner:
 
         # Prioritize the mask_bit_vector over the dictionary based version.
         if config["mask_bit_vector"]:
-            mask_steps.append(BitVectorMasker(config["mask_bit_vector"], [0]))
+            mask_steps.append(BitVectorMasker(config["mask_bit_vector"]))
         elif config["flag_keys"] and len(config["flag_keys"]) > 0:
             mask_steps.append(DictionaryMasker(config["mask_bits_dict"], config["flag_keys"]))
 

--- a/src/kbmod/search/image_stack.cpp
+++ b/src/kbmod/search/image_stack.cpp
@@ -73,9 +73,9 @@ void ImageStack::save_images(const std::string& path) {
 
 const RawImage& ImageStack::get_global_mask() const { return global_mask; }
 
-void ImageStack::apply_mask_flags(int flags, const std::vector<int>& exceptions) {
+void ImageStack::apply_mask_flags(int flags) {
     for (auto& i : images) {
-        i.apply_mask_flags(flags, exceptions);
+        i.apply_mask_flags(flags);
     }
 }
 

--- a/src/kbmod/search/image_stack.h
+++ b/src/kbmod/search/image_stack.h
@@ -31,7 +31,7 @@ public:
 
     // Apply makes to all the images.
     void apply_global_mask(int flags, int threshold);
-    void apply_mask_flags(int flags, const std::vector<int>& exceptions);
+    void apply_mask_flags(int flags);
     void apply_mask_threshold(float thresh);
     void grow_mask(int steps);
     const RawImage& get_global_mask() const;

--- a/src/kbmod/search/layered_image.cpp
+++ b/src/kbmod/search/layered_image.cpp
@@ -83,15 +83,15 @@ void LayeredImage::convolve_given_psf(const PSF& given_psf) {
 
 void LayeredImage::convolve_psf() { convolve_given_psf(psf); }
 
-void LayeredImage::apply_mask_flags(int flags, const std::vector<int>& exceptions) {
-    science.apply_mask(flags, exceptions, mask);
-    variance.apply_mask(flags, exceptions, mask);
+void LayeredImage::apply_mask_flags(int flags) {
+    science.apply_mask(flags, mask);
+    variance.apply_mask(flags, mask);
 }
 
 /* Mask all pixels that are not 0 in global mask */
 void LayeredImage::apply_global_mask(const RawImage& global_mask) {
-    science.apply_mask(0xFFFFFF, {}, global_mask);
-    variance.apply_mask(0xFFFFFF, {}, global_mask);
+    science.apply_mask(0xFFFFFF, global_mask);
+    variance.apply_mask(0xFFFFFF, global_mask);
 }
 
 void LayeredImage::apply_mask_threshold(float thresh) {

--- a/src/kbmod/search/layered_image.h
+++ b/src/kbmod/search/layered_image.h
@@ -40,7 +40,7 @@ public:
     RawImage& get_variance() { return variance; }
 
     // Applies the mask functions to each of the science and variance layers.
-    void apply_mask_flags(int flag, const std::vector<int>& exceptions);
+    void apply_mask_flags(int flag);
     void apply_global_mask(const RawImage& global_mask);
     void apply_mask_threshold(float thresh);
     void grow_mask(int steps);

--- a/src/kbmod/search/pydocs/image_stack_docs.h
+++ b/src/kbmod/search/pydocs/image_stack_docs.h
@@ -40,8 +40,6 @@ static const auto DOC_ImageStack_apply_mask_flags = R"doc(
   ----------
   flag : `int`
       The bit mask of mask flags to use.
-  exceptions : `list` of `int`
-      A list of exceptions (combinations of bits where we do not apply the mask).
   )doc";
 
 static const auto DOC_ImageStack_apply_mask_threshold = R"doc(

--- a/src/kbmod/search/pydocs/layered_image_docs.h
+++ b/src/kbmod/search/pydocs/layered_image_docs.h
@@ -64,8 +64,6 @@ static const auto DOC_LayeredImage_apply_mask_flags = R"doc(
   ----------
   flag : `int`
       The bit mask of mask flags to use.
-  exceptions : `list` of `int`
-      A list of exceptions (combinations of bits where we do not apply the mask).
   )doc";
 
 static const auto DOC_LayeredImage_apply_mask_threshold = R"doc(

--- a/src/kbmod/search/pydocs/raw_image_docs.h
+++ b/src/kbmod/search/pydocs/raw_image_docs.h
@@ -255,8 +255,6 @@ static const auto DOC_RawImage_apply_mask = R"doc(
   ----------
   flag : `int`
       The bit mask of mask flags to use.
-  exceptions : `list` of `int`
-      A list of exceptions (combinations of bits where we do not apply the mask).
   mask : `RawImage`
       The image of pixel mask values.
   )doc";

--- a/src/kbmod/search/raw_image.cpp
+++ b/src/kbmod/search/raw_image.cpp
@@ -229,7 +229,7 @@ void RawImage::convolve(PSF psf) {
 
 void RawImage::apply_mask(int flags, const RawImage& mask) {
     for (unsigned int j = 0; j < height; ++j) {
-	for (unsigned int i = 0; i < width; ++i) {
+	    for (unsigned int i = 0; i < width; ++i) {
             int pix_flags = static_cast<int>(mask.image(j, i));
             if ((flags & pix_flags) != 0) {
                 image(j, i) = NO_DATA;

--- a/src/kbmod/search/raw_image.cpp
+++ b/src/kbmod/search/raw_image.cpp
@@ -480,7 +480,7 @@ RawImage create_median_image(const std::vector<RawImage>& images) {
     int width = images[0].get_width();
     int height = images[0].get_height();
     for (auto& img : images) {
-        assert(img.cols() == width and img.rows() == height);
+        assert(img.get_width() == width and img.get_height() == height);
     }
 
     Image result = Image::Zero(height, width);

--- a/src/kbmod/search/raw_image.cpp
+++ b/src/kbmod/search/raw_image.cpp
@@ -227,18 +227,11 @@ void RawImage::convolve(PSF psf) {
 #endif
 }
 
-// Imma be honest, this function makes no sense to me... I think I transcribed
-// it right, but I'm not sure? If a flag is in mask, it's masked unless it's in
-// exceptions? But why do we have two lists? Is the example above better than this?
-void RawImage::apply_mask(int flags, const std::vector<int>& exceptions, const RawImage& mask) {
+void RawImage::apply_mask(int flags, const RawImage& mask) {
     for (unsigned int j = 0; j < height; ++j) {
-        for (unsigned int i = 0; i < width; ++i) {
+	for (unsigned int i = 0; i < width; ++i) {
             int pix_flags = static_cast<int>(mask.image(j, i));
-            bool is_exception = false;
-            for (auto& e : exceptions) {
-                is_exception = is_exception || e == pix_flags;
-            }
-            if (!is_exception && ((flags & pix_flags) != 0)) {
+            if ((flags & pix_flags) != 0) {
                 image(j, i) = NO_DATA;
             }
         }  // for i

--- a/src/kbmod/search/raw_image.h
+++ b/src/kbmod/search/raw_image.h
@@ -94,12 +94,9 @@ public:
     void convolve(PSF psf);
     void convolve_cpu(PSF& psf);
 
-    // Masks out the array of the image where:
-    //   flags a bit vector of mask flags to apply
-    //       (use 0xFFFFFF to apply all flags)
-    //   exceptions is a vector of pixel flags to ignore
-    //   mask is an image of bit vector mask flags
-    void apply_mask(int flags, const std::vector<int>& exceptions, const RawImage& mask);
+    // Masks out the array of the image where 'flags' is a bit vector of mask flags
+    // to apply (use 0xFFFFFF to apply all flags).
+    void apply_mask(int flags, const RawImage& mask);
 
     // Grow the area of masked array.
     void grow_mask(int steps);

--- a/src/kbmod/search/stamp_creator.cpp
+++ b/src/kbmod/search/stamp_creator.cpp
@@ -190,8 +190,8 @@ std::vector<RawImage> StampCreator::get_coadded_stamps_gpu(ImageStack& stack,
         // should not accept images of different sizes being added to the stack
         // and then get rid of all these for loops in the code
         auto& sci = stack.get_single_image(t).get_science().get_image();
-        assertm(sci.get_width() == width, "Stack image " + t + " has different width than 0th image.");
-        assertm(sci.get_height() == height, "Stack image " + t + " has different width than 0th image.");
+        assertm(sci.cols() == width, "Stack image has different width than 0th image.");
+        assertm(sci.rows() == height, "Stack image has different width than 0th image.");
         data_refs[t] = sci.data();
     }
 

--- a/tests/regression_test.py
+++ b/tests/regression_test.py
@@ -413,7 +413,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--num_times", default=20, help="The number of time steps to use.")
     parser.add_argument("--obs_per_night", default=4, help="The number of same night observations.")
-    parser.add_argument("--flux", default=250.0, help="The flux level to use.")
+    parser.add_argument("--flux", default=500.0, help="The flux level to use.")
     parser.add_argument("--default_psf", default=1.05, help="The default PSF value to use.")
     args = parser.parse_args()
     default_psf = float(args.default_psf)

--- a/tests/test_image_stack.py
+++ b/tests/test_image_stack.py
@@ -65,7 +65,7 @@ class test_ImageStack(unittest.TestCase):
                 for x in range(self.im_stack.get_width()):
                     self.assertTrue(sci.pixel_has_data(y, x))
 
-        self.im_stack.apply_mask_flags(1, [])
+        self.im_stack.apply_mask_flags(1)
 
         # Check that one pixel is masked in each time.
         for i in range(self.num_images):

--- a/tests/test_layered_image.py
+++ b/tests/test_layered_image.py
@@ -171,7 +171,7 @@ class test_LayeredImage(unittest.TestCase):
         mask.set_pixel(10, 13, 3)
 
         # Apply the mask flags to only (10, 11) and (10, 13)
-        self.image.apply_mask_flags(1, [])
+        self.image.apply_mask_flags(1)
 
         science = self.image.get_science()
         for y in range(self.image.get_height()):
@@ -181,29 +181,12 @@ class test_LayeredImage(unittest.TestCase):
                 else:
                     self.assertTrue(science.pixel_has_data(y, x))
 
-    def test_apply_mask_exceptions(self):
-        mask = self.image.get_mask()
-        mask.set_pixel(10, 11, 1)
-        mask.set_pixel(10, 12, 2)
-        mask.set_pixel(10, 13, 3)
-
-        # Apply the mask flags to only (10, 11).
-        self.image.apply_mask_flags(1, [1])
-
-        science = self.image.get_science()
-        for y in range(self.image.get_height()):
-            for x in range(self.image.get_width()):
-                if y == 10 and x == 13:
-                    self.assertFalse(science.pixel_has_data(y, x))
-                else:
-                    self.assertTrue(science.pixel_has_data(y, x))
-
     def test_grow_mask(self):
         mask = self.image.get_mask()
         mask.set_pixel(11, 10, 1)
         mask.set_pixel(12, 10, 1)
         mask.set_pixel(13, 10, 1)
-        self.image.apply_mask_flags(1, [])
+        self.image.apply_mask_flags(1)
         self.image.grow_mask(1)
 
         # Check that the mask has grown to all adjacent pixels.
@@ -221,7 +204,7 @@ class test_LayeredImage(unittest.TestCase):
         mask = self.image.get_mask()
         mask.set_pixel(11, 10, 1)
         mask.set_pixel(12, 10, 1)
-        self.image.apply_mask_flags(1, [])
+        self.image.apply_mask_flags(1)
         self.image.grow_mask(3)
 
         # Check that the mask has grown to all applicable pixels.

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -115,7 +115,7 @@ class test_masking_classes(unittest.TestCase):
                 msk.set_pixel(8, 2 + i, 1)
 
         # Apply the bit vector based mask and check that one pixel per image is masked.
-        self.stack = BitVectorMasker(1, []).apply_mask(self.stack)
+        self.stack = BitVectorMasker(1).apply_mask(self.stack)
         for i in range(self.img_count):
             sci = self.stack.get_single_image(i).get_science()
             for x in range(self.dim_x):

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -439,8 +439,8 @@ class test_RawImage(unittest.TestCase):
         self.assertTrue(np.allclose(median_image.image, expected, atol=1e-6))
 
         # Apply masks to images 1 and 3.
-        imgs[0].apply_mask(1, [], RawImage(np.array([[0, 1], [0, 1], [0, 1]], dtype=np.single)))
-        imgs[2].apply_mask(1, [], RawImage(np.array([[0, 0], [1, 1], [1, 0]], dtype=np.single)))
+        imgs[0].apply_mask(1, RawImage(np.array([[0, 1], [0, 1], [0, 1]], dtype=np.single)))
+        imgs[2].apply_mask(1, RawImage(np.array([[0, 0], [1, 1], [1, 0]], dtype=np.single)))
 
         median_image = create_median_image(imgs)
 
@@ -478,7 +478,7 @@ class test_RawImage(unittest.TestCase):
 
         imgs = list(map(RawImage, arrs))
         for img, mask in zip(imgs, masks):
-            img.apply_mask(1, [], RawImage(mask))
+            img.apply_mask(1, RawImage(mask))
 
         median_image = create_median_image(imgs)
         expected = np.array([[4, 0], [-2, 0], [4.5, 0.1]], dtype=np.single)
@@ -505,8 +505,8 @@ class test_RawImage(unittest.TestCase):
         self.assertTrue(np.allclose(expected, summed_image.image, atol=1e-6))
 
         # Apply masks to images 1 and 3.
-        imgs[0].apply_mask(1, [], RawImage(np.array([[0, 1], [0, 1], [0, 1]], dtype=np.single)))
-        imgs[2].apply_mask(1, [], RawImage(np.array([[0, 0], [1, 1], [1, 0]], dtype=np.single)))
+        imgs[0].apply_mask(1, RawImage(np.array([[0, 1], [0, 1], [0, 1]], dtype=np.single)))
+        imgs[2].apply_mask(1, RawImage(np.array([[0, 0], [1, 1], [1, 0]], dtype=np.single)))
 
         summed_image = create_summed_image(imgs)
 
@@ -538,7 +538,7 @@ class test_RawImage(unittest.TestCase):
             [[[0, 1], [0, 1], [0, 1]], [[0, 0], [0, 0], [0, 1]], [[0, 0], [1, 1], [1, 1]]], dtype=np.single
         )
         for img, mask in zip(imgs, masks):
-            img.apply_mask(1, [], RawImage(mask))
+            img.apply_mask(1, RawImage(mask))
 
         mean_image = create_mean_image(imgs)
 

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -82,6 +82,18 @@ class test_RawImage(unittest.TestCase):
         self.assertEqual(img.get_pixel(5, -1), KB_NO_DATA)
         self.assertEqual(img.get_pixel(self.height, 5), KB_NO_DATA)
 
+    def test_interpolated_add(self):
+        """Test that we can add values to the pixel."""
+        img = RawImage(img=self.array, obs_time=10.0)
+
+        # Get the original value using (r, c) lookup.
+        org_val17 = img.get_pixel(1, 7)
+
+        # Interpolated add uses the cartesian coordinates (x, y)
+        img.interpolated_add(7, 1, 10.0)
+        self.assertLess(img.get_pixel(1, 7), org_val17 + 10.0)
+        self.assertGreater(img.get_pixel(1, 7), org_val17 + 2.0)
+
     def test_approx_equal(self):
         """Test RawImage pixel value setters."""
         img = RawImage(img=self.array, obs_time=10.0)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -69,7 +69,7 @@ class test_search(unittest.TestCase):
             if i % 2 == 0:
                 mask = im.get_mask()
                 mask.set_pixel(self.masked_y, self.masked_x, 1)
-                im.apply_mask_flags(1, [])
+                im.apply_mask_flags(1)
 
             self.imlist.append(im)
         self.stack = ImageStack(self.imlist)
@@ -104,7 +104,7 @@ class test_search(unittest.TestCase):
 
         mask = image2.get_mask()
         mask.set_pixel(9, 4, 1)
-        image2.apply_mask_flags(1, [])
+        image2.apply_mask_flags(1)
 
         # Create a stack from the two objects.
         stack = ImageStack([image1, image2])
@@ -485,7 +485,7 @@ class test_search(unittest.TestCase):
                 mask.set_pixel(1, 1, 1)
             if i == 1:
                 mask.set_pixel(0, 1, 1)
-            im.apply_mask_flags(1, [])
+            im.apply_mask_flags(1)
 
             imlist.append(im)
         stack = ImageStack(imlist)
@@ -545,7 +545,7 @@ class test_search(unittest.TestCase):
                 mask.set_pixel(1, 1, 1)
             if i == 1:
                 mask.set_pixel(0, 1, 1)
-            im.apply_mask_flags(1, [])
+            im.apply_mask_flags(1)
 
             imlist.append(im)
         stack = ImageStack(imlist)

--- a/tests/test_stamp_parity.py
+++ b/tests/test_stamp_parity.py
@@ -72,7 +72,7 @@ class test_search(unittest.TestCase):
             if i % 2 == 0:
                 mask = im.get_mask()
                 mask.set_pixel(self.masked_y, self.masked_x, 1)
-                im.apply_mask_flags(1, [])
+                im.apply_mask_flags(1)
 
             self.imlist.append(im)
         self.stack = ImageStack(self.imlist)


### PR DESCRIPTION
- Fix a couple breakages that started happening when I compiled on a fresh environment.
- Fix the regression test by increasing the flux. I'm not sure why the change to Eigen caused a small difference in `add_fake_object`, but it looks like the `interpolated_add` is spreading out the flux more than the previous implementation. This compensates without changing any of the code.
- Add a test for `interpolated_add`.
- Remove the exceptions list from `apply_map`. This was never used (except in a single test).