### PR TITLE
Add options to output result data

### DIFF
--- a/src/kbmod/file_utils.py
+++ b/src/kbmod/file_utils.py
@@ -5,6 +5,7 @@ import re
 from collections import OrderedDict
 from math import copysign
 from pathlib import Path
+from yaml import dump, safe_load
 
 import astropy.units as u
 import numpy as np
@@ -12,6 +13,7 @@ from astropy.coordinates import *
 from astropy.time import Time
 
 import kbmod.search as kb
+from kbmod.trajectory_utils import trajectory_from_np_object
 
 
 class FileUtils:
@@ -206,31 +208,6 @@ class FileUtils:
         return psf_dict
 
     @staticmethod
-    def trajectory_from_np_object(result):
-        """Transform a numpy object holding trajectory information
-        into a trajectory object.
-
-        Parameters
-        ----------
-        result : np object
-            The result object loaded by numpy.
-
-        Returns
-        -------
-        trj : trajectory
-            The corresponding trajectory object.
-        """
-        trj = kb.Trajectory()
-        trj.x = int(result["x"][0])
-        trj.y = int(result["y"][0])
-        trj.vx = float(result["vx"][0])
-        trj.vy = float(result["vy"][0])
-        trj.flux = float(result["flux"][0])
-        trj.lh = float(result["lh"][0])
-        trj.obs_count = int(result["num_obs"][0])
-        return trj
-
-    @staticmethod
     def save_results_file(filename, results):
         """Save the result trajectories to a file.
 
@@ -280,7 +257,7 @@ class FileUtils:
             A list of trajectory objects
         """
         np_results = FileUtils.load_results_file(filename)
-        results = [FileUtils.trajectory_from_np_object(x) for x in np_results]
+        results = [trajectory_from_np_object(x) for x in np_results]
         return results
 
     @staticmethod

--- a/src/kbmod/file_utils.py
+++ b/src/kbmod/file_utils.py
@@ -5,7 +5,6 @@ import re
 from collections import OrderedDict
 from math import copysign
 from pathlib import Path
-from yaml import dump, safe_load
 
 import astropy.units as u
 import numpy as np

--- a/src/kbmod/result_list.py
+++ b/src/kbmod/result_list.py
@@ -443,7 +443,7 @@ class ResultList:
         """
         yaml_dict = {
             "all_times": self.all_times,
-            "results": [row.to_yaml_string() for row in self.results],
+            "results": [row.to_yaml() for row in self.results],
             "track_filtered": False,
             "filtered": {},
         }

--- a/src/kbmod/result_list.py
+++ b/src/kbmod/result_list.py
@@ -261,13 +261,13 @@ class ResultList:
             The serialized string.
         """
         yaml_dict = safe_load(yaml_str)
-        result = ResultList(yaml_dict["all_times"], yaml_dict["track_filtered"])
-        result.results = [ResultRow.from_yaml(row) for row in yaml_dict["results"]]
+        result_list = ResultList(yaml_dict["all_times"], yaml_dict["track_filtered"])
+        result_list.results = [ResultRow.from_yaml(row) for row in yaml_dict["results"]]
 
-        if result.track_filtered:
+        if result_list.track_filtered:
             for key in yaml_dict["filtered"]:
-                results.filtered[key] = [ResultRow.from_yaml(row) for row in yaml_dict["filtered"][key]]
-        return result
+                result_list.filtered[key] = [ResultRow.from_yaml(row) for row in yaml_dict["filtered"][key]]
+        return result_list
 
     def num_results(self):
         """Return the number of results in the list.
@@ -467,7 +467,7 @@ class ResultList:
         if serialize_filtered and self.track_filtered:
             yaml_dict["track_filtered"] = True
             for key in self.filtered:
-                yaml_dict["filtered"][key] = [row.to_yaml() for row in self.results]
+                yaml_dict["filtered"][key] = [row.to_yaml() for row in self.filtered[key]]
 
         return dump(yaml_dict)
 

--- a/src/kbmod/result_list.py
+++ b/src/kbmod/result_list.py
@@ -49,9 +49,10 @@ class ResultRow:
         result = ResultRow(trj, num_times)
 
         # Copy the values into the object.
-        for attr in cls.__slots__:
+        for attr in ResultRow.__slots__:
             if attr != "trajectory":
                 setattr(result, attr, yaml_params[attr])
+        return result
 
     def to_yaml_string(self):
         """Serial a ResultRow from a YAML formatted string.
