### PR TITLE
Add DebugTimer to the pybind bindings

### DIFF
--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -17,6 +17,7 @@ namespace py = pybind11;
 #include "stamp_creator.cpp"
 #include "kernel_testing_helpers.cpp"
 #include "psi_phi_array.cpp"
+#include "debug_timer.cpp"
 
 PYBIND11_MODULE(search, m) {
     m.attr("KB_NO_DATA") = pybind11::float_(search::NO_DATA);
@@ -40,6 +41,7 @@ PYBIND11_MODULE(search, m) {
     search::image_moments_bindings(m);
     search::stamp_parameters_bindings(m);
     search::psi_phi_array_binding(m);
+    search::debug_timer_binding(m);
     // Functions from raw_image.cpp
     m.def("create_median_image", &search::create_median_image);
     m.def("create_summed_image", &search::create_summed_image);

--- a/src/kbmod/search/debug_timer.cpp
+++ b/src/kbmod/search/debug_timer.cpp
@@ -40,11 +40,11 @@ double DebugTimer::read() {
         std::chrono::time_point<std::chrono::system_clock> t_current_ = std::chrono::system_clock::now();
         t_delta = std::chrono::duration_cast<std::chrono::milliseconds>(t_current_ - t_start_);
     } else {
-        t_delta = std::chrono::duration_cast<std::chrono::milliseconds>(t_end_ - t_start_);      
+        t_delta = std::chrono::duration_cast<std::chrono::milliseconds>(t_end_ - t_start_);
     }
 
     double result = t_delta.count() / 1000.0;
-    if (verbose) {
+    if (verbose_) {
         std::cout << name_ << " at " << result << " seconds.\n" << std::flush;
     }
     return result;
@@ -54,7 +54,7 @@ double DebugTimer::read() {
 static void debug_timer_binding(py::module& m) {
     using dbt = search::DebugTimer;
     py::class_<dbt>(m, "DebugTimer", pydocs::DOC_DEBUG_TIMER)
-            .def(py::init<>())
+            .def(py::init<std::string, bool>())
             .def("start", &dbt::start, pydocs::DOC_DEBUG_TIMER_start)
             .def("stop", &dbt::stop, pydocs::DOC_DEBUG_TIMER_stop)
             .def("read", &dbt::read, pydocs::DOC_DEBUG_TIMER_read);

--- a/src/kbmod/search/debug_timer.cpp
+++ b/src/kbmod/search/debug_timer.cpp
@@ -1,0 +1,64 @@
+/* A very simple class that wraps debug output with timing. Used for
+   providing status updates as the system is running if in verbose
+   mode and nothing otherwise.
+
+   This is *not* a high precision timer meant to be used for benchmarking.
+*/
+
+#include "debug_timer.h"
+#include "pydocs/debug_timer_docs.h"
+
+namespace search {
+
+DebugTimer::DebugTimer(std::string name, bool verbose) {
+    name_ = name;
+    verbose_ = verbose;
+    start();
+}
+
+void DebugTimer::start() {
+    running_ = true;
+    t_start_ = std::chrono::system_clock::now();
+    if (verbose_) {
+        std::cout << "Starting " << name_ << "...\n" << std::flush;
+    }
+}
+
+void DebugTimer::stop() {
+    t_end_ = std::chrono::system_clock::now();
+    running_ = false;
+
+    if (verbose_) {
+        auto t_delta = std::chrono::duration_cast<std::chrono::milliseconds>(t_end_ - t_start_);
+        std::cout << name_ << " finished in " << t_delta.count() / 1000.0 << " seconds.\n" << std::flush;
+    }
+}
+
+double DebugTimer::read() {
+    std::chrono::milliseconds t_delta;
+    if (running_) {
+        std::chrono::time_point<std::chrono::system_clock> t_current_ = std::chrono::system_clock::now();
+        t_delta = std::chrono::duration_cast<std::chrono::milliseconds>(t_current_ - t_start_);
+    } else {
+        t_delta = std::chrono::duration_cast<std::chrono::milliseconds>(t_end_ - t_start_);      
+    }
+
+    double result = t_delta.count() / 1000.0;
+    if (verbose) {
+        std::cout << name_ << " at " << result << " seconds.\n" << std::flush;
+    }
+    return result;
+}
+
+#ifdef Py_PYTHON_H
+static void debug_timer_binding(py::module& m) {
+    using dbt = search::DebugTimer;
+    py::class_<dbt>(m, "DebugTimer", pydocs::DOC_DEBUG_TIMER)
+            .def(py::init<>())
+            .def("start", &dbt::start, pydocs::DOC_DEBUG_TIMER_start)
+            .def("stop", &dbt::stop, pydocs::DOC_DEBUG_TIMER_stop)
+            .def("read", &dbt::read, pydocs::DOC_DEBUG_TIMER_read);
+}
+#endif /* Py_PYTHON_H */
+
+} /* namespace search */

--- a/src/kbmod/search/debug_timer.h
+++ b/src/kbmod/search/debug_timer.h
@@ -13,31 +13,21 @@
 namespace search {
 class DebugTimer {
 public:
-    DebugTimer(std::string name, bool verbose) {
-        name_ = name;
-        verbose_ = verbose;
-        start();
-    }
+    DebugTimer(std::string name, bool verbose);
 
-    void start() {
-        t_start_ = std::chrono::system_clock::now();
-        if (verbose_) {
-            std::cout << "Starting " << name_ << "...\n" << std::flush;
-        }
-    }
+    void start();
+    void stop();
 
-    void stop() {
-        if (verbose_) {
-            std::chrono::time_point<std::chrono::system_clock> t_end = std::chrono::system_clock::now();
-            auto t_delta = std::chrono::duration_cast<std::chrono::milliseconds>(t_end - t_start_);
-            std::cout << name_ << " took " << t_delta.count() / 1000.0 << " seconds.\n" << std::flush;
-        }
-    }
+    // Read the time in decimal seconds without stopping the timer.
+    // If the timer is already stopped, read the duration from end time.
+    double read();
 
 private:
     std::chrono::time_point<std::chrono::system_clock> t_start_;
+    std::chrono::time_point<std::chrono::system_clock> t_end_;
     std::string name_;
     bool verbose_;
+    bool running_;
 };
 
 } /* namespace search */

--- a/src/kbmod/search/pydocs/debug_timer_docs.h
+++ b/src/kbmod/search/pydocs/debug_timer_docs.h
@@ -1,0 +1,36 @@
+#ifndef DEBUG_TIMER_DOCS_
+#define DEBUG_TIMER_DOCS_
+
+namespace pydocs {
+static const auto DOC_DEBUG_TIMER = R"doc(
+  A simple timer used for consistent outputing of timing results in verbose mode.
+  Timer automatically starts when it is created.
+
+  Parameters
+  ----------
+  name : `str`
+      The name string of the timer. Used for ouput.
+  verbose : `bool`
+      Output the timing information to the standard output.
+  )doc";
+
+static const auto DOC_DEBUG_TIMER_start = R"doc(
+  Start (or restart) the timer. If verbose outputs a message.
+  )doc";
+
+static const auto DOC_DEBUG_TIMER_stop = R"doc(
+  Stop the timer. If verbose outputs the duration.
+  )doc";
+
+static const auto DOC_DEBUG_TIMER_read = R"doc(
+  Read the timer duration as decimal seconds.
+
+  Returns
+  -------
+  duration : `float`
+      The duration of the timer.
+  )doc";
+
+}  // namespace pydocs
+
+#endif /* #define DEBUG_TIMER_DOCS_ */

--- a/tests/test_debug_timer.py
+++ b/tests/test_debug_timer.py
@@ -1,0 +1,26 @@
+import time
+import unittest
+
+from kbmod.search import DebugTimer
+
+
+class test_debug_timer(unittest.TestCase):
+    def test_create(self):
+        my_timer = DebugTimer("hi", False)
+        time1 = my_timer.read()
+
+        # We use sleep (100ms) because we are only interested in
+        # wall clock time having increased.
+        time.sleep(0.1)
+        time2 = my_timer.read()
+        self.assertGreater(time2, time1)
+
+        my_timer.stop()
+        time3 = my_timer.read()
+        time.sleep(0.1)
+        time4 = my_timer.read()
+        self.assertAlmostEqual(time3, time4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Expose `DebugTimer` through the pybind bindings to allow us to use the same timing messages in python and C++. Uses the accessibility via python to add some tests.