### PR TITLE
PixelPos cleanup

### DIFF
--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -37,7 +37,6 @@ PYBIND11_MODULE(search, m) {
     search::stack_search_bindings(m);
     search::stamp_creator_bindings(m);
     search::trajectory_bindings(m);
-    search::pixel_pos_bindings(m);
     search::image_moments_bindings(m);
     search::stamp_parameters_bindings(m);
     search::psi_phi_array_binding(m);

--- a/src/kbmod/search/common.h
+++ b/src/kbmod/search/common.h
@@ -133,7 +133,6 @@ static void trajectory_bindings(py::module &m) {
             .def_readwrite("obs_count", &tj::obs_count)
             .def("get_x_pos", &tj::get_x_pos, pydocs::DOC_Trajectory_get_x_pos)
             .def("get_y_pos", &tj::get_y_pos, pydocs::DOC_Trajectory_get_y_pos)
-            .def("get_pos", &tj::get_pos, pydocs::DOC_Trajectory_get_pos)
             .def("__repr__", [](const tj &t) { return "Trajectory(" + t.to_string() + ")"; })
             .def("__str__", &tj::to_string)
             .def(py::pickle(

--- a/src/kbmod/search/common.h
+++ b/src/kbmod/search/common.h
@@ -26,18 +26,6 @@ constexpr float NO_DATA = -9999.0;
 
 enum StampType { STAMP_SUM = 0, STAMP_MEAN, STAMP_MEDIAN };
 
-// The position (in pixels) of a trajectory.
-struct PixelPos {
-    float x;
-    float y;
-
-    const std::string to_string() const { return "x: " + std::to_string(x) + " y: " + std::to_string(y); }
-
-    const std::string to_yaml() const {
-        return "{x: " + std::to_string(x) + ", y: " + std::to_string(y) + "}";
-    }
-};
-
 /*
  * Data structure to represent an objects trajectory
  * through a stack of images
@@ -59,7 +47,6 @@ struct Trajectory {
     // Get pixel positions from a zero-shifted time.
     float get_x_pos(float time) const { return x + time * vx; }
     float get_y_pos(float time) const { return y + time * vy; }
-    PixelPos get_pos(float time) const { return {x + time * vx, y + time * vy}; }
 
     // I can't believe string::format is not a thing until C++ 20
     const std::string to_string() const {
@@ -160,15 +147,6 @@ static void trajectory_bindings(py::module &m) {
                                   t[6].cast<short>()};
                         return trj;
                     }));
-}
-
-static void pixel_pos_bindings(py::module &m) {
-    py::class_<PixelPos>(m, "PixelPos", pydocs::DOC_PixelPos)
-            .def(py::init<>())
-            .def_readwrite("x", &PixelPos::x)
-            .def_readwrite("y", &PixelPos::y)
-            .def("__repr__", [](const PixelPos &p) { return "PixelPos(" + p.to_string() + ")"; })
-            .def("__str__", &PixelPos::to_string);
 }
 
 static void image_moments_bindings(py::module &m) {

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -50,10 +50,6 @@ public:
     // Gets the vector of result trajectories.
     std::vector<Trajectory> get_results(int start, int end);
 
-    // Get the predicted (pixel) positions for a given trajectory.
-    Point get_trajectory_position(const Trajectory& t, int i) const;
-    std::vector<Point> get_trajectory_positions(Trajectory& t) const;
-
     // Filters the results based on various parameters.
     void filter_results(int min_observations);
     void filter_results_lh(float min_lh);


### PR DESCRIPTION
Clean up the (now unused) `PixelPos`. KBMOD now uses `Point` to pass around this information. 

Also remove two unused functions from the `StackSearch` (`get_trajectory_position` and `get_trajectory_positions`). Instead the users should be using `Trajectory`'s functions directly to consolidate logic.