### PR TITLE
Small StackSearch cleanup

### DIFF
--- a/src/kbmod/search/pydocs/raw_image_docs.h
+++ b/src/kbmod/search/pydocs/raw_image_docs.h
@@ -195,7 +195,6 @@ static const auto DOC_RawImage_center_is_local_max = R"doc(
       Whether or not the stamp passes the check.
   )doc";
 
-
 static const auto DOC_RawImage_create_stamp = R"doc(
   Create an image stamp around a given region.
 

--- a/src/kbmod/search/pydocs/stack_search_docs.h
+++ b/src/kbmod/search/pydocs/stack_search_docs.h
@@ -15,23 +15,48 @@ static const auto DOC_StackSearch_enable_gpu_sigmag_filter = R"doc(
   )doc";
 
 static const auto DOC_StackSearch_enable_gpu_encoding = R"doc(
-  todo
-  )doc";
+  Set the encoding level for the data copied to the GPU.
+      1 = uint8
+      2 = uint16
+      4 or -1 = float
 
-static const auto DOC_StackSearch_enable_corr = R"doc(
-  todo
+  Parameters
+  ----------
+  encode_num_bytes : `int`
+      The number of bytes to use for encoding the data.
   )doc";
 
 static const auto DOC_StackSearch_set_start_bounds_x = R"doc(
-  todo
+  Set the starting and ending bounds in the x direction for a grid search.
+  The grid search will test all pixels [x_min, x_max).
+
+  Parameters
+  ----------
+  x_min : `int`
+      The inclusive lower bound of the search.
+  x_max : `int`
+      The exclusive upper bound of the search.
   )doc";
 
 static const auto DOC_StackSearch_set_start_bounds_y = R"doc(
-  todo
+  Set the starting and ending bounds in the y direction for a grid search.
+  The grid search will test all pixels [y_min, y_max).
+
+  Parameters
+  ----------
+  y_min : `int`
+      The inclusive lower bound of the search.
+  y_max : `int`
+      The exclusive upper bound of the search.
   )doc";
 
 static const auto DOC_StackSearch_set_debug = R"doc(
-  todo
+  Set whether to dislpay debug output.
+
+  Parameters
+  ----------
+  d : `bool`
+      Set to ``True`` to turn on debug output and ``False`` to turn it off.
   )doc";
 
 static const auto DOC_StackSearch_filter_min_obs = R"doc(
@@ -55,35 +80,39 @@ static const auto DOC_StackSearch_get_image_npixels = R"doc(
   ")doc";
 
 static const auto DOC_StackSearch_get_imagestack = R"doc(
-  todo
-  )doc";
-
-static const auto DOC_StackSearch_get_trajectory_position = R"doc(
-  todo
-  )doc";
-
-static const auto DOC_StackSearch_get_trajectory_positions = R"doc(
-  todo
+  Return the `kb.ImageStack` containing the data to search.
   )doc";
 
 static const auto DOC_StackSearch_get_psi_curves = R"doc(
-  todo
+  Return the time series of psi values for a given trajectory in pixel space.
+
+  Parameters
+  ----------
+  trj : `kb.Trajectory`
+      The input trajectory.
+
+  Returns
+  -------
+  result : `list` of `float`
+     The psi values at each time step with NO_DATA replaced by 0.0.
   )doc";
 
 static const auto DOC_StackSearch_get_phi_curves = R"doc(
-  todo
+  Return the time series of phi values for a given trajectory in pixel space.
+
+  Parameters
+  ----------
+  trj : `kb.Trajectory`
+      The input trajectory.
+
+  Returns
+  -------
+  result : `list` of `float`
+     The phi values at each time step with NO_DATA replaced by 0.0.
   )doc";
 
 static const auto DOC_StackSearch_prepare_psi_phi = R"doc(
-  todo
-  )doc";
-
-static const auto DOC_StackSearch_get_psi_images = R"doc(
-  todo
-  )doc";
-
-static const auto DOC_StackSearch_get_phi_images = R"doc(
-  todo
+  Compute the cached psi and phi data.
   )doc";
 
 static const auto DOC_StackSearch_get_results = R"doc(

--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -209,10 +209,6 @@ std::vector<float> StackSearch::get_phi_curves(Trajectory& t) {
     return create_curves(t, phi_images);
 }
 
