### PR TITLE
Fully replace old NO_DATA values

### DIFF
--- a/src/kbmod/filters/stamp_filters.py
+++ b/src/kbmod/filters/stamp_filters.py
@@ -12,7 +12,6 @@ from kbmod.configuration import SearchConfiguration
 from kbmod.result_list import ResultRow
 from kbmod.search import (
     HAS_GPU,
-    KB_NO_DATA,
     ImageStack,
     RawImage,
     StampCreator,

--- a/src/kbmod/search/common.h
+++ b/src/kbmod/search/common.h
@@ -22,13 +22,16 @@ constexpr unsigned short CONV_THREAD_DIM = 32;
 constexpr unsigned short THREAD_DIM_X = 128;
 constexpr unsigned short THREAD_DIM_Y = 2;
 constexpr unsigned short RESULTS_PER_PIXEL = 8;
-constexpr float NO_DATA = -9999.0;
+
+// The NO_DATA flag indicates masked values in the image.
+constexpr float NO_DATA = std::numeric_limits<float>::quiet_NaN();
 
 enum StampType { STAMP_SUM = 0, STAMP_MEAN, STAMP_MEDIAN };
 
-// A helper function to check that a pixel value is valid.
+// A helper function to check that a pixel value is valid. This should include
+// both masked pixel values (NO_DATA above) and other invalid values (e.g. inf).
 inline bool pixel_value_valid(float value) {
-    return ((value != NO_DATA) && !std::isnan(value));
+    return std::isfinite(value);
 }
 
 /*

--- a/src/kbmod/search/common.h
+++ b/src/kbmod/search/common.h
@@ -2,6 +2,7 @@
 #define COMMON_H_
 
 #include <assert.h>
+#include <math.h>
 #include <string>
 
 #include "pydocs/common_docs.h"
@@ -24,7 +25,7 @@ constexpr unsigned short THREAD_DIM_Y = 2;
 constexpr unsigned short RESULTS_PER_PIXEL = 8;
 
 // The NO_DATA flag indicates masked values in the image.
-constexpr float NO_DATA = std::numeric_limits<float>::quiet_NaN();
+constexpr float NO_DATA = NAN;
 
 enum StampType { STAMP_SUM = 0, STAMP_MEAN, STAMP_MEDIAN };
 

--- a/src/kbmod/search/image_stack.cpp
+++ b/src/kbmod/search/image_stack.cpp
@@ -2,9 +2,7 @@
 
 namespace search {
 
-ImageStack::ImageStack(const std::vector<LayeredImage>& imgs) {
-    images = imgs;
-}
+ImageStack::ImageStack(const std::vector<LayeredImage>& imgs) { images = imgs; }
 
 LayeredImage& ImageStack::get_single_image(int index) {
     if (index < 0 || index > images.size()) throw std::out_of_range("ImageStack index out of bounds.");

--- a/src/kbmod/search/layered_image.cpp
+++ b/src/kbmod/search/layered_image.cpp
@@ -120,8 +120,6 @@ void LayeredImage::subtract_template(RawImage& sub_template) {
     for (unsigned i = 0; i < num_pixels; ++i) {
         if (pixel_value_valid(sci_pixels[i]) && pixel_value_valid(tem_pixels[i])) {
             sci_pixels[i] -= tem_pixels[i];
-        } else {
-            sci_pixels[i] = NO_DATA;
         }
     }
 }

--- a/src/kbmod/search/psi_phi_array.cpp
+++ b/src/kbmod/search/psi_phi_array.cpp
@@ -263,24 +263,6 @@ void fill_psi_phi_array(PsiPhiArray& result_data, int num_bytes, const std::vect
     int height = phi_imgs[0].get_height();
     result_data.set_meta_data(num_bytes, num_times, height, width);
 
-    // Check that we are not processing any bad data (NaNs or infs). We do this once
-    // before allocating space, encoding, etc.
-    for (int t = 0; t < num_times; ++t) {
-        for (int row = 0; row < height; ++row) {
-            for (int col = 0; col < width; ++col) {
-                float psi_val = psi_imgs[t].get_pixel({row, col});
-                if (std::isnan(psi_val) || std::isinf(psi_val)) {
-                    throw std::runtime_error("Invalid value found in PSI array");
-                }
-
-                float phi_val = phi_imgs[t].get_pixel({row, col});
-                if (std::isnan(phi_val) || std::isinf(phi_val)) {
-                    throw std::runtime_error("Invalid value found in PHI array");
-                }
-            }
-        }
-    }
-
     if (result_data.get_num_bytes() == 1 || result_data.get_num_bytes() == 2) {
         // Compute the scaling parameters needed for encoding.
         std::array<float, 3> psi_params =

--- a/src/kbmod/search/psi_phi_array_ds.h
+++ b/src/kbmod/search/psi_phi_array_ds.h
@@ -37,7 +37,8 @@ struct PsiPhi {
 
 // Helper utility functions.
 inline float encode_uint_scalar(float value, float min_val, float max_val, float scale) {
-    return !pixel_value_valid(value) ? 0 : (std::max(std::min(value, max_val), min_val) - min_val) / scale + 1.0;
+    return !pixel_value_valid(value) ? 0
+                                     : (std::max(std::min(value, max_val), min_val) - min_val) / scale + 1.0;
 }
 
 inline float decode_uint_scalar(float value, float min_val, float scale) {

--- a/src/kbmod/search/pydocs/raw_image_docs.h
+++ b/src/kbmod/search/pydocs/raw_image_docs.h
@@ -129,7 +129,7 @@ static const auto DOC_RawImage_mask_pixel = R"doc(
   j : `int`
       Column.
   )doc";
-      
+
 static const auto DOC_RawImage_set_all = R"doc(
   Sets all image pixel values to the given value.
 
@@ -137,6 +137,15 @@ static const auto DOC_RawImage_set_all = R"doc(
   ----------
   value : `float`
       Value to set the pixels to.
+  )doc";
+
+static const auto DOC_RawImage_replace_masked_values = R"doc(
+  Replace the masked values in an image with a given value.
+
+  Parameters
+  ----------
+  value : `float`
+      The value to swap in. Default = 0.0.
   )doc";
 
 static const auto DOC_RawImage_l2_allclose = R"doc(

--- a/src/kbmod/search/pydocs/raw_image_docs.h
+++ b/src/kbmod/search/pydocs/raw_image_docs.h
@@ -119,6 +119,17 @@ static const auto DOC_RawImage_set_pixel = R"doc(
       Value to set the pixels to.
   )doc";
 
+static const auto DOC_RawImage_mask_pixel = R"doc(
+  Sets image pixel at an invalid value that indicates it is masked.
+
+  Parameters
+  ----------
+  i : `int`
+      Row.
+  j : `int`
+      Column.
+  )doc";
+      
 static const auto DOC_RawImage_set_all = R"doc(
   Sets all image pixel values to the given value.
 

--- a/src/kbmod/search/pydocs/stack_search_docs.h
+++ b/src/kbmod/search/pydocs/stack_search_docs.h
@@ -28,7 +28,6 @@ static const auto DOC_StackSearch_set_min_lh = R"doc(
       The minimum likelihood value for a trajectory to be returned.
   )doc";
 
-
 static const auto DOC_StackSearch_enable_gpu_sigmag_filter = R"doc(
   Enable on-GPU sigma-G filtering.
 

--- a/src/kbmod/search/raw_image.cpp
+++ b/src/kbmod/search/raw_image.cpp
@@ -240,7 +240,7 @@ Index RawImage::find_peak(bool furthest_from_center) const {
 
     // Initialize the variables for tracking the peak's location.
     Index result = {0, 0};
-    float max_val = NO_DATA;
+    float max_val = std::numeric_limits<float>::lowest();
     float dist2 = c_x * c_x + c_y * c_y;
 
     // Search each pixel for the peak.
@@ -270,7 +270,7 @@ Index RawImage::find_peak(bool furthest_from_center) const {
 // Find the basic image moments in order to test if stamps have a gaussian shape.
 // It computes the moments on the "normalized" image where the minimum
 // value has been shifted to zero and the sum of all elements is 1.0.
-// Elements with NO_DATA are treated as zero.
+// Elements with invalid or masked data are treated as zero.
 ImageMoments RawImage::find_central_moments() const {
     const int num_pixels = width * height;
     const int c_x = width / 2;
@@ -280,13 +280,13 @@ ImageMoments RawImage::find_central_moments() const {
     ImageMoments res = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
     auto pixels = image.reshaped();
 
-    // Find the min (non-NO_DATA) value to subtract off.
+    // Find the minimum (valid) value to subtract off.
     float min_val = FLT_MAX;
     for (int p = 0; p < num_pixels; ++p) {
         min_val = (pixel_value_valid(pixels[p]) && (pixels[p] < min_val)) ? pixels[p] : min_val;
     }
 
-    // Find the sum of the zero-shifted (non-NO_DATA) pixels.
+    // Find the sum of the zero-shifted (valid) pixels.
     double sum = 0.0;
     for (int p = 0; p < num_pixels; ++p) {
         sum += pixel_value_valid(pixels[p]) ? (pixels[p] - min_val) : 0.0;
@@ -320,7 +320,7 @@ bool RawImage::center_is_local_max(double flux_thresh, bool local_max) const {
     auto pixels = image.reshaped();
     double center_val = pixels[c_ind];
 
-    // Find the sum of the zero-shifted (non-NO_DATA) pixels.
+    // Find the sum of the zero-shifted (valid) pixels.
     double sum = 0.0;
     for (int p = 0; p < num_pixels; ++p) {
         float pix_val = pixels[p];

--- a/src/kbmod/search/raw_image.cpp
+++ b/src/kbmod/search/raw_image.cpp
@@ -457,6 +457,7 @@ static void raw_image_bindings(py::module& m) {
             .def("get_pixel", &rie::get_pixel, pydocs::DOC_RawImage_get_pixel)
             .def("pixel_has_data", &rie::pixel_has_data, pydocs::DOC_RawImage_pixel_has_data)
             .def("set_pixel", &rie::set_pixel, pydocs::DOC_RawImage_set_pixel)
+            .def("mask_pixel", &rie::mask_pixel, pydocs::DOC_RawImage_mask_pixel)
             .def("set_all", &rie::set_all, pydocs::DOC_RawImage_set_all)
             // python interface adapters (avoids having to construct Index & Point)
             .def("get_pixel",
@@ -470,6 +471,10 @@ static void raw_image_bindings(py::module& m) {
             .def("set_pixel",
                  [](rie& cls, int i, int j, double val) {
                      cls.set_pixel({i, j}, val);
+                 })
+            .def("mask_pixel",
+                 [](rie& cls, int i, int j) {
+                     cls.mask_pixel({i, j});
                  })
             // methods
             .def("l2_allclose", &rie::l2_allclose, pydocs::DOC_RawImage_l2_allclose)

--- a/src/kbmod/search/raw_image.h
+++ b/src/kbmod/search/raw_image.h
@@ -51,20 +51,25 @@ public:
 
     inline float get_pixel(const Index& idx) const { return contains(idx) ? image(idx.i, idx.j) : NO_DATA; }
 
-    inline bool pixel_has_data(const Index& idx) const {
-        return pixel_value_valid(get_pixel(idx)) ? true : false;
-    }
-
     inline void set_pixel(const Index& idx, float value) {
         if (!contains(idx)) throw std::runtime_error("Index out of bounds!");
         image(idx.i, idx.j) = value;
+    }
+
+    void set_all(float value);
+
+    // Functions for determining and setting whether pixels have valid data.
+    inline bool pixel_has_data(const Index& idx) const {
+        return pixel_value_valid(get_pixel(idx)) ? true : false;
     }
 
     inline void mask_pixel(const Index& idx) {
         if (!contains(idx)) throw std::runtime_error("Index out of bounds!");
         image(idx.i, idx.j) = NO_DATA;
     }
-    
+
+    void replace_masked_values(float value = 0.0);
+
     // Functions for locally storing the image time.
     double get_obstime() const { return obstime; }
     void set_obstime(double new_time) { obstime = new_time; }
@@ -72,9 +77,9 @@ public:
     // this will be a raw pointer to the underlying array
     // we use this to copy to GPU and nowhere else!
     float* data() { return image.data(); }
-    void set_all(float value);
 
-    // Check if two raw images are approximately equal.
+    // Check if two raw images are approximately equal. Counts invalid pixels
+    // (NaNs) as equal if they appear in both images.
     bool l2_allclose(const RawImage& imgB, float atol) const;
 
     // Get the interpolated brightness of a real values point

--- a/src/kbmod/search/raw_image.h
+++ b/src/kbmod/search/raw_image.h
@@ -60,6 +60,11 @@ public:
         image(idx.i, idx.j) = value;
     }
 
+    inline void mask_pixel(const Index& idx) {
+        if (!contains(idx)) throw std::runtime_error("Index out of bounds!");
+        image(idx.i, idx.j) = NO_DATA;
+    }
+    
     // Functions for locally storing the image time.
     double get_obstime() const { return obstime; }
     void set_obstime(double new_time) { obstime = new_time; }

--- a/src/kbmod/search/stamp_creator.cpp
+++ b/src/kbmod/search/stamp_creator.cpp
@@ -31,7 +31,7 @@ std::vector<RawImage> StampCreator::create_stamps(ImageStack& stack, const Traje
     return stamps;
 }
 
-// For stamps used for visualization we replace NO_DATA tages with zeros
+// For stamps used for visualization we replace invalid pixels with zeros
 // and return all the stamps (regardless of whether individual timesteps
 // have been filtered).
 std::vector<RawImage> StampCreator::get_stamps(ImageStack& stack, const Trajectory& t, int radius) {
@@ -40,21 +40,21 @@ std::vector<RawImage> StampCreator::get_stamps(ImageStack& stack, const Trajecto
 }
 
 // For creating coadded stamps, we do not interpolate the pixel values and keep
-// NO_DATA tagged (so we can filter it out of mean/median).
+// invalid pixels tagged (so we can filter it out of mean/median).
 RawImage StampCreator::get_median_stamp(ImageStack& stack, const Trajectory& trj, int radius,
                                         const std::vector<bool>& use_index) {
     return create_median_image(create_stamps(stack, trj, radius, true /*=keep_no_data*/, use_index));
 }
 
 // For creating coadded stamps, we do not interpolate the pixel values and keep