@@ -61,10 +62,10 @@ class ResultRow:
         yaml_str : `str`
             The YAML string to deserialize.
         """
-        yaml_dict = {"trajectory": trajectory_to_yaml(self.trj)}
-        for attr in cls.__slots__:
+        yaml_dict = {"trajectory": trajectory_to_yaml(self.trajectory)}
+        for attr in ResultRow.__slots__:
             if attr != "trajectory":
-                yaml_dict[attr] = getattr(result, attr)
+                yaml_dict[attr] = getattr(self, attr)
         return dump(yaml_dict)
 
     def valid_times(self, all_times):

--- a/src/kbmod/result_list.py
+++ b/src/kbmod/result_list.py
@@ -54,8 +54,10 @@ class ResultRow:
                 setattr(result, attr, yaml_params[attr])
 
         # Convert the stamps to np arrays
-        result.stamp = np.array(result.stamp)
-        result.all_stamps = np.array(result.all_stamps)
+        if result.stamp is not None:
+            result.stamp = np.array(result.stamp)
+        if result.all_stamps is not None:
+            result.all_stamps = np.array(result.all_stamps)
 
         return result
 
@@ -68,11 +70,17 @@ class ResultRow:
             The YAML string to deserialize.
         """
         yaml_dict = {"trajectory": trajectory_to_yaml(self.trajectory)}
+
         for attr in ResultRow.__slots__:
             if attr != "trajectory":
                 value = getattr(self, attr)
+
+                # Strip numpy types which cannot be safely loaded by YAML.
                 if type(value) is np.ndarray:
                     value = value.tolist()
+                elif type(value) is np.float64:
+                    value = float(value)
+
                 yaml_dict[attr] = value
         return dump(yaml_dict)
 

--- a/src/kbmod/result_list.py
+++ b/src/kbmod/result_list.py
@@ -1,10 +1,11 @@
 import math
 import multiprocessing as mp
-import os.path as ospath
-
 import numpy as np
+import os.path as ospath
+from yaml import dump, safe_load
 
 from kbmod.file_utils import *
+from kbmod.trajectory_utils import trajectory_from_yaml, trajectory_to_yaml
 
 
 class ResultRow:
@@ -30,6 +31,41 @@ class ResultRow:
         self.psi_curve = None
         self.phi_curve = None
         self.num_times = num_times
