### PR TITLE
Code formatting that passes black v24.

### DIFF
--- a/src/kbmod/analysis/create_stamps.py
+++ b/src/kbmod/analysis/create_stamps.py
@@ -181,11 +181,14 @@ class CreateStamps(object):
         y = np.linspace(-10, 10, size)
 
         x, y = np.meshgrid(x, y)
+        # ignore black, different versions format differently
+        # fmt: off
         gaussian_kernel = (
             1
             / (2 * np.pi * sigma_x * sigma_y)
             * np.exp(-(x**2 / (2 * sigma_x**2) + y**2 / (2 * sigma_y**2)))
         )
+        # fmt: on
         sum_pipi = np.sum(gaussian_kernel**2)
         noise_kernel = np.zeros((21, 21))
         x_mask = np.logical_or(x > 5, x < -5)

--- a/src/kbmod/analysis/precovery_utils.py
+++ b/src/kbmod/analysis/precovery_utils.py
@@ -2,7 +2,6 @@ import pandas as pd
 
 
 class ssoisPrecovery:
-
     """
     This class is designed to use the Solar System Object Image Search (SSOIS) website provided by CADC
     and accessible at this website: https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/en/ssois/index.html.

--- a/src/kbmod/fake_data_creator.py
+++ b/src/kbmod/fake_data_creator.py
@@ -5,6 +5,7 @@ for testing, including generating images with random noise and
 adding artificial objects. The fake data can be saved to files
 or used directly.
 """
+
 import os
 import random
 from pathlib import Path

--- a/tests/test_regression_test.py
+++ b/tests/test_regression_test.py
@@ -2,6 +2,7 @@
 This is a manually run regression test that is more comprehensive than
 the individual unittests.
 """
+
 import math
 import os
 import sys


### PR DESCRIPTION
Black v24 seems to have different opinions about formatting than [black v23 ](https://github.com/dirac-institute/kbmod/actions/runs/7651515666/job/20849459621#step:5:49) causing the [canary build to fail](https://github.com/dirac-institute/kbmod/actions/runs/7665420840/job/20891287247#step:5:49). 

Proposed fixes pass black 23 and 24. 