### PR TITLE
Build instructions for KBMOD in conda/virtual environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ cmake --build src/kbmod --clean-first
 ```
 To rebuild, it is sufficient to just re-run the `cmake --build` command. Optionally, invoke the cmake generated `Makefile` as `make clean && make` from the `src/kbmod` directory.
 
+If installing KBMOD into an activated conda/virtual environment, it may be necessary to specify a value for the the CMake `Python3_FIND_VIRTUALENV` configuration to allow CMake to find and use the Python installation in the conda/virtual environment.
+```
+cmake -DPython3_FIND_VIRTUALENV=ONLY B src/kbmod -S .
+cmake --build src/kbmod --clean-first
+```
+
 If you want to build the documentation you must have pandoc which seems not installable by pip.
 See [Pandoc](https://pandoc.org/installing.html), or if you are using conda:
 ```


### PR DESCRIPTION
I had trouble building KBMOD source on the UW Hyak/Klone GPU nodes into a conda environment. The problem was that CMake's `FindPython` was finding the wrong version of Python (even though the conda environment was activated and the correct Python installation was the first on the `PATH` etc.).

It was necessary to specify:
```
cmake -DPython3_FIND_VIRTUALENV=ONLY -B src/kbmod -S .
```
when installing.