+
+    @classmethod
+    def from_yaml_string(cls, yaml_str):
+        """Deserialize a ResultRow from a YAML formatted string.
+
+        Parameters
+        ----------
+        yaml_str : `str`
+            The YAML string to deserialize.
+        """
+        yaml_params = safe_load(yaml_str)
+
+        # Access the minimum values to create the ResultRow object.
+        trj = trajectory_from_yaml(yaml_params["trajectory"])
+        num_times = yaml_params["num_times"]
+        result = ResultRow(trj, num_times)
+
+        # Copy the values into the object.
+        for attr in cls.__slots__:
+            if attr != "trajectory":
+                setattr(result, attr, yaml_params[attr])
+
+    def to_yaml_string(self):
+        """Serial a ResultRow from a YAML formatted string.
+
+        Parameters
+        ----------
+        yaml_str : `str`
+            The YAML string to deserialize.
+        """
+        yaml_dict = {"trajectory": trajectory_to_yaml(self.trj)}
+        for attr in cls.__slots__:
+            if attr != "trajectory":
+                yaml_dict[attr] = getattr(result, attr)
+        return dump(yaml_dict)
 
     def valid_times(self, all_times):
         """Get the times for the indices marked as valid.

--- a/src/kbmod/result_list.py
+++ b/src/kbmod/result_list.py
@@ -52,6 +52,11 @@ class ResultRow:
         for attr in ResultRow.__slots__:
             if attr != "trajectory":
                 setattr(result, attr, yaml_params[attr])
+
+        # Convert the stamps to np arrays
+        result.stamp = np.array(result.stamp)
+        result.all_stamps = np.array(result.all_stamps)
+
         return result
 
     def to_yaml(self):
@@ -65,7 +70,10 @@ class ResultRow:
         yaml_dict = {"trajectory": trajectory_to_yaml(self.trajectory)}
         for attr in ResultRow.__slots__:
             if attr != "trajectory":
-                yaml_dict[attr] = getattr(self, attr)
+                value = getattr(self, attr)
+                if type(value) is np.ndarray:
+                    value = value.tolist()
+                yaml_dict[attr] = value
         return dump(yaml_dict)
 
     def valid_times(self, all_times):

--- a/src/kbmod/result_list.py
+++ b/src/kbmod/result_list.py
@@ -62,7 +62,7 @@ class ResultRow:
         return result
 
     def to_yaml(self):
-        """Serial a ResultRow from a YAML formatted string.
+        """Serialize a ResultRow from a YAML formatted string.
 
         Parameters
         ----------
@@ -253,7 +253,7 @@ class ResultList:
 
     @classmethod
     def from_yaml(cls, yaml_str):
-        """Desrialize a ResultList from a YAML string.
+        """Deserialize a ResultList from a YAML string.
 
         Parameters
         ----------

--- a/src/kbmod/trajectory_utils.py
+++ b/src/kbmod/trajectory_utils.py
@@ -1,0 +1,143 @@
+"""A collection of methods for working with Trajectories
+
+Examples
+--------
+* Create a Trajectory from parameters.
+
+* Convert a Trajectory into another data type.
+
+* Serialize and deserialize a Trajectory.
+"""
+
+import numpy as np
+from yaml import dump, safe_load
+
+from kbmod.search import Trajectory
+
+
+def make_trajectory(x=0, y=0, vx=0.0, vy=0.0, flux=0.0, lh=0.0, obs_count=0):
+    """Create a Trajectory given the parameters with reasonable defaults.
+
+    Parameters
+    ----------
+    x : `int`
+        The starting x coordinate in pixels (default = 0)
+    y : `int`
+        The starting y coordinate in pixels (default = 0)
+    vx : `float`
+        The velocity in x in pixels per day (default = 0.0)
+    vy : `float`
+       The velocity in y in pixels per day (default = 0.0)
+    flux : `float`
+       The flux of the object (default = 0.0)
+    lh : `float`
+       The computed likelihood of the trajectory (default = 0.0)
+    obs_count : `int`
+       The number of observations in a trajectory (default = 0)
+
+    Returns
+    -------
+    trj : `Trajectory`
+        The resulting Trajectory object.
+    """
+    trj = Trajectory()
+    trj.x = x
+    trj.y = y
+    trj.vx = vx
+    trj.vy = vy
+    trj.flux = flux
+    trj.lh = lh
+    trj.obs_count = obs_count
+    return trj
+
+
+def trajectory_from_np_object(result):
+    """Transform a numpy object holding trajectory information
+    into a trajectory object.
+
+    Parameters
+    ----------
+    result : np object
+        The result object loaded by numpy.
+
+    Returns
+    -------
+    trj : `Trajectory`
+        The corresponding trajectory object.
+    """
+    trj = kb.Trajectory()
+    trj.x = int(result["x"][0])
+    trj.y = int(result["y"][0])
+    trj.vx = float(result["vx"][0])
+    trj.vy = float(result["vy"][0])
+    trj.flux = float(result["flux"][0])
+    trj.lh = float(result["lh"][0])
+    trj.obs_count = int(result["num_obs"][0])
+    return trj
+
+
+def trajectory_from_dict(trj_dict):
+    """Create a trajectory from a dictionary of the parameters.
+
+    Parameters
+    ----------
+    trj_dict : `dict`
+        The dictionary of parameters.
+
+    Returns
+    -------
+    trj : `Trajectory`
+        The corresponding trajectory object.
+    """
+    trj = Trajectory()
+    trj.x = int(trj_dict["x"])
+    trj.y = int(trj_dict["y"])
+    trj.vx = float(trj_dict["vx"])
+    trj.vy = float(trj_dict["vy"])
+    trj.flux = float(trj_dict["flux"])
+    trj.lh = float(trj_dict["lh"])
+    trj.obs_count = int(trj_dict["num_obs"])
+    return trj
+
+
+def trajectory_from_yaml(yaml_str):
+    """Parse a Trajectory object from a YAML string.
+
+    Parameters
+    ----------
+    yaml_str : `str`
+        The YAML string.
+
+    Returns
+    -------
+    trj : `Trajectory`
+        The corresponding trajectory object.
+    """
+    yaml_params = safe_load(config)
+    trj = trajectory_from_dict(yaml_params)
+    return trj
+
+
+def trajectory_to_yaml(trj):
+    """Serialize a Trajectory object to a YAML string.
+
+    Parameters
+    ----------
+    trj : `Trajectory`
+        The trajectory object to serialize.
+
+    Returns
+    -------
+    yaml_str : `str`
+        The YAML string.
+    """
+    yaml_dict = {
+        "x": trj.x,
+        "y": trj.y,
+        "vx": trj.vx,
+        "vy": trj.vx,
+        "flux": trj.flux,
+        "lh": trj.lh,
+        "obs_count": obs_count,
+    }
+    return dump(yaml_dict)

--- a/src/kbmod/trajectory_utils.py
+++ b/src/kbmod/trajectory_utils.py
@@ -65,7 +65,7 @@ def trajectory_from_np_object(result):
     trj : `Trajectory`
         The corresponding trajectory object.
     """
