### PR TITLE
Small StackSearch cleanups

### DIFF
--- a/src/kbmod/search/pydocs/stack_search_docs.h
+++ b/src/kbmod/search/pydocs/stack_search_docs.h
@@ -59,10 +59,6 @@ static const auto DOC_StackSearch_set_debug = R"doc(
       Set to ``True`` to turn on debug output and ``False`` to turn it off.
   )doc";
 
-static const auto DOC_StackSearch_filter_min_obs = R"doc(
-  todo
-  )doc";
-
 static const auto DOC_StackSearch_get_num_images = R"doc(
   "Returns the number of images to process.
   ")doc";

--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -68,7 +68,8 @@ void StackSearch::set_start_bounds_y(int y_min, int y_max) {
 void StackSearch::search(int ang_steps, int vel_steps, float min_ang, float max_ang, float min_vel,
                          float mavx, int min_observations) {
     DebugTimer core_timer = DebugTimer("Running core search", debug_info);
-    create_search_list(ang_steps, vel_steps, min_ang, max_ang, min_vel, mavx);
+    std::vector<Trajectory> search_list =
+            create_grid_search_list(ang_steps, vel_steps, min_ang, max_ang, min_vel, mavx);
 
     // Create a data stucture for the per-image data.
     std::vector<float> image_times = stack.build_zeroed_times();
@@ -132,8 +133,9 @@ void StackSearch::prepare_psi_phi() {
     }
 }
 
-void StackSearch::create_search_list(int angle_steps, int velocity_steps, float min_ang, float max_ang,
-                                     float min_vel, float mavx) {
+std::vector<Trajectory> StackSearch::create_grid_search_list(int angle_steps, int velocity_steps,
+                                                             float min_ang, float max_ang, float min_vel,
+                                                             float mavx) {
     DebugTimer timer = DebugTimer("Creating search candidate list", debug_info);
 
     std::vector<float> angles(angle_steps);
@@ -149,7 +151,7 @@ void StackSearch::create_search_list(int angle_steps, int velocity_steps, float 
     }
 
     int trajCount = angle_steps * velocity_steps;
-    search_list = std::vector<Trajectory>(trajCount);
+    std::vector<Trajectory> search_list = std::vector<Trajectory>(trajCount);
     for (int a = 0; a < angle_steps; ++a) {
         for (int v = 0; v < velocity_steps; ++v) {
             search_list[a * velocity_steps + v].vx = cos(angles[a]) * velocities[v];
@@ -157,6 +159,8 @@ void StackSearch::create_search_list(int angle_steps, int velocity_steps, float 
         }
     }
     timer.stop();
+
+    return search_list;
 }
 
 std::vector<float> StackSearch::create_curves(Trajectory t, const std::vector<RawImage>& imgs) {
@@ -214,20 +218,6 @@ void StackSearch::sort_results() {
                          [](Trajectory a, Trajectory b) { return b.lh < a.lh; });
 }
 
-void StackSearch::filter_results(int min_observations) {
-    results.erase(std::remove_if(results.begin(), results.end(),
-                                 std::bind([](Trajectory t, int cutoff) { return t.obs_count < cutoff; },
-                                           std::placeholders::_1, min_observations)),
-                  results.end());
-}
-
-void StackSearch::filter_results_lh(float min_lh) {
-    results.erase(std::remove_if(results.begin(), results.end(),
-                                 std::bind([](Trajectory t, float cutoff) { return t.lh < cutoff; },
-                                           std::placeholders::_1, min_lh)),
-                  results.end());
-}
-
 std::vector<Trajectory> StackSearch::get_results(int start, int count) {
     if (start + count >= results.size()) {
         count = results.size() - start;
@@ -256,7 +246,6 @@ static void stack_search_bindings(py::module& m) {
             .def("set_start_bounds_x", &ks::set_start_bounds_x, pydocs::DOC_StackSearch_set_start_bounds_x)
             .def("set_start_bounds_y", &ks::set_start_bounds_y, pydocs::DOC_StackSearch_set_start_bounds_y)
             .def("set_debug", &ks::set_debug, pydocs::DOC_StackSearch_set_debug)
-            .def("filter_min_obs", &ks::filter_results, pydocs::DOC_StackSearch_filter_min_obs)
             .def("get_num_images", &ks::num_images, pydocs::DOC_StackSearch_get_num_images)
             .def("get_image_width", &ks::get_image_width, pydocs::DOC_StackSearch_get_image_width)
             .def("get_image_height", &ks::get_image_height, pydocs::DOC_StackSearch_get_image_height)

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -50,10 +50,6 @@ public:
     // Gets the vector of result trajectories.
     std::vector<Trajectory> get_results(int start, int end);
 
-    // Filters the results based on various parameters.
-    void filter_results(int min_observations);
-    void filter_results_lh(float min_lh);
-
     // Getters for the Psi and Phi data.
     std::vector<float> get_psi_curves(Trajectory& t);
     std::vector<float> get_phi_curves(Trajectory& t);
@@ -71,13 +67,12 @@ protected:
     std::vector<float> create_curves(Trajectory t, const std::vector<RawImage>& imgs);
 
     // Creates list of trajectories to search.
-    void create_search_list(int angle_steps, int velocity_steps, float min_ang, float max_ang, float min_vel,
-                            float max_vel);
+    std::vector<Trajectory> create_grid_search_list(int angle_steps, int velocity_steps, float min_ang,
+                                                    float max_ang, float min_vel, float mavx);
 
     bool psi_phi_generated;
     bool debug_info;
     ImageStack stack;
-    std::vector<Trajectory> search_list;
     std::vector<RawImage> psi_images;
     std::vector<RawImage> phi_images;
     std::vector<Trajectory> results;


### PR DESCRIPTION
A few small cleanups to `StackSearch` to help long term maintainability:
- Remove `search_list` as a object variable. We only use it in a single function.
- Remove unused functions `filter_results` and `filter_results_lh`