-// NO_DATA tagged (so we can filter it out of mean/median).
+// invalid pixels tagged (so we can filter it out of mean/median).
 RawImage StampCreator::get_mean_stamp(ImageStack& stack, const Trajectory& trj, int radius,
                                       const std::vector<bool>& use_index) {
     return create_mean_image(create_stamps(stack, trj, radius, true /*=keep_no_data*/, use_index));
 }
 
-// For creating summed stamps, we do not interpolate the pixel values and replace NO_DATA
-// with zero (which is the same as filtering it out for the sum).
+// For creating summed stamps, we do not interpolate the pixel values and replace
+// invalid pixels with zero (which is the same as filtering it out for the sum).
 RawImage StampCreator::get_summed_stamp(ImageStack& stack, const Trajectory& trj, int radius,
                                         const std::vector<bool>& use_index) {
     return create_summed_image(create_stamps(stack, trj, radius, false /*=keep_no_data*/, use_index));

--- a/src/kbmod/search/stamp_creator.h
+++ b/src/kbmod/search/stamp_creator.h
@@ -15,8 +15,8 @@ public:
     StampCreator();
 
     // Functions science stamps for filtering, visualization, etc. User can specify
-    // the radius of the stamp, whether to keep NO_DATA values or replace them with zero,
-    // and what indices to use.
+    // the radius of the stamp, whether to keep no data values (e.g. NaN) or replace
+    //  them with zero, and what indices to use.
     // The indices to use are indicated by use_index: a vector<bool> indicating whether to use
     // each time step. An empty (size=0) vector will use all time steps.
     static std::vector<RawImage> create_stamps(ImageStack& stack, const Trajectory& trj, int radius,

--- a/tests/test_layered_image.py
+++ b/tests/test_layered_image.py
@@ -313,8 +313,8 @@ class test_LayeredImage(unittest.TestCase):
 
         # Mask a single pixel, set another to variance of zero,
         # and mark two as NaN.
-        sci.set_pixel(3, 1, KB_NO_DATA)
-        var.set_pixel(3, 1, KB_NO_DATA)
+        sci.mask_pixel(3, 1)
+        var.mask_pixel(3, 1)
         var.set_pixel(3, 2, 0.0)
         var.set_pixel(3, 0, np.nan)
         sci.set_pixel(3, 3, math.nan)
@@ -347,8 +347,8 @@ class test_LayeredImage(unittest.TestCase):
 
     def test_subtract_template(self):
         sci = self.image.get_science()
-        sci.set_pixel(7, 10, KB_NO_DATA)
-        sci.set_pixel(7, 11, KB_NO_DATA)
+        sci.mask_pixel(7, 10)
+        sci.mask_pixel(7, 11)
         sci.set_pixel(7, 12, math.nan)
         sci.set_pixel(7, 13, np.nan)
         old_sci = RawImage(sci.image.copy())  # Make a copy.

--- a/tests/test_layered_image.py
+++ b/tests/test_layered_image.py
@@ -53,21 +53,21 @@ class test_LayeredImage(unittest.TestCase):
         # Check that the LayeredImage pixel lookups work with a masked pixel.
         # But the the mask was not applied yet to the images themselves.
         mask.set_pixel(5, 6, 1)
-        self.assertGreater(science.get_pixel(5, 6), KB_NO_DATA)
-        self.assertGreater(variance.get_pixel(5, 6), KB_NO_DATA)
-        self.assertEqual(self.image.get_science_pixel(5, 6), KB_NO_DATA)
-        self.assertEqual(self.image.get_variance_pixel(5, 6), KB_NO_DATA)
+        self.assertTrue(pixel_value_valid(science.get_pixel(5, 6)))
+        self.assertTrue(pixel_value_valid(variance.get_pixel(5, 6)))
+        self.assertFalse(pixel_value_valid(self.image.get_science_pixel(5, 6)))
+        self.assertFalse(pixel_value_valid(self.image.get_variance_pixel(5, 6)))
 
         # Test that out of bounds pixel lookups are handled correctly.
-        self.assertEqual(self.image.get_science_pixel(-1, 1), KB_NO_DATA)
-        self.assertEqual(self.image.get_science_pixel(1, -1), KB_NO_DATA)
-        self.assertEqual(self.image.get_science_pixel(self.image.get_height() + 1, 1), KB_NO_DATA)
-        self.assertEqual(self.image.get_science_pixel(1, self.image.get_width() + 1), KB_NO_DATA)
+        self.assertFalse(pixel_value_valid(self.image.get_science_pixel(-1, 1)))
+        self.assertFalse(pixel_value_valid(self.image.get_science_pixel(1, -1)))
+        self.assertFalse(pixel_value_valid(self.image.get_science_pixel(self.image.get_height() + 1, 1)))
+        self.assertFalse(pixel_value_valid(self.image.get_science_pixel(1, self.image.get_width() + 1)))
 
-        self.assertEqual(self.image.get_variance_pixel(-1, 1), KB_NO_DATA)
-        self.assertEqual(self.image.get_variance_pixel(1, -1), KB_NO_DATA)
-        self.assertEqual(self.image.get_variance_pixel(self.image.get_height() + 1, 1), KB_NO_DATA)
-        self.assertEqual(self.image.get_variance_pixel(1, self.image.get_width() + 1), KB_NO_DATA)
+        self.assertFalse(pixel_value_valid(self.image.get_variance_pixel(-1, 1)))
+        self.assertFalse(pixel_value_valid(self.image.get_variance_pixel(1, -1)))
+        self.assertFalse(pixel_value_valid(self.image.get_variance_pixel(self.image.get_height() + 1, 1)))
+        self.assertFalse(pixel_value_valid(self.image.get_variance_pixel(1, self.image.get_width() + 1)))
 
     def test_create_from_layers(self):
         sci = RawImage(30, 40)
@@ -106,8 +106,8 @@ class test_LayeredImage(unittest.TestCase):
                 if x == 12 and y == 10:
                     # The masked pixel should have no data.
                     self.assertEqual(mask2.get_pixel(y, x), 1)
-                    self.assertAlmostEqual(img2.get_science_pixel(y, x), KB_NO_DATA)
-                    self.assertAlmostEqual(img2.get_variance_pixel(y, x), KB_NO_DATA)
+                    self.assertFalse(pixel_value_valid(img2.get_science_pixel(y, x)))
+                    self.assertFalse(pixel_value_valid(img2.get_variance_pixel(y, x)))
                 else:
                     self.assertEqual(mask2.get_pixel(y, x), 0)
                     self.assertAlmostEqual(img2.get_science_pixel(y, x), x + 40.0 * y)
@@ -336,14 +336,14 @@ class test_LayeredImage(unittest.TestCase):
                 if psi_has_data:
                     self.assertAlmostEqual(psi.get_pixel(y, x), x / (y + 1), delta=1e-5)
                 else:
-                    self.assertEqual(psi.get_pixel(y, x), KB_NO_DATA)
+                    self.assertFalse(pixel_value_valid(psi.get_pixel(y, x)))
 
                 phi_has_data = y != 3 or x > 2
                 self.assertEqual(phi.pixel_has_data(y, x), phi_has_data)
                 if phi_has_data:
                     self.assertAlmostEqual(phi.get_pixel(y, x), 1.0 / (y + 1), delta=1e-5)
                 else:
-                    self.assertEqual(phi.get_pixel(y, x), KB_NO_DATA)
+                    self.assertFalse(pixel_value_valid(phi.get_pixel(y, x)))
 
     def test_subtract_template(self):
         sci = self.image.get_science()

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -241,9 +241,9 @@ class test_RawImage(unittest.TestCase):
 
         # Mask out three pixels.
         img = RawImage(self.array)
-        img.set_pixel(0, 3, KB_NO_DATA)
-        img.set_pixel(5, 6, KB_NO_DATA)
-        img.set_pixel(5, 7, KB_NO_DATA)
+        img.mask_pixel(0, 3)
+        img.mask_pixel(5, 6)
+        img.mask_pixel(5, 7)
 
         if device.upper() == "CPU":
             img.convolve_cpu(p)
@@ -304,7 +304,7 @@ class test_RawImage(unittest.TestCase):
     def convolve_psf_average(self, device):
         # Mask out a single pixel.
         img = RawImage(self.array)
-        img.set_pixel(4, 6, KB_NO_DATA)
+        img.mask_pixel(4, 6)
 
         # Set up a simple "averaging" psf to convolve.
         psf_data = np.zeros((5, 5), dtype=np.single)

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -84,6 +84,22 @@ class test_RawImage(unittest.TestCase):
         self.assertFalse(pixel_value_valid(img.get_pixel(5, -1)))
         self.assertFalse(pixel_value_valid(img.get_pixel(self.height, 5)))
 
+    def test_validity_checker(self):
+        img = RawImage(img=np.array([[0, 0], [0, 0]]).astype(np.float32), obs_time=10.0)
+        self.assertTrue(img.pixel_has_data(0, 0))
+
+        img.set_pixel(0, 0, np.nan)
+        self.assertFalse(img.pixel_has_data(0, 0))
+
+        img.set_pixel(0, 0, np.inf)
+        self.assertFalse(img.pixel_has_data(0, 0))
+
+        img.set_pixel(0, 0, -np.inf)
+        self.assertFalse(img.pixel_has_data(0, 0))
+
+        img.mask_pixel(0, 0)
+        self.assertFalse(img.pixel_has_data(0, 0))
+        
     def test_interpolated_add(self):
         """Test that we can add values to the pixel."""
         img = RawImage(img=self.array, obs_time=10.0)
@@ -104,25 +120,25 @@ class test_RawImage(unittest.TestCase):
         # norm closeness.
         img2 = RawImage(img)
         img2.imref += 0.0001
-        self.assertTrue(np.allclose(img.image, img2.image, atol=0.01))
+        self.assertTrue(img.l2_allclose(img2, 0.01))
 
-        # Add a single NO_DATA entry.
-        img.set_pixel(5, 7, KB_NO_DATA)
-        self.assertFalse(np.allclose(img.image, img2.image, atol=0.01))
+        # Add a single masked entry.
+        img.mask_pixel(5, 7)
+        self.assertFalse(img.l2_allclose(img2, 0.01))
 
-        img2.set_pixel(5, 7, KB_NO_DATA)
-        self.assertTrue(np.allclose(img.image, img2.image, atol=0.01))
+        img2.mask_pixel(5, 7)
+        self.assertTrue(img.l2_allclose(img2, 0.01))
 
-        # Add a second NO_DATA entry to image 2.
-        img2.set_pixel(7, 7, KB_NO_DATA)
-        self.assertFalse(np.allclose(img.image, img2.image, atol=0.01))
+        # Add a second masked entry to image 2.
+        img2.mask_pixel(7, 7)
+        self.assertFalse(img.l2_allclose(img2, 0.01))
 
-        img.set_pixel(7, 7, KB_NO_DATA)
-        self.assertTrue(np.allclose(img.image, img2.image, atol=0.01))
+        img.mask_pixel(7, 7)
+        self.assertTrue(img.l2_allclose(img2, 0.01))
 
         # Add some noise to mess up an observation.
         img2.set_pixel(1, 3, 13.1)
-        self.assertFalse(np.allclose(img.image, img2.image, atol=0.01))
+        self.assertFalse(img.l2_allclose(img2, 0.01))
 
         # test set_all
         img.set_all(15.0)
@@ -142,6 +158,20 @@ class test_RawImage(unittest.TestCase):
         self.assertAlmostEqual(lower, 0.1, delta=1e-6)
         self.assertAlmostEqual(upper, 100.0, delta=1e-6)
 
+    def test_replace_masked_values(self):
+        img2 = RawImage(np.copy(self.masked_array))
+        img2.replace_masked_values(0.0)
+        
+        for row in range(img2.height):
+            for col in range(img2.width):
+                if pixel_value_valid(self.masked_array[row, col]):
+                    self.assertEqual(
+                        self.masked_array[row, col],
+                        img2.get_pixel(row, col),
+                    )
+                else:
+                    self.assertEqual(img2.get_pixel(row, col), 0.0)
+        
     def test_find_peak(self):
         "Test RawImage find_peak"
         img = RawImage(self.masked_array)
@@ -407,19 +437,19 @@ class test_RawImage(unittest.TestCase):
         self.assertEqual(stamp.image.shape, (3, 3))
         self.assertTrue((stamp.image == self.array[4:7, 7:10]).all())
 
-        # Test a stamp with NO_DATA.
+        # Test a stamp with masked pixels.
         img2 = RawImage(self.masked_array)
         stamp = img2.create_stamp(7.5, 5.5, 1, True)
         self.assertEqual(stamp.image.shape, (3, 3))
-        self.assertTrue((stamp.image == self.masked_array[4:7, 6:9]).all())
+        stamp2 = RawImage(img2.image[4:7, 6:9])
+        self.assertTrue(stamp.l2_allclose(stamp2, 0.01))
 
-        # Test a stamp with NO_DATA and replacement.
-        img2 = RawImage(self.masked_array)
+        # Test a stamp with masked pixels and replacement.
         stamp = img2.create_stamp(7.5, 5.5, 2, False)
         self.assertEqual(stamp.image.shape, (5, 5))
-        expected = np.copy(self.masked_array[3:8, 5:10])
-        expected[expected == KB_NO_DATA] = 0.0
-        self.assertTrue((stamp.image == expected).all())
+        expected_stamp = RawImage(np.copy(self.masked_array[3:8, 5:10]))
+        expected_stamp.replace_masked_values(0.0)
+        self.assertTrue((stamp.image == expected_stamp.image).all())
 
         # Test a stamp that goes out of bounds.
         stamp = img.create_stamp(0.5, 11.5, 1, False)
@@ -433,14 +463,12 @@ class test_RawImage(unittest.TestCase):
 
         # Test a stamp that overlaps at a single corner pixel.
         stamp = img.create_stamp(-1.5, -1.5, 1, True)
-        expected = np.array(
-            [
-                [KB_NO_DATA, KB_NO_DATA, KB_NO_DATA],
-                [KB_NO_DATA, KB_NO_DATA, KB_NO_DATA],
-                [KB_NO_DATA, KB_NO_DATA, 0.0],
-            ]
-        )
-        self.assertTrue((stamp.image == expected).all())
+        for row in range(3):
+            for col in range(3):
+                if row == 2 and col == 2:
+                    self.assertEqual(stamp.image[row][col], 0.0)
+                else:
+                    self.assertFalse(stamp.pixel_has_data(row, col))
 
     def test_create_median_image(self):
         """Tests median image coaddition."""

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -12,6 +12,7 @@ from kbmod.search import (
     create_median_image,
     create_summed_image,
     create_mean_image,
+    pixel_value_valid,
 )
 
 
@@ -78,10 +79,10 @@ class test_RawImage(unittest.TestCase):
     def test_pixel_getters(self):
         """Test RawImage masked pixel value getters"""
         img = RawImage(img=self.array, obs_time=10.0)
-        self.assertEqual(img.get_pixel(-1, 5), KB_NO_DATA)
-        self.assertEqual(img.get_pixel(5, self.width), KB_NO_DATA)
-        self.assertEqual(img.get_pixel(5, -1), KB_NO_DATA)
-        self.assertEqual(img.get_pixel(self.height, 5), KB_NO_DATA)
+        self.assertFalse(pixel_value_valid(img.get_pixel(-1, 5)))
+        self.assertFalse(pixel_value_valid(img.get_pixel(5, self.width)))
+        self.assertFalse(pixel_value_valid(img.get_pixel(5, -1)))
+        self.assertFalse(pixel_value_valid(img.get_pixel(self.height, 5)))
 
     def test_interpolated_add(self):
         """Test that we can add values to the pixel."""
@@ -332,7 +333,7 @@ class test_RawImage(unittest.TestCase):
                         if i == -2 or i == 2 or j == -2 or j == 2:
                             psf_value = 0.0
 
-                        if value != KB_NO_DATA:
+                        if pixel_value_valid(value):
                             running_sum += psf_value * value
                             count += psf_value
                 ave = running_sum / count

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -99,7 +99,7 @@ class test_RawImage(unittest.TestCase):
 
         img.mask_pixel(0, 0)
         self.assertFalse(img.pixel_has_data(0, 0))
-        
+
     def test_interpolated_add(self):
         """Test that we can add values to the pixel."""
         img = RawImage(img=self.array, obs_time=10.0)
@@ -161,7 +161,7 @@ class test_RawImage(unittest.TestCase):
     def test_replace_masked_values(self):
         img2 = RawImage(np.copy(self.masked_array))
         img2.replace_masked_values(0.0)
-        
+
         for row in range(img2.height):
             for col in range(img2.width):
                 if pixel_value_valid(self.masked_array[row, col]):
@@ -171,7 +171,7 @@ class test_RawImage(unittest.TestCase):
                     )
                 else:
                     self.assertEqual(img2.get_pixel(row, col), 0.0)
-        
+
     def test_find_peak(self):
         "Test RawImage find_peak"
         img = RawImage(self.masked_array)

--- a/tests/test_reprojection.py
+++ b/tests/test_reprojection.py
@@ -4,7 +4,7 @@ import numpy as np
 from utils.utils_for_tests import get_absolute_data_path
 
 from kbmod.reprojection import reproject_work_unit
-from kbmod.search import KB_NO_DATA
+from kbmod.search import pixel_value_valid
 from kbmod.work_unit import ImageStack, WorkUnit
 
 
@@ -31,8 +31,6 @@ class test_reprojection(unittest.TestCase):
         data = [[i.get_science().image, i.get_variance().image, i.get_mask().image] for i in images]
 
         for img in data:
-            for i in img:
-                assert not np.any(np.isnan(i))
             # test that mask values are binary
             assert np.all(np.array(img[2] == 1.0) | np.array(img[2] == 0.0))
 
@@ -41,7 +39,6 @@ class test_reprojection(unittest.TestCase):
                 231.61615,
                 113.59214,
                 166.82635,
-                KB_NO_DATA,
                 4.0,
                 1.0,
             ]
