### PR TITLE
Move sigmaG filtering to its own file

### DIFF
--- a/src/kbmod/filters/sigma_g_filter.py
+++ b/src/kbmod/filters/sigma_g_filter.py
@@ -1,0 +1,114 @@
+"""Functions to help with the SigmaG clipping.
+
+For more details see:
+Sifting Through the Static: Moving Objectg Detection in Difference Images
+by Smotherman et. al. 2021
+"""
+
+import multiprocessing as mp
+import numpy as np
+from scipy.special import erfinv
+
+from kbmod.result_list import ResultList, ResultRow
+
+
+class SigmaGClipping:
+    """This class contains the basic information for performing SigmaG clipping.
+
+    Attributes
+    ----------
+    low_bnd : `float`
+        The lower bound of the interval to use to estimate the standard deviation.
+    high_bnd : `float`
+        The upper bound of the interval to use to estimate the standard deviation.
+    n_sigma : `float`
+        The number of standard deviations to use for the bound.
+    clip_negative : `bool`
+        A Boolean indicating whether to use negative values when computing
+        standard deviation.
+    coeff : `float`
+        The precomputed coefficient based on the given bounds.
+    """
+
+    def __init__(self, low_bnd=25, high_bnd=75, n_sigma=2, clip_negative=False):
+        if low_bnd > high_bnd or low_bnd <= 0.0 or high_bnd >= 100.0:
+            raise ValueError(f"Invalid bounds [{low_bnd}, {high_bnd}]")
+        if n_sigma <= 0.0:
+            raise ValueError(f"Invalid n_sigma {n_sigma}")
+
+        self.low_bnd = low_bnd
+        self.high_bnd = high_bnd
+        self.clip_negative = clip_negative
+        self.n_sigma = n_sigma
+        self.coeff = SigmaGClipping.find_sigma_g_coeff(low_bnd, high_bnd)
+
+    @staticmethod
+    def find_sigma_g_coeff(low_bnd, high_bnd):
+        x1 = SigmaGClipping.invert_gauss_cdf(low_bnd / 100.0)
+        x2 = SigmaGClipping.invert_gauss_cdf(high_bnd / 100.0)
+        return 1 / (x2 - x1)
+
+    @staticmethod
+    def invert_gauss_cdf(z):
+        if z < 0.5:
+            sign = -1
+        else:
+            sign = 1
+        x = sign * np.sqrt(2) * erfinv(sign * (2 * z - 1))
+        return float(x)
+
+    def compute_clipped_sigma_g(self, lh):
+        """Compute the SigmaG clipping on the given likelihood curve.
+        Points are eliminated if they are more than n_sigma*sigmaG away from the median.
+
+        Parameters
+        ----------
+        lh : numpy array
+            A single likelihood curve.
+
+        Returns
+        -------
+        good_index: numpy array
+            The indices that pass the filtering for a given set of curves.
+        """
+        if self.clip_negative:
+            lower_per, median, upper_per = np.percentile(lh[lh > 0], [self.low_bnd, 50, self.high_bnd])
+        else:
+            lower_per, median, upper_per = np.percentile(lh, [self.low_bnd, 50, self.high_bnd])
+
+        delta = max(upper_per - lower_per, 1e-8)
+        sigmaG = self.coeff * delta
+        nSigmaG = self.n_sigma * sigmaG
+        good_index = np.where(np.logical_and(lh > median - nSigmaG, lh < median + nSigmaG))[0]
+        return good_index
+
+
+def apply_clipped_sigma_g(params, result_list, num_threads=1):
+    """This function applies a clipped median filter to the results of a KBMOD
+    search using sigmaG as a robust estimater of standard deviation.
+
+    Parameters
+    ----------
+    params : `SigmaGClipping`
+        The object to apply the SigmaG clipping.
+    result_list : `ResultList`
+        The values from trajectories. This data gets modified directly by the filtering.
+    num_threads : `int`
+        The number of threads to use.
+    """
+    if num_threads > 1:
+        lh_list = [[row.likelihood_curve] for row in result_list.results]
+
+        keep_idx_results = []
+        pool = mp.Pool(processes=num_threads)
+        keep_idx_results = pool.starmap_async(params.compute_clipped_sigma_g, lh_list)
+        pool.close()
+        pool.join()
+        keep_idx_results = keep_idx_results.get()
+
+        for i, res in enumerate(keep_idx_results):
+            result_list.results[i].filter_indices(res)
+    else:
+        for i, row in enumerate(result_list.results):
+            single_res = params.compute_clipped_sigma_g(row.likelihood_curve)
+            row.filter_indices(single_res)

