### PR TITLE
Change how WCS is validated in a WorkUnit

### DIFF
--- a/src/kbmod/reprojection.py
+++ b/src/kbmod/reprojection.py
@@ -78,6 +78,8 @@ def reproject_work_unit(work_unit, common_wcs):
             variance = image.get_variance()
             mask = image.get_mask()
             original_wcs = work_unit.get_wcs(index)
+            if original_wcs is None:
+                raise ValueError(f"No WCS provided for index {index}")
 
             reprojected_science, footprint = reproject_raw_image(science, original_wcs, common_wcs, time)
 

--- a/src/kbmod/reprojection.py
+++ b/src/kbmod/reprojection.py
@@ -60,9 +60,6 @@ def reproject_work_unit(work_unit, common_wcs):
     images = work_unit.im_stack.get_images()
     obstimes = np.array(work_unit.get_all_obstimes())
 
-    if len(work_unit.per_image_wcs) != len(images):
-        raise ValueError("per_image_wcs not provided for all WorkUnit")
-
     image_list = []
 
     unique_obstimes = np.unique(obstimes)
@@ -80,7 +77,7 @@ def reproject_work_unit(work_unit, common_wcs):
             science = image.get_science()
             variance = image.get_variance()
             mask = image.get_mask()
-            original_wcs = work_unit.per_image_wcs[index]
+            original_wcs = work_unit.get_wcs(index)
 
             reprojected_science, footprint = reproject_raw_image(science, original_wcs, common_wcs, time)
 
@@ -130,7 +127,6 @@ def reproject_work_unit(work_unit, common_wcs):
         image_list.append(new_layered_image)
 
     stack = ImageStack(image_list)
-    new_wunit = WorkUnit(im_stack=stack, config=work_unit.config)
-    new_wunit.wcs = common_wcs
+    new_wunit = WorkUnit(im_stack=stack, config=work_unit.config, wcs=common_wcs)
 
     return new_wunit

--- a/src/kbmod/wcs_utils.py
+++ b/src/kbmod/wcs_utils.py
@@ -381,7 +381,7 @@ def wcs_to_dict(wcs):
 
 
 def make_fake_wcs_info(center_ra, center_dec, height, width, deg_per_pixel=None):
-    """Create a fake WCS given basic information. This is not a realistic
+    """Create a fake WCS dictionary given basic information. This is not a realistic
     WCS in terms of astronomy, but can provide a place holder for many tests.
 
     Parameters
@@ -421,3 +421,63 @@ def make_fake_wcs_info(center_ra, center_dec, height, width, deg_per_pixel=None)
         wcs_dict["CDELT2"] = deg_per_pixel
 
     return wcs_dict
+
+
+def make_fake_wcs(center_ra, center_dec, height, width, deg_per_pixel=None):
+    """Create a fake WCS given basic information. This is not a realistic
+    WCS in terms of astronomy, but can provide a place holder for many tests.
+
+    Parameters
+    ----------
+    center_ra : `float`
+        The center of the pointing in RA (degrees)
+    center_dev : `float`
+        The center of the pointing in DEC (degrees)
+    height : `int`
+        The image height (pixels).
+    width : `int`
+        The image width (pixels).
+    deg_per_pixel : `float`, optional
+        The angular resolution of a pixel (degrees).
+
+    Returns
+    -------
+    result : `astropy.wcs.WCS`
+        The resulting WCS.
+    """
+    wcs_dict = make_fake_wcs_info(center_ra, center_dec, height, width, deg_per_pixel)
+    return astropy.wcs.WCS(wcs_dict)
+
+
+def wcs_fits_equal(wcs_a, wcs_b):
+    """Test if two WCS objects are equal at the level they would be
+    written to FITS headers. Treats a pair of None values as equal.
+
+    Parameters
+    ----------
+    wcs_a : `astropy.wcs.WCS`
+        The WCS of the first object.
+    wcs_b : `astropy.wcs.WCS`
+        The WCS of the second object.
+    """
+    # Handle None data.
+    if wcs_a is None and wcs_b is None:
+        return True
+    if wcs_a is None:
+        return False
+    if wcs_b is None:
+        return False
+
+    header_a = wcs_a.to_header()
+    header_b = wcs_b.to_header()
+    if len(header_a) != len(header_b):
+        return False
+
+    # Check the derived FITs header data have the same keys and values.
+    for key in header_a:
+        if not key in header_b:
+            return False
+        if header_a[key] != header_b[key]:
+            return False
+
+    return True

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -8,6 +8,7 @@ from kbmod.fake_data.fake_data_creator import *
 from kbmod.run_search import *
 from kbmod.search import *
 from kbmod.trajectory_utils import make_trajectory
+from kbmod.wcs_utils import make_fake_wcs
 from kbmod.work_unit import WorkUnit
 
 # from .utils_for_tests import get_absolute_demo_data_path