@@ -55,12 +52,12 @@ class test_reprojection(unittest.TestCase):
         assert data[2][0][21][49] == test_vals[2]
 
         # test variance
-        assert data[2][1][25][0] == test_vals[3]
-        assert data[2][1][25][9] == test_vals[4]
+        assert not pixel_value_valid(data[2][1][25][0])
+        assert data[2][1][25][9] == test_vals[3]
 
         # test that mask values are projected without interpolation/bleeding
-        assert np.all(data[2][2][35] == test_vals[5])
-        assert np.all(data[2][2][9] == test_vals[5])
+        assert np.all(data[2][2][35] == test_vals[4])
+        assert np.all(data[2][2][9] == test_vals[4])
         assert len(data[2][2][36][data[2][2][36] == 1.0]) == 7
         assert len(data[2][2][34][data[2][2][34] == 1.0]) == 7
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -269,7 +269,7 @@ class test_search(unittest.TestCase):
             x = int(self.trj.x + self.trj.vx * t)
             y = int(self.trj.y + self.trj.vy * t)
             pixVal = self.imlist[i].get_science().get_pixel(y, x)
-            if pixVal == KB_NO_DATA:
+            if not pixel_value_valid(pixVal):
                 pivVal = 0.0
 
             # Check that pixel value of the projected location equals
