### PR TITLE
Check against case where all likelihoods < 0

### DIFF
--- a/src/kbmod/filters/sigma_g_filter.py
+++ b/src/kbmod/filters/sigma_g_filter.py
@@ -72,6 +72,9 @@ class SigmaGClipping:
             The indices that pass the filtering for a given set of curves.
         """
         if self.clip_negative:
+            # Skip entries where we will clip everything (all lh < 0).
+            if np.count_nonzero(lh > 0) == 0:
+                return np.array([])
             lower_per, median, upper_per = np.percentile(lh[lh > 0], [self.low_bnd, 50, self.high_bnd])
         else:
             lower_per, median, upper_per = np.percentile(lh, [self.low_bnd, 50, self.high_bnd])

--- a/tests/test_sigma_g_filter.py
+++ b/tests/test_sigma_g_filter.py
@@ -54,6 +54,13 @@ class test_sigma_g_math(unittest.TestCase):
         for i in range(num_points):
             self.assertEqual(i in result, i > 2 and i != 5 and i != 14)
 
+    def test_sigma_g_all_negative_clipping(self):
+        num_points = 10
+        lh = np.array([(-100.0 + i * 0.2) for i in range(num_points)])
+        params = SigmaGClipping(clip_negative=True)
+        result = params.compute_clipped_sigma_g(lh)
+        self.assertEqual(len(result), 0)
+
     def test_apply_clipped_sigma_g(self):
         """Confirm the clipped sigmaG filter works when used in the bulk filter mode."""
         num_times = 20


### PR DESCRIPTION
Handle an edge case where we try to do clipped sigma G filtering on all negative likelihoods.