### PR TITLE
Remove bendis as target tag from PR worklow.

### DIFF
--- a/.github/workflows/pr_tests.yaml
+++ b/.github/workflows/pr_tests.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   test-fiducial:
     name:  Testing in kbmod_ci env.
-    runs-on: [self-hosted, bendis]
+    runs-on: self-hosted
     strategy:
       fail-fast: true
     defaults:


### PR DESCRIPTION
Fix the reason why current PR jobs hang indefinitely (I forgot to tag the machine 'bendis" last week when starting the runner again after an update).