-    trj = kb.Trajectory()
+    trj = Trajectory()
     trj.x = int(result["x"][0])
     trj.y = int(result["y"][0])
     trj.vx = float(result["vx"][0])
@@ -96,7 +96,7 @@ def trajectory_from_dict(trj_dict):
     trj.vy = float(trj_dict["vy"])
     trj.flux = float(trj_dict["flux"])
     trj.lh = float(trj_dict["lh"])
-    trj.obs_count = int(trj_dict["num_obs"])
+    trj.obs_count = int(trj_dict["obs_count"])
     return trj
 
 
@@ -113,7 +113,7 @@ def trajectory_from_yaml(yaml_str):
     trj : `Trajectory`
         The corresponding trajectory object.
     """
-    yaml_params = safe_load(config)
+    yaml_params = safe_load(yaml_str)
     trj = trajectory_from_dict(yaml_params)
     return trj
 
@@ -135,9 +135,9 @@ def trajectory_to_yaml(trj):
         "x": trj.x,
         "y": trj.y,
         "vx": trj.vx,
-        "vy": trj.vx,
+        "vy": trj.vy,
         "flux": trj.flux,
         "lh": trj.lh,
-        "obs_count": obs_count,
+        "obs_count": trj.obs_count,
     }
     return dump(yaml_dict)

--- a/tests/regression_test.py
+++ b/tests/regression_test.py
@@ -16,6 +16,7 @@ from kbmod.fake_data_creator import add_fake_object
 from kbmod.file_utils import *
 from kbmod.run_search import SearchRunner
 from kbmod.search import *
+from kbmod.trajectory_utils import make_trajectory
 
 
 def ave_trajectory_distance(trjA, trjB, times=[0.0]):
@@ -148,33 +149,6 @@ def find_set_difference(traj_query, traj_base, threshold, times=[0.0]):
         else:
             results.append(query)
     return results
-
-
-def make_trajectory(x, y, vx, vy, flux):
-    """Create a fake Trajectory given the parameters.
-
-    Arguments:
-        x : int
-            The starting x coordinate.
-        y : int
-            The starting y coordinate.
-        vx : float
-            The velocity in x.
-        vy : float
-            The velocity in y.
-        flux : float
-            The flux of the object.
-
-    Returns:
-        A Trajectory object.
-    """
-    t = Trajectory()
-    t.x = x
-    t.y = y
-    t.vx = vx
-    t.vy = vy
-    t.flux = flux
-    return t
 
 
 def make_fake_ImageStack(times, trjs, psf_vals):

--- a/tests/test_result_list.py
+++ b/tests/test_result_list.py
@@ -24,8 +24,8 @@ class test_result_data_row(unittest.TestCase):
         self.rdr = ResultRow(self.trj, self.num_times)
         self.rdr.set_psi_phi([1.0, 1.1, 1.2, 1.3], [1.0, 1.0, 0.0, 2.0])
 
-        example_stample = np.ones((5, 5))
-        self.rdr.all_stamps = np.array([np.copy(example_stample) for _ in range(4)])
+        example_stamp = np.ones((5, 5))
+        self.rdr.all_stamps = np.array([np.copy(example_stamp) for _ in range(4)])
 
     def test_get_boolean_valid_indices(self):
         self.assertEqual(self.rdr.valid_indices_as_booleans(), [True, True, True, True])

--- a/tests/test_result_list.py
+++ b/tests/test_result_list.py
@@ -1,4 +1,5 @@
 import os
+import numpy as np
 import tempfile
 import unittest
 from pathlib import Path
@@ -18,7 +19,9 @@ class test_result_data_row(unittest.TestCase):
         self.num_times = len(self.times)
         self.rdr = ResultRow(self.trj, self.num_times)
         self.rdr.set_psi_phi([1.0, 1.1, 1.2, 1.3], [1.0, 1.0, 0.0, 2.0])
-        self.rdr.all_stamps = [1.0, 1.0, 1.0, 1.0]
+
+        example_stample = np.ones((5, 5))
+        self.rdr.all_stamps = np.array([example_stample for _ in range(4)])
 
     def test_get_boolean_valid_indices(self):
         self.assertEqual(self.rdr.valid_indices_as_booleans(), [True, True, True, True])
@@ -69,6 +72,9 @@ class test_result_data_row(unittest.TestCase):
         self.assertEqual(row2.trajectory.obs_count, 4)
         self.assertIsNone(row2.stamp)
         self.assertIsNotNone(row2.all_stamps)
+        self.assertEqual(row2.all_stamps.shape[0], 4)
+        self.assertEqual(row2.all_stamps.shape[1], 5)
+        self.assertEqual(row2.all_stamps.shape[2], 5)
 
         self.assertIsNotNone(row2.trajectory)
         self.assertAlmostEqual(row2.trajectory.flux, 1.15)

--- a/tests/test_result_list.py
+++ b/tests/test_result_list.py
@@ -21,7 +21,7 @@ class test_result_data_row(unittest.TestCase):
         self.rdr.set_psi_phi([1.0, 1.1, 1.2, 1.3], [1.0, 1.0, 0.0, 2.0])
 
         example_stample = np.ones((5, 5))
-        self.rdr.all_stamps = np.array([example_stample for _ in range(4)])
+        self.rdr.all_stamps = np.array([np.copy(example_stample) for _ in range(4)])
 
     def test_get_boolean_valid_indices(self):
         self.assertEqual(self.rdr.valid_indices_as_booleans(), [True, True, True, True])
@@ -48,7 +48,7 @@ class test_result_data_row(unittest.TestCase):
         # The curves and stamps should not change.
         self.assertEqual(self.rdr.psi_curve, [1.0, 1.1, 1.2, 1.3])
         self.assertEqual(self.rdr.phi_curve, [1.0, 1.0, 0.0, 2.0])
-        self.assertEqual(self.rdr.all_stamps, [1.0, 1.0, 1.0, 1.0])
+        self.assertEqual(self.rdr.all_stamps.shape, (4, 5, 5))
 
     def test_set_psi_phi(self):
         self.rdr.set_psi_phi([1.5, 1.1, 1.2, 1.0], [1.0, 0.0, 0.0, 0.5])
@@ -236,8 +236,8 @@ class test_result_list(unittest.TestCase):
         rs_a = ResultList.from_yaml(yaml_str_a)
         self.assertEqual(len(rs_a.results), len(inds))
         for i in range(len(inds)):
-            self.assertAlmostEqual(res_a.results[i].psi_curve[0], i)
-            self.assertAlmostEqual(res_a.results[i].phi_curve[0], 0.01 * i)
+            self.assertAlmostEqual(rs_a.results[i].psi_curve[0], i)
+            self.assertAlmostEqual(rs_a.results[i].phi_curve[0], 0.01 * i)
         self.assertFalse(rs_a.track_filtered)
         self.assertEqual(len(rs_a.filtered), 0)
 
@@ -248,8 +248,8 @@ class test_result_list(unittest.TestCase):
         rs_b = ResultList.from_yaml(yaml_str_b)
         self.assertEqual(len(rs_b.results), len(inds))
         for i in range(len(inds)):
-            self.assertAlmostEqual(res_b.results[i].psi_curve[0], i)
-            self.assertAlmostEqual(res_b.results[i].phi_curve[0], 0.01 * i)
+            self.assertAlmostEqual(rs_b.results[i].psi_curve[0], i)
+            self.assertAlmostEqual(rs_b.results[i].phi_curve[0], 0.01 * i)
         self.assertTrue(rs_b.track_filtered)
         self.assertEqual(len(rs_b.filtered), 1)
         self.assertEqual(len(rs_b.filtered["test"]), 10 - len(inds))

--- a/tests/test_result_list.py
+++ b/tests/test_result_list.py
@@ -58,6 +58,22 @@ class test_result_data_row(unittest.TestCase):
         lh = self.rdr.likelihood_curve
         self.assertEqual(lh, [1.5, 0.0, 0.6, 2.2])
 
+    def test_to_from_yaml(self):
+        yaml_str = self.rdr.to_yaml_string()
+        self.assertGreater(len(yaml_str), 0)
+
+        row2 = ResultRow.from_yaml_string(yaml_str)
+        self.assertAlmostEqual(row2.lh, 2.3)
+        self.assertEqual(row2.valid_indices, [0, 1, 2, 3])
+        self.assertEqual(row2.valid_times(self.times), [1.0, 2.0, 3.0, 4.0])
+        self.assertEqual(row2.trajectory.obs_count, 4)
+        self.assertIsNone(row2.stamp)
+        self.assertIsNone(row2.all_stamps)
+
+        self.assertIsNotNone(row2.trajectory)
+        self.assertAlmostEqual(row2.trajectory.flux, 1.15)
+        self.assertAlmostEqual(row2.trajectory.lh, 2.3)
+
 
 class test_result_list(unittest.TestCase):
     def setUp(self):

--- a/tests/test_result_list.py
+++ b/tests/test_result_list.py
@@ -63,12 +63,12 @@ class test_result_data_row(unittest.TestCase):
         self.assertGreater(len(yaml_str), 0)
 
         row2 = ResultRow.from_yaml_string(yaml_str)
-        self.assertAlmostEqual(row2.lh, 2.3)
+        self.assertAlmostEqual(row2.final_likelihood, 2.3)
         self.assertEqual(row2.valid_indices, [0, 1, 2, 3])
         self.assertEqual(row2.valid_times(self.times), [1.0, 2.0, 3.0, 4.0])
         self.assertEqual(row2.trajectory.obs_count, 4)
         self.assertIsNone(row2.stamp)
-        self.assertIsNone(row2.all_stamps)
+        self.assertIsNotNone(row2.all_stamps)
 
         self.assertIsNotNone(row2.trajectory)
         self.assertAlmostEqual(row2.trajectory.flux, 1.15)

--- a/tests/test_result_list.py
+++ b/tests/test_result_list.py
@@ -236,8 +236,8 @@ class test_result_list(unittest.TestCase):
         rs_a = ResultList.from_yaml(yaml_str_a)
         self.assertEqual(len(rs_a.results), len(inds))
         for i in range(len(inds)):
-            self.assertAlmostEqual(rs_a.results[i].psi_curve[0], i)
-            self.assertAlmostEqual(rs_a.results[i].phi_curve[0], 0.01 * i)
+            self.assertAlmostEqual(rs_a.results[i].psi_curve[0], inds[i])
+            self.assertAlmostEqual(rs_a.results[i].phi_curve[0], 0.01 * inds[i])
         self.assertFalse(rs_a.track_filtered)
         self.assertEqual(len(rs_a.filtered), 0)
 
@@ -248,8 +248,8 @@ class test_result_list(unittest.TestCase):
         rs_b = ResultList.from_yaml(yaml_str_b)
         self.assertEqual(len(rs_b.results), len(inds))
         for i in range(len(inds)):
-            self.assertAlmostEqual(rs_b.results[i].psi_curve[0], i)
-            self.assertAlmostEqual(rs_b.results[i].phi_curve[0], 0.01 * i)
+            self.assertAlmostEqual(rs_b.results[i].psi_curve[0], inds[i])
+            self.assertAlmostEqual(rs_b.results[i].phi_curve[0], 0.01 * inds[i])
         self.assertTrue(rs_b.track_filtered)
         self.assertEqual(len(rs_b.filtered), 1)
         self.assertEqual(len(rs_b.filtered["test"]), 10 - len(inds))

--- a/tests/test_trajectory_utils.py
+++ b/tests/test_trajectory_utils.py
@@ -1,0 +1,76 @@
+from kbmod.trajectory_utils import *
+from kbmod.search import *
+
+
+class test_trajectory_utils(unittest.TestCase):
+    def test_make_trajectory(self):
+        trj = make_trajectory(x=1, y=2, vx=3.0, vy=4.0, flux=5.0, lh=6.0, obs_count=7)
+        self.assertEqual(trj.x, 1)
+        self.assertEqual(trj.y, 2)
+        self.assertEqual(trj.xv, 3.0)
+        self.assertEqual(trj.yv, 4.0)
+        self.assertEqual(trj.flux, 5.0)
+        self.assertEqual(trj.lh, 6.0)
+        self.assertEqual(trj.obs_count, 7)
+
+    def test_trajectory_from_np_object(self):
+        np_obj = np.array(
+            [(300.0, 750.0, 106.0, 44.0, 9.52, -0.5, 10.0)],
+            dtype=[
+                ("lh", "<f8"),
+                ("flux", "<f8"),
+                ("x", "<f8"),
+                ("y", "<f8"),
+                ("vx", "<f8"),
+                ("vy", "<f8"),
+                ("num_obs", "<f8"),
+            ],
+        )
+
+        trj = trajectory_from_np_object(np_obj)
+        self.assertEqual(trj.x, 106)
+        self.assertEqual(trj.y, 44)
+        self.assertEqual(trj.xv, 9.52)
+        self.assertEqual(trj.yv, -0.5)
+        self.assertEqual(trj.flux, 750.0)
+        self.assertEqual(trj.lh, 300.0)
+        self.assertEqual(trj.obs_count, 10)
+
+    def test_trajectory_from_dict(self):
+        trj_dict = {
+            "x": 1,
+            "y": 2,
+            "vx": 3.0,
+            "vy": 4.0,
+            "flux": 5.0,
+            "lh": 6.0,
+            "obs_count": 7,
+        }
+        trj = trajectory_from_dict(trj_dict)
+
+        self.assertEqual(trj.x, 1)
+        self.assertEqual(trj.y, 2)
+        self.assertEqual(trj.xv, 3.0)
+        self.assertEqual(trj.yv, 4.0)
+        self.assertEqual(trj.flux, 5.0)
+        self.assertEqual(trj.lh, 6.0)
+        self.assertEqual(trj.obs_count, 7)
+
+    def test_trajectory_yaml(self):
+        """Test serializing and then deserializing the Trajectory to a YAML."""
+        org_trj = make_trajectory(x=1, y=2, vx=3.0, vy=4.0, flux=5.0, lh=6.0, obs_count=7)
+        yaml_str = trajectory_to_yaml(org_trj)
+        self.assertGreater(len(yaml_str), 0)
+
+        new_trj = trajectory_from_yaml(yaml_str)
+        self.assertEqual(new_trj.x, 1)
+        self.assertEqual(new_trj.y, 2)
+        self.assertEqual(new_trj.xv, 3.0)
+        self.assertEqual(new_trj.yv, 4.0)
+        self.assertEqual(new_trj.flux, 5.0)
+        self.assertEqual(new_trj.lh, 6.0)
+        self.assertEqual(new_trj.obs_count, 7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_trajectory_utils.py
+++ b/tests/test_trajectory_utils.py
@@ -1,3 +1,5 @@
+import unittest
+
 from kbmod.trajectory_utils import *
 from kbmod.search import *
 
@@ -7,8 +9,8 @@ class test_trajectory_utils(unittest.TestCase):
         trj = make_trajectory(x=1, y=2, vx=3.0, vy=4.0, flux=5.0, lh=6.0, obs_count=7)
         self.assertEqual(trj.x, 1)
         self.assertEqual(trj.y, 2)
-        self.assertEqual(trj.xv, 3.0)
-        self.assertEqual(trj.yv, 4.0)
+        self.assertEqual(trj.vx, 3.0)
+        self.assertEqual(trj.vy, 4.0)
         self.assertEqual(trj.flux, 5.0)
         self.assertEqual(trj.lh, 6.0)
         self.assertEqual(trj.obs_count, 7)
@@ -30,8 +32,8 @@ class test_trajectory_utils(unittest.TestCase):
         trj = trajectory_from_np_object(np_obj)
         self.assertEqual(trj.x, 106)
         self.assertEqual(trj.y, 44)
-        self.assertEqual(trj.xv, 9.52)
-        self.assertEqual(trj.yv, -0.5)
+        self.assertAlmostEqual(trj.vx, 9.52, delta=1e-5)
+        self.assertAlmostEqual(trj.vy, -0.5, delta=1e-5)
         self.assertEqual(trj.flux, 750.0)
         self.assertEqual(trj.lh, 300.0)
         self.assertEqual(trj.obs_count, 10)
@@ -50,8 +52,8 @@ class test_trajectory_utils(unittest.TestCase):
 
         self.assertEqual(trj.x, 1)
         self.assertEqual(trj.y, 2)
-        self.assertEqual(trj.xv, 3.0)
-        self.assertEqual(trj.yv, 4.0)
+        self.assertEqual(trj.vx, 3.0)
+        self.assertEqual(trj.vy, 4.0)
         self.assertEqual(trj.flux, 5.0)
         self.assertEqual(trj.lh, 6.0)
         self.assertEqual(trj.obs_count, 7)
@@ -65,8 +67,8 @@ class test_trajectory_utils(unittest.TestCase):
         new_trj = trajectory_from_yaml(yaml_str)
         self.assertEqual(new_trj.x, 1)
         self.assertEqual(new_trj.y, 2)
-        self.assertEqual(new_trj.xv, 3.0)
-        self.assertEqual(new_trj.yv, 4.0)
+        self.assertEqual(new_trj.vx, 3.0)
+        self.assertEqual(new_trj.vy, 4.0)
         self.assertEqual(new_trj.flux, 5.0)
         self.assertEqual(new_trj.lh, 6.0)
         self.assertEqual(new_trj.obs_count, 7)


### PR DESCRIPTION
Allow users to output options in a two different formats:
1) serialize the results to YAML for data transfer. This is currently inefficient, because we convert the stamps from numpy arrays to lists for YAML compatibility (numpy arrays need unsafe loading in YAML). We can improve this in the future.
2) extract the results data to an astropy table for analysis

This PR also moves some of the trajectory serialization into its own file for organizational purposes.