--- a/src/kbmod/filters/sigma_g_filter.py
+++ b/src/kbmod/filters/sigma_g_filter.py
@@ -79,7 +79,16 @@ class SigmaGClipping:
         delta = max(upper_per - lower_per, 1e-8)
         sigmaG = self.coeff * delta
         nSigmaG = self.n_sigma * sigmaG
-        good_index = np.where(np.logical_and(lh > median - nSigmaG, lh < median + nSigmaG))[0]
+
+        # Its unclear why we only filter zeros for one of the two cases, but leaving the logic in
+        # to stay consistent with the original code.
+        if self.clip_negative:
+            good_index = np.where(
+                np.logical_and(lh != 0, np.logical_and(lh > median - nSigmaG, lh < median + nSigmaG))
+            )[0]
+        else:
+            good_index = np.where(np.logical_and(lh > median - nSigmaG, lh < median + nSigmaG))[0]
+
         return good_index
 
 

--- a/src/kbmod/result_list.py
+++ b/src/kbmod/result_list.py
@@ -1,8 +1,7 @@
 import math
 import multiprocessing as mp
-import os.path as ospath
-
 import numpy as np
+import os.path as ospath
 
 from kbmod.file_utils import *
 
@@ -52,18 +51,16 @@ class ResultRow:
 
         Returns
         -------
-        lc : list
-            The likelihood curve. This is an empty list if either
+        lc : `numpy.ndarray`
+            The light curve. This is an empty array if either
             psi or phi are not set.
         """
         if self.psi_curve is None or self.phi_curve is None:
-            return []
+            return np.array([])
 
-        num_elements = len(self.psi_curve)
-        lc = [0.0] * num_elements
-        for i in range(num_elements):
-            if self.phi_curve[i] != 0.0:
-                lc[i] = self.psi_curve[i] / self.phi_curve[i]
+        masked_phi = np.copy(self.phi_curve)
+        masked_phi[masked_phi == 0] = 1e12
+        lc = np.divide(self.psi_curve, masked_phi)
         return lc
 
     @property
@@ -72,20 +69,16 @@ class ResultRow:
 
         Returns
         -------
-        lh : list
-            The likelihood curve. This is an empty list if either
+        lh : `numpy.ndarray`
+            The likelihood curve. This is an empty array if either
             psi or phi are not set.
         """
-        if self.psi_curve is None:
-            raise ValueError("Psi curve is None")
-        if self.phi_curve is None:
-            raise ValueError("Phi curve is None")
+        if self.psi_curve is None or self.phi_curve is None:
+            return np.array([])
 
-        num_elements = len(self.psi_curve)
-        lh = [0.0] * num_elements
-        for i in range(num_elements):
-            if self.phi_curve[i] > 0.0:
-                lh[i] = self.psi_curve[i] / math.sqrt(self.phi_curve[i])
+        masked_phi = np.copy(self.phi_curve)
+        masked_phi[masked_phi == 0] = 1e12
+        lh = np.divide(self.psi_curve, np.sqrt(masked_phi))
         return lh
 
     def valid_indices_as_booleans(self):
@@ -172,8 +165,8 @@ class ResultRow:
             self.trajectory.lh = 0.0
             self.trajectory.flux = 0.0
         else:
-            self.final_likelihood = psi_sum / math.sqrt(phi_sum)
-            self.trajectory.lh = psi_sum / math.sqrt(phi_sum)
+            self.final_likelihood = psi_sum / np.sqrt(phi_sum)
+            self.trajectory.lh = psi_sum / np.sqrt(phi_sum)
             self.trajectory.flux = psi_sum / phi_sum
 
 
