### PR TITLE
Restore ImageCollection.toImageStack because of StampCreator.

### DIFF
--- a/src/kbmod/image_collection.py
+++ b/src/kbmod/image_collection.py
@@ -491,6 +491,17 @@ class ImageCollection:
         # maybe timespan?
         return self.data["mjd"][-1] - self.data["mjd"][0]
 
+    def toImageStack(self):
+        """Return an `~kbmod.search.image_stack` object for processing with
+        KBMOD.
+        Returns
+        -------
+        imageStack : `~kbmod.search.image_stack`
+            Image stack for processing with KBMOD.
+        """
+        layeredImages = [img for std in self._standardizers for img in std.toLayeredImage()]
+        return ImageStack(layeredImages)
+
     def toWorkUnit(self, config):
         """Return an `~kbmod.WorkUnit` object for processing with
         KBMOD.


### PR DESCRIPTION
`StampCreator` doesn't work with `WorkUnit`, only `ImageStack`. This restores the ability to export the `ImageCollection` as the CPP internal `ImageStack` object so that we can create stamps in notebook. 

This should be a temporary patch because there are no reasons for the `StampCreator` not to work with `WorkUnit` eventually (or even `ImageCollection`). 