### PR TITLE
Fix precision error

### DIFF
--- a/src/kbmod/search/image_stack.cpp
+++ b/src/kbmod/search/image_stack.cpp
@@ -47,7 +47,7 @@ float ImageStack::get_zeroed_time(int index) const {
 std::vector<float> ImageStack::build_zeroed_times() const {
     std::vector<float> zeroed_times = std::vector<float>();
     if (images.size() > 0) {
-        float t0 = images[0].get_obstime();
+        double t0 = images[0].get_obstime();
         for (auto& i : images) {
             zeroed_times.push_back(i.get_obstime() - t0);
         }


### PR DESCRIPTION
The image's time should be subtracted as a double before converting to a float. Noticed this because there was a slight different between `build_zeroed_times` and `get_zeroed_time` on one DEEP data set.