@@ -290,7 +290,7 @@ class test_search(unittest.TestCase):
             x = int(self.trj.x + self.trj.vx * t)
             y = int(self.trj.y + self.trj.vy * t)
             pixVal = self.imlist[i].get_science().get_pixel(y, x)
-            if pixVal == KB_NO_DATA:
+            if not pixel_value_valid(pixVal):
                 pivVal = 0.0
             sum_middle = sum_middle + pixVal
 
@@ -322,9 +322,9 @@ class test_search(unittest.TestCase):
             x = int(self.trj.x + self.trj.vx * t)
             y = int(self.trj.y + self.trj.vy * t)
             pixVal = self.imlist[i].get_science().get_pixel(y, x)
-            if pixVal != KB_NO_DATA and goodIdx[0][i] == 1:
+            if pixel_value_valid(pixVal) and goodIdx[0][i] == 1:
                 pix_values0.append(pixVal)
-            if pixVal != KB_NO_DATA and goodIdx[1][i] == 1:
+            if pixel_value_valid(pixVal) and goodIdx[1][i] == 1:
                 pix_values1.append(pixVal)
         self.assertEqual(len(pix_values0), self.img_count)
         self.assertEqual(len(pix_values1), self.img_count - 3)
@@ -346,7 +346,7 @@ class test_search(unittest.TestCase):
         pix_values = []
         for i in range(self.img_count):
             pixVal = self.imlist[i].get_science().get_pixel(self.masked_y, self.masked_x)