@@ -113,7 +114,8 @@ class test_end_to_end(unittest.TestCase):
         config.set("ang_arr", [math.pi, math.pi, 16])
         config.set("v_arr", [0, 10.0, 20])
 
-        work = WorkUnit(im_stack=ds.stack, config=config)
+        fake_wcs = make_fake_wcs(10.0, 10.0, 128, 128)
+        work = WorkUnit(im_stack=ds.stack, config=config, wcs=fake_wcs)
 
         with tempfile.TemporaryDirectory() as dir_name:
             file_path = os.path.join(dir_name, "test_workunit.fits")

--- a/tests/test_fake_data_creator.py
+++ b/tests/test_fake_data_creator.py
@@ -5,6 +5,7 @@ import unittest
 from kbmod.fake_data.fake_data_creator import *
 from kbmod.file_utils import *
 from kbmod.search import *
+from kbmod.wcs_utils import make_fake_wcs, wcs_fits_equal
 from kbmod.work_unit import WorkUnit
 
 
@@ -107,6 +108,7 @@ class test_fake_image_creator(unittest.TestCase):
     def test_save_work_unit(self):
         num_images = 25
         ds = FakeDataSet(15, 10, create_fake_times(num_images))
+        ds.set_wcs(make_fake_wcs(10.0, 15.0, 15, 10))
 
         with tempfile.TemporaryDirectory() as dir_name:
             file_name = os.path.join(dir_name, "fake_work_unit.fits")

--- a/tests/test_reprojection.py
+++ b/tests/test_reprojection.py
@@ -12,7 +12,7 @@ class test_reprojection(unittest.TestCase):
     def setUp(self):
         self.data_path = get_absolute_data_path("shifted_wcs_diff_dimms_tiled.fits")
         self.test_wunit = WorkUnit.from_fits(self.data_path)
-        self.common_wcs = self.test_wunit.per_image_wcs[0]
+        self.common_wcs = self.test_wunit.get_wcs(0)
 
     def test_reproject(self):
         reprojected_wunit = reproject_work_unit(self.test_wunit, self.common_wcs)
@@ -64,14 +64,6 @@ class test_reprojection(unittest.TestCase):
         assert len(data[2][2][36][data[2][2][36] == 1.0]) == 7
         assert len(data[2][2][34][data[2][2][34] == 1.0]) == 7
 
-    def test_except_no_per_image_wcs(self):
-        """Make sure we fail when we don't have all the provided WCS."""
-        self.test_wunit.per_image_wcs = self.test_wunit.per_image_wcs[:-1]
-        try:
-            reproject_work_unit(self.test_wunit, self.common_wcs)
-        except ValueError as e:
-            assert str(e) == "per_image_wcs not provided for all WorkUnit"
-
     def test_except_add_overlapping_images(self):
         """Make sure that the reprojection fails when images at the same time
         have overlapping pixels."""
@@ -84,3 +76,7 @@ class test_reprojection(unittest.TestCase):
             reproject_work_unit(self.test_wunit, self.common_wcs)
         except ValueError as e:
             assert str(e) == "Images with the same obstime are overlapping."
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wcs_utils.py
+++ b/tests/test_wcs_utils.py
@@ -22,6 +22,19 @@ class test_wcs_conversion(unittest.TestCase):
         self.wcs = WCS(self.header_dict)
         self.header = self.wcs.to_header()
 
+    def test_wcs_equal_fits(self):
+        self.assertTrue(wcs_fits_equal(self.wcs, self.wcs))
+        self.assertTrue(wcs_fits_equal(None, None))
+        self.assertFalse(wcs_fits_equal(None, self.wcs))
+        self.assertFalse(wcs_fits_equal(self.wcs, None))
+
+        self.header_dict["CRVAL1"] = 201.5
+        wcs2 = WCS(self.header_dict)
+        self.assertFalse(wcs_fits_equal(self.wcs, wcs2))
+
+        wcs3 = WCS(self.header_dict)
+        self.assertTrue(wcs_fits_equal(wcs2, wcs3))
+
     def test_wcs_from_dict(self):
         # The base dictionary is good.
         self.assertIsNotNone(wcs_from_dict(self.header_dict))


### PR DESCRIPTION
Reduce the chances of inconsistent global and per-image WCS objects in a WorkUnit. 
- If both are provided check that all the per-image WCS match the global WCS. 
- If only per-image WCS are provided and they are all the same, set the global WCS.
- If neither are provided, raise a warning (that could become an exception in the future).

Also adds code to support this:
- Add a helper function to indicate if the WorkUnit is in a common WCS.
- Add a function for comparing two WCS objects.
- Makes some small changes to reprojection and fake_data_creator to support the new checks,.