-std::vector<RawImage>& StackSearch::get_psi_images() { return psi_images; }
-
-std::vector<RawImage>& StackSearch::get_phi_images() { return phi_images; }
-
 void StackSearch::sort_results() {
     __gnu_parallel::sort(results.begin(), results.end(),
                          [](Trajectory a, Trajectory b) { return b.lh < a.lh; });
@@ -273,8 +269,6 @@ static void stack_search_bindings(py::module& m) {
             .def("get_phi_curves", (std::vector<float>(ks::*)(tj&)) & ks::get_phi_curves,
                  pydocs::DOC_StackSearch_get_phi_curves)
             .def("prepare_psi_phi", &ks::prepare_psi_phi, pydocs::DOC_StackSearch_prepare_psi_phi)
-            .def("get_psi_images", &ks::get_psi_images, pydocs::DOC_StackSearch_get_psi_images)
-            .def("get_phi_images", &ks::get_phi_images, pydocs::DOC_StackSearch_get_phi_images)
             .def("get_results", &ks::get_results, pydocs::DOC_StackSearch_get_results)
             .def("set_results", &ks::set_results, pydocs::DOC_StackSearch_set_results);
 }

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -55,8 +55,6 @@ public:
     void filter_results_lh(float min_lh);
 
     // Getters for the Psi and Phi data.
-    std::vector<RawImage>& get_psi_images();
-    std::vector<RawImage>& get_phi_images();
     std::vector<float> get_psi_curves(Trajectory& t);
     std::vector<float> get_phi_curves(Trajectory& t);
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -87,56 +87,6 @@ class test_search(unittest.TestCase):
         self.params.m02_limit = 35.5
         self.params.m20_limit = 35.5
 
-    def test_psiphi(self):
-        p = PSF(0.00001)
-
-        # Image1 has a single object.
-        height = 19
-        width = 5
-        image1 = LayeredImage(width, height, 2.0, 4.0, 1.0, p)
-        add_fake_object(image1, 3.5, 2.5, 400.0, p)
-
-        # Image2 has a single object and a masked pixel.
-        image2 = LayeredImage(width, height, 2.0, 4.0, 2.0, p)
-        add_fake_object(image2, 4.5, 2.5, 400.0, p)
-
-        mask = image2.get_mask()
-        mask.set_pixel(9, 4, 1)
-        image2.apply_mask(1)
-
-        # Create a stack from the two objects.
-        stack = ImageStack([image1, image2])
-        search = StackSearch(stack)
-
-        # Generate psi and phi.
-        search.prepare_psi_phi()
-        psi = search.get_psi_images()
-        phi = search.get_phi_images()
-
-        # Test phi and psi for image1.
-        sci = image1.get_science()
-        var = image1.get_variance()
-        for x in range(width):
-            for y in range(height):
-                self.assertAlmostEqual(
-                    psi[0].get_pixel(y, x), sci.get_pixel(y, x) / var.get_pixel(y, x), delta=1e-6
-                )
-                self.assertAlmostEqual(phi[0].get_pixel(y, x), 1.0 / var.get_pixel(y, x), delta=1e-6)
-
-        # Test phi and psi for image2.
-        sci = image2.get_science()
-        var = image2.get_variance()
-        for x in range(width):
-            for y in range(height):
-                if x == 4 and y == 9:
-                    self.assertFalse(psi[1].pixel_has_data(y, x))
-                    self.assertFalse(phi[1].pixel_has_data(y, x))
-                else:
-                    self.assertAlmostEqual(
-                        psi[1].get_pixel(y, x), sci.get_pixel(y, x) / var.get_pixel(y, x), delta=1e-6
-                    )
-                    self.assertAlmostEqual(phi[1].get_pixel(y, x), 1.0 / var.get_pixel(y, x), delta=1e-6)
-
     @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
     def test_results(self):
         self.search.search(


### PR DESCRIPTION
Two small changes to `StackSearch`:
1) Fill in some of the missing pydoc comments.
2) Remove a redundant test (`test_psiphi`) this is already covered by `test_layered_image.py`'s `test_psi_and_phi_image`. Removing this test allows us to remove the otherwise unused `get_psi_images` and `get_phi_images` functions.