-            if pixVal != KB_NO_DATA:
+            if pixel_value_valid(pixVal):
                 pix_values.append(pixVal)
         self.assertEqual(len(pix_values), self.img_count / 2)
 
@@ -379,10 +379,10 @@ class test_search(unittest.TestCase):
             x = int(self.trj.x + self.trj.vx * t)
             y = int(self.trj.y + self.trj.vy * t)
             pixVal = self.imlist[i].get_science().get_pixel(y, x)
-            if pixVal != KB_NO_DATA and goodIdx[0][i] == 1:
+            if pixel_value_valid(pixVal) and goodIdx[0][i] == 1:
                 pix_sum0 += pixVal
                 pix_count0 += 1
-            if pixVal != KB_NO_DATA and goodIdx[1][i] == 1:
+            if pixel_value_valid(pixVal) and goodIdx[1][i] == 1:
                 pix_sum1 += pixVal
                 pix_count1 += 1
         self.assertEqual(pix_count0, self.img_count)
@@ -406,7 +406,7 @@ class test_search(unittest.TestCase):
         pix_count = 0.0
         for i in range(self.img_count):
             pixVal = self.imlist[i].get_science().get_pixel(self.masked_y, self.masked_x)
-            if pixVal != KB_NO_DATA:
+            if pixel_value_valid(pixVal):
                 pix_sum += pixVal
                 pix_count += 1.0
         self.assertEqual(pix_count, self.img_count / 2.0)
