### PR TITLE
Add WCS information to the WorkUnit

### DIFF
--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -87,7 +87,7 @@ class WorkUnit:
                 imgs.append(LayeredImage(sci, var, msk, p))
 
         im_stack = ImageStack(imgs)
-	result = WorkUnit(im_stack=im_stack, config=config, wcs=global_wcs)
+        result = WorkUnit(im_stack=im_stack, config=config, wcs=global_wcs)
         result.per_image_wcs = per_image_wcs
         return result
 
@@ -117,9 +117,14 @@ class WorkUnit:
         # the metadata (empty), and the configuration.
         hdul = fits.HDUList()
         pri = fits.PrimaryHDU()
-        if self.wcs is not None:
-            pri.header = self.wcs.to_header()
         pri.header["NUMIMG"] = self.im_stack.img_count()
+
+        # If the global WCS exists, append the corresponding keys.
+        if self.wcs is not None:
+            wcs_header = self.wcs.to_header()
+            for key in wcs_header:
+                pri.header[key] = wcs_header[key]
+
         hdul.append(pri)
 
         meta_hdu = fits.BinTableHDU()
@@ -177,7 +182,7 @@ def extract_wcs(hdu):
         return None
     if "CRPIX1" not in hdu.header or "CRPIX2" not in hdu.header:
         return None
-    
+
     curr_wcs = WCS(hdu.header)
     if curr_wcs is None:
         return None

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -2,9 +2,11 @@ import math
 
 from astropy.io import fits
 from astropy.table import Table
+from astropy.utils.exceptions import AstropyWarning
 from astropy.wcs import WCS
 import numpy as np
 from pathlib import Path
+import warnings
 
 from kbmod.configuration import SearchConfiguration
 from kbmod.search import ImageStack, LayeredImage, PSF, RawImage
@@ -60,7 +62,11 @@ class WorkUnit:
             config = SearchConfiguration.from_hdu(hdul["kbmod_config"])
 
             # Read in the global WCS from extension 0 if the information exists.
-            global_wcs = extract_wcs(hdul[0])
+            # We filter the warning that the image dimension does not match the WCS dimension
+            # since the primary header does not have an image.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", AstropyWarning)
+                global_wcs = extract_wcs(hdul[0])
 
             # Read the size and order information from the primary header.
             num_images = hdul[0].header["NUMIMG"]

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -41,7 +41,7 @@ class test_work_unit(unittest.TestCase):
         self.config.set("mask_bits_dict", {"A": 1, "B": 2})
         self.config.set("repeated_flag_keys", None)
 
-        # Creater a fake WCS
+        # Create a fake WCS
         header_dict = {
             "WCSAXES": 2,
             "CTYPE1": "RA---TAN-SIP",

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -40,11 +40,39 @@ class test_work_unit(unittest.TestCase):
         self.config.set("mask_bits_dict", {"A": 1, "B": 2})
         self.config.set("repeated_flag_keys", None)
 
+        # Creater a fake WCS
+        header_dict = {
+            "WCSAXES": 2,
+            "CTYPE1": "RA---TAN-SIP",
+            "CTYPE2": "DEC--TAN-SIP",
+            "CRVAL1": 200.614997245422,
+            "CRVAL2": -7.78878863332778,
+            "CRPIX1": 1033.934327,
+            "CRPIX2": 2043.548284,
+            "CD1_1": -1.13926485986789e-07,
+            "CD1_2": 7.31839748843125e-05,
+            "CD2_1": -7.30064978350695e-05,
+            "CD2_2": -1.27520156332774e-07,
+            "CTYPE1A": "LINEAR  ",
+            "CTYPE2A": "LINEAR  ",
+            "CUNIT1A": "PIXEL   ",
+            "CUNIT2A": "PIXEL   ",
+        }
+        self.wcs = WCS(header_dict)
+
     def test_create(self):
         work = WorkUnit(self.im_stack, self.config)
         self.assertEqual(work.im_stack.img_count(), 5)
         self.assertEqual(work.config["im_filepath"], "Here")
         self.assertEqual(work.config["num_obs"], 5)
+        self.assertIsNone(work.wcs)
+
+        # Create with a global WCS
+        work2 = WorkUnit(self.im_stack, self.config, self.wcs)
+        self.assertEqual(work.im_stack.img_count(), 5)
+        self.assertEqual(work.config["im_filepath"], "Here")
+        self.assertEqual(work.config["num_obs"], 5)
+        self.assertIsNotNone(work.wcs)
 
     def test_save_and_load_fits(self):
         with tempfile.TemporaryDirectory() as dir_name:
@@ -55,13 +83,14 @@ class test_work_unit(unittest.TestCase):
             self.assertRaises(ValueError, WorkUnit.from_fits, file_path)
 
             # Write out the existing WorkUnit
-            work = WorkUnit(self.im_stack, self.config)
+            work = WorkUnit(self.im_stack, self.config, self.wcs)
             work.to_fits(file_path)
             self.assertTrue(Path(file_path).is_file())
 
             # Read in the file and check that the values agree.
             work2 = WorkUnit.from_fits(file_path)
             self.assertEqual(work2.im_stack.img_count(), self.num_images)
+            self.assertIsNotNone(work2.wcs)
             for i in range(self.num_images):
                 li = work2.im_stack.get_single_image(i)
                 self.assertEqual(li.get_width(), self.width)
@@ -92,6 +121,9 @@ class test_work_unit(unittest.TestCase):
                 for y in range(p1.get_dim()):
                     for x in range(p1.get_dim()):
                         self.assertAlmostEqual(p1.get_value(y, x), p2.get_value(y, x))
+
+                # No per-image WCS
+                self.assertIsNone(work2.per_image_wcs[i])
 
             # Check that we read in the configuration values correctly.
             self.assertEqual(work2.config["im_filepath"], "Here")

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -1,5 +1,6 @@
 from astropy.io import fits
 from astropy.table import Table
+from astropy.wcs import WCS
 import tempfile
 import unittest
 from pathlib import Path
@@ -69,10 +70,8 @@ class test_work_unit(unittest.TestCase):
 
         # Create with a global WCS
         work2 = WorkUnit(self.im_stack, self.config, self.wcs)
-        self.assertEqual(work.im_stack.img_count(), 5)
-        self.assertEqual(work.config["im_filepath"], "Here")
-        self.assertEqual(work.config["num_obs"], 5)
-        self.assertIsNotNone(work.wcs)
+        self.assertEqual(work2.im_stack.img_count(), 5)
+        self.assertIsNotNone(work2.wcs)
 
     def test_save_and_load_fits(self):
         with tempfile.TemporaryDirectory() as dir_name:


### PR DESCRIPTION
Adds two forms of WCS information to the `WorkUnit` class. A global `wcs` attribute that should be set when all the images are projected into the same pixel space and a `per_image_wcs` for images that live in different pixel spaces. This information is automatically stored in and read from the FITS headers.