@@ -206,6 +199,10 @@ class ResultList:
         int
             The number of results in the list.
         """
+        return len(self.results)
+
+    def __len__(self):
+        """Return the number of results in the list."""
         return len(self.results)
 
     def clear(self):

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -12,7 +12,7 @@ from numpy.linalg import lstsq
 
 import kbmod.search as kb
 
-from .analysis_utils import find_sigmaG_coeff, PostProcess
+from .analysis_utils import PostProcess
 from .data_interface import load_input_from_config
 from .configuration import SearchConfiguration
 from .masking import (
@@ -24,6 +24,7 @@ from .masking import (
     apply_mask_operations,
 )
 from .result_list import *
+from .filters.sigma_g_filter import SigmaGClipping
 from .work_unit import WorkUnit
 
 
@@ -137,7 +138,10 @@ class SearchRunner:
         # If we are using gpu_filtering, enable it and set the parameters.
         if config["gpu_filter"]:
             print("Using in-line GPU sigmaG filtering methods", flush=True)
-            coeff = find_sigmaG_coeff(config["sigmaG_lims"])
+            coeff = SigmaGClipping.find_sigma_g_coeff(
+                config["sigmaG_lims"][0],
+                config["sigmaG_lims"][1],
+            )
             search.enable_gpu_sigmag_filter(
                 np.array(config["sigmaG_lims"]) / 100.0,
                 coeff,

--- a/tests/test_analysis_utils.py
+++ b/tests/test_analysis_utils.py
@@ -142,35 +142,6 @@ class test_analysis_utils(unittest.TestCase):
             row.set_psi_phi(get_psi_curves[i], get_phi_curves[i])
             self.curve_result_set.append_result(row)
 
-    def test_apply_clipped_sigmaG_single_thread(self):
-        # make sure apply_clipped_sigmaG works when num_cores == 1
-        kb_post_process = PostProcess(self.config, self.time_list)
-
-        kb_post_process.apply_clipped_sigmaG(self.curve_result_set)
-
-        # Check to ensure first three results have all indices passing and the
-        # last index is missing two points.
-        all_indices = [i for i in range(len(self.curve_time_list))]
-        self.assertEqual(self.curve_result_set.results[0].valid_indices, all_indices)
-        self.assertEqual(self.curve_result_set.results[1].valid_indices, all_indices)
-        self.assertEqual(self.curve_result_set.results[2].valid_indices, all_indices)
-        self.assertEqual(self.curve_result_set.results[3].valid_indices, self.good_indices)
-
-    def test_apply_clipped_sigmaG_multi_thread(self):
-        # make sure apply_clipped_sigmaG works when multithreading is enabled
-        self.config["num_cores"] = 2
-        kb_post_process = PostProcess(self.config, self.time_list)
-
-        kb_post_process.apply_clipped_sigmaG(self.curve_result_set)
-
-        # Check to ensure first three results have all indices passing and the
-        # last index is missing two points.
-        all_indices = [i for i in range(len(self.curve_time_list))]
-        self.assertEqual(self.curve_result_set.results[0].valid_indices, all_indices)
-        self.assertEqual(self.curve_result_set.results[1].valid_indices, all_indices)
-        self.assertEqual(self.curve_result_set.results[2].valid_indices, all_indices)
-        self.assertEqual(self.curve_result_set.results[3].valid_indices, self.good_indices)
-
     @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
     def test_apply_stamp_filter(self):
         # object properties

--- a/tests/test_result_list.py
+++ b/tests/test_result_list.py
@@ -1,3 +1,4 @@
+import numpy as np
 import os
 import tempfile
 import unittest
@@ -28,7 +29,7 @@ class test_result_data_row(unittest.TestCase):
 
     def test_filter(self):
         self.assertEqual(self.rdr.valid_indices, [0, 1, 2, 3])
-        self.assertEqual(self.rdr.valid_times(self.times), [1.0, 2.0, 3.0, 4.0])
+        self.assertTrue(np.allclose(self.rdr.valid_times(self.times), [1.0, 2.0, 3.0, 4.0]))
         self.assertEqual(self.rdr.trajectory.obs_count, 4)
         self.assertAlmostEqual(self.rdr.trajectory.flux, 1.15)
         self.assertAlmostEqual(self.rdr.trajectory.lh, 2.3)
@@ -43,20 +44,20 @@ class test_result_data_row(unittest.TestCase):
         self.assertAlmostEqual(self.rdr.trajectory.lh, 2.020725, delta=1e-5)
 
         # The curves and stamps should not change.
-        self.assertEqual(self.rdr.psi_curve, [1.0, 1.1, 1.2, 1.3])
-        self.assertEqual(self.rdr.phi_curve, [1.0, 1.0, 0.0, 2.0])
-        self.assertEqual(self.rdr.all_stamps, [1.0, 1.0, 1.0, 1.0])
+        self.assertTrue(np.allclose(self.rdr.psi_curve, [1.0, 1.1, 1.2, 1.3]))
+        self.assertTrue(np.allclose(self.rdr.phi_curve, [1.0, 1.0, 0.0, 2.0]))
+        self.assertTrue(np.allclose(self.rdr.all_stamps, [1.0, 1.0, 1.0, 1.0]))
 
     def test_set_psi_phi(self):
         self.rdr.set_psi_phi([1.5, 1.1, 1.2, 1.0], [1.0, 0.0, 0.0, 0.5])
-        self.assertEqual(self.rdr.psi_curve, [1.5, 1.1, 1.2, 1.0])
-        self.assertEqual(self.rdr.phi_curve, [1.0, 0.0, 0.0, 0.5])
-        self.assertEqual(self.rdr.light_curve, [1.5, 0.0, 0.0, 2.0])
+        self.assertTrue(np.allclose(self.rdr.psi_curve, [1.5, 1.1, 1.2, 1.0]))
+        self.assertTrue(np.allclose(self.rdr.phi_curve, [1.0, 0.0, 0.0, 0.5]))
+        self.assertTrue(np.allclose(self.rdr.light_curve, [1.5, 0.0, 0.0, 2.0]))
 
     def test_compute_likelihood_curve(self):
         self.rdr.set_psi_phi([1.5, 1.1, 1.2, 1.1], [1.0, 0.0, 4.0, 0.25])
         lh = self.rdr.likelihood_curve
-        self.assertEqual(lh, [1.5, 0.0, 0.6, 2.2])
+        self.assertTrue(np.allclose(lh, [1.5, 0.0, 0.6, 2.2], atol=1e-5))
 
 
 class test_result_list(unittest.TestCase):

--- a/tests/test_result_list.py
+++ b/tests/test_result_list.py
@@ -1,4 +1,3 @@
-import numpy as np
 import os
 import tempfile
 import unittest
@@ -29,7 +28,7 @@ class test_result_data_row(unittest.TestCase):
 
     def test_filter(self):
         self.assertEqual(self.rdr.valid_indices, [0, 1, 2, 3])
-        self.assertTrue(np.allclose(self.rdr.valid_times(self.times), [1.0, 2.0, 3.0, 4.0]))
+        self.assertEqual(self.rdr.valid_times(self.times), [1.0, 2.0, 3.0, 4.0])
         self.assertEqual(self.rdr.trajectory.obs_count, 4)
         self.assertAlmostEqual(self.rdr.trajectory.flux, 1.15)
         self.assertAlmostEqual(self.rdr.trajectory.lh, 2.3)
@@ -44,20 +43,20 @@ class test_result_data_row(unittest.TestCase):
         self.assertAlmostEqual(self.rdr.trajectory.lh, 2.020725, delta=1e-5)
 
         # The curves and stamps should not change.
-        self.assertTrue(np.allclose(self.rdr.psi_curve, [1.0, 1.1, 1.2, 1.3]))
-        self.assertTrue(np.allclose(self.rdr.phi_curve, [1.0, 1.0, 0.0, 2.0]))
-        self.assertTrue(np.allclose(self.rdr.all_stamps, [1.0, 1.0, 1.0, 1.0]))
+        self.assertEqual(self.rdr.psi_curve, [1.0, 1.1, 1.2, 1.3])
+        self.assertEqual(self.rdr.phi_curve, [1.0, 1.0, 0.0, 2.0])
+        self.assertEqual(self.rdr.all_stamps, [1.0, 1.0, 1.0, 1.0])
 
     def test_set_psi_phi(self):
         self.rdr.set_psi_phi([1.5, 1.1, 1.2, 1.0], [1.0, 0.0, 0.0, 0.5])
-        self.assertTrue(np.allclose(self.rdr.psi_curve, [1.5, 1.1, 1.2, 1.0]))
-        self.assertTrue(np.allclose(self.rdr.phi_curve, [1.0, 0.0, 0.0, 0.5]))
-        self.assertTrue(np.allclose(self.rdr.light_curve, [1.5, 0.0, 0.0, 2.0]))
+        self.assertEqual(self.rdr.psi_curve, [1.5, 1.1, 1.2, 1.0])
+        self.assertEqual(self.rdr.phi_curve, [1.0, 0.0, 0.0, 0.5])
+        self.assertEqual(self.rdr.light_curve, [1.5, 0.0, 0.0, 2.0])
 
     def test_compute_likelihood_curve(self):
         self.rdr.set_psi_phi([1.5, 1.1, 1.2, 1.1], [1.0, 0.0, 4.0, 0.25])
         lh = self.rdr.likelihood_curve
-        self.assertTrue(np.allclose(lh, [1.5, 0.0, 0.6, 2.2], atol=1e-5))
+        self.assertEqual(lh, [1.5, 0.0, 0.6, 2.2])
 
 
 class test_result_list(unittest.TestCase):

--- a/tests/test_sigma_g_filter.py
+++ b/tests/test_sigma_g_filter.py
@@ -1,0 +1,82 @@
+import numpy as np
+import unittest
+
+from kbmod.filters.sigma_g_filter import SigmaGClipping, apply_clipped_sigma_g
+from kbmod.result_list import ResultRow, ResultList
+from kbmod.search import Trajectory
+
+
+class test_sigma_g_math(unittest.TestCase):
+    def test_create(self):
+        params = SigmaGClipping()
+        self.assertEqual(params.low_bnd, 25.0)
+        self.assertEqual(params.high_bnd, 75.0)
+        self.assertEqual(params.n_sigma, 2.0)
+        self.assertFalse(params.clip_negative)
+        self.assertAlmostEqual(params.coeff, 0.7413, places=4)
+
+        self.assertRaises(ValueError, SigmaGClipping, n_sigma=-1.0)
+        self.assertRaises(ValueError, SigmaGClipping, low_bnd=90.0, high_bnd=10.0)
+        self.assertRaises(ValueError, SigmaGClipping, high_bnd=101.0)
+        self.assertRaises(ValueError, SigmaGClipping, low_bnd=-1.0)
+
+    def test_sigma_g_clipping(self):
+        num_points = 20
+        params = SigmaGClipping()
+
+        # Everything is good.
+        lh = np.array([(10.0 + i * 0.05) for i in range(num_points)])
+        result = params.compute_clipped_sigma_g(lh)
+        for i in range(num_points):
+            self.assertTrue(i in result)
+
+        # Two outliers
+        lh[2] = 100.0
+        lh[14] = -100.0
+        result = params.compute_clipped_sigma_g(lh)
+        for i in range(num_points):
+            self.assertEqual(i in result, i != 2 and i != 14)
+
+        # Add a third outlier
+        lh[0] = 50.0
+        result = params.compute_clipped_sigma_g(lh)
+        for i in range(num_points):
+            self.assertEqual(i in result, i != 0 and i != 2 and i != 14)
+
+    def test_sigma_g_negative_clipping(self):
+        num_points = 20
+        lh = np.array([(-1.0 + i * 0.2) for i in range(num_points)])
+        lh[2] = 20.0
+        lh[14] = -20.0
+
+        params = SigmaGClipping(clip_negative=True)
+        result = params.compute_clipped_sigma_g(lh)
+        for i in range(num_points):
+            self.assertEqual(i in result, i > 2 and i != 14)
+
+    def test_apply_clipped_sigma_g(self):
+        """Confirm the clipped sigmaG filter works when used in the bulk filter mode."""
+        num_times = 20
+        times = [(10.0 + 0.1 * float(i)) for i in range(num_times)]
+        r_set = ResultList(times, track_filtered=True)
+        phi_all = np.array([0.1] * num_times)
+
+        for i in range(5):
+            row = ResultRow(Trajectory(), num_times)
+            psi_i = np.array([1.0] * num_times)
+            for j in range(i):
+                psi_i[j] = 100.0
+            row.set_psi_phi(psi_i, phi_all)
+            r_set.append_result(row)
+
+        clipper = SigmaGClipping(10, 90)
+        apply_clipped_sigma_g(clipper, r_set, num_threads=2)
+        self.assertEqual(r_set.num_results(), 5)
+
+        # Confirm that the ResultRows were modified in place.
+        for i in range(5):
+            self.assertEqual(len(r_set.results[i].valid_indices), num_times - i)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sigma_g_filter.py
+++ b/tests/test_sigma_g_filter.py
@@ -52,7 +52,7 @@ class test_sigma_g_math(unittest.TestCase):
         params = SigmaGClipping(clip_negative=True)
         result = params.compute_clipped_sigma_g(lh)
         for i in range(num_points):
-            self.assertEqual(i in result, i > 2 and i != 14)
+            self.assertEqual(i in result, i > 2 and i != 5 and i != 14)
 
     def test_apply_clipped_sigma_g(self):
         """Confirm the clipped sigmaG filter works when used in the bulk filter mode."""


### PR DESCRIPTION
This is primarily a cleanup PR. It moves sigmaG filtering to its own file and adds more tests. The goal is to reduce the amount of different code in `analysis_utils.py`.

The code also vectorizes some of the curve computations in `ResultRow`.