@@ -638,7 +638,7 @@ class test_search(unittest.TestCase):
                     x = int(self.trj.x + self.trj.vx * t) + x_offset
                     y = int(self.trj.y + self.trj.vy * t) + y_offset
                     pixVal = self.imlist[i].get_science().get_pixel(y, x)
-                    if pixVal != KB_NO_DATA:
+                    if pixel_value_valid(pixVal):
                         pix_sum += pixVal
                         pix_count += 1.0
                         pix_vals.append(pixVal)
@@ -695,7 +695,7 @@ class test_search(unittest.TestCase):
                     x = int(self.trj.x + self.trj.vx * t) + x_offset
                     y = int(self.trj.y + self.trj.vy * t) + y_offset
                     pixVal = self.imlist[i].get_science().get_pixel(y, x)
-                    if pixVal != KB_NO_DATA:
+                    if pixel_value_valid(pixVal):
                         pix_sum += pixVal
                         pix_count += 1.0
                         pix_vals.append(pixVal)
@@ -745,11 +745,11 @@ class test_search(unittest.TestCase):
                     y = int(self.trj.y + self.trj.vy * t) + y_offset
                     pixVal = self.imlist[i].get_science().get_pixel(y, x)
 
-                    if pixVal != KB_NO_DATA and inds[0][i] > 0:
+                    if pixel_value_valid(pixVal) and inds[0][i] > 0:
                         sum_0 += pixVal
                         count_0 += 1.0
 
-                    if pixVal != KB_NO_DATA and inds[1][i] > 0:
+                    if pixel_value_valid(pixVal) and inds[1][i] > 0:
                         sum_1 += pixVal
                         count_1 += 1.0
 
@@ -796,11 +796,11 @@ class test_search(unittest.TestCase):
                     y = int(self.trj.y + self.trj.vy * t) + y_offset
                     pixVal = self.imlist[i].get_science().get_pixel(y, x)
 
-                    if pixVal != KB_NO_DATA and inds[0][i] > 0:
+                    if pixel_value_valid(pixVal) and inds[0][i] > 0:
                         sum_0 += pixVal
                         count_0 += 1.0
 
-                    if pixVal != KB_NO_DATA and inds[1][i] > 0:
+                    if pixel_value_valid(pixVal) and inds[1][i] > 0:
                         sum_1 += pixVal
                         count_1 += 1.0
 


### PR DESCRIPTION
Replaces the `NO_DATA = -9999.0` with setting `NO_DATA = NAN`. This breaks all direct `==` comparisons, so we make use of the new `pixel_value_valid()` function for testing data validity.  Unfortunately this breaks the vectorization of a few Eigen functions (although there is probably a better way to structure them to keep the vectorization intact).

The `NO_DATA` and `KB_NO_DATA` flags are kept so we can use them to set data throughout the program.

The structure of the change is also meant to provide flexibility down the road if we want to change how we represent masked data. We only need to change a few locations within `common.h` instead of changing values throughout the files.