### PR TITLE
Add a TrajectoryList data structure the manages CPU and GPU memory

### DIFF
--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -18,6 +18,7 @@ namespace py = pybind11;
 #include "kernel_testing_helpers.cpp"
 #include "psi_phi_array.cpp"
 #include "debug_timer.cpp"
+#include "trajectory_list.cpp"
 
 PYBIND11_MODULE(search, m) {
     m.attr("KB_NO_DATA") = pybind11::float_(search::NO_DATA);
@@ -42,6 +43,7 @@ PYBIND11_MODULE(search, m) {
     search::stamp_parameters_bindings(m);
     search::psi_phi_array_binding(m);
     search::debug_timer_binding(m);
+    search::trajectory_list_binding(m);
     // Helper function from common.h
     m.def("pixel_value_valid", &search::pixel_value_valid);
     // Functions from raw_image.cpp

--- a/src/kbmod/search/image_stack.cpp
+++ b/src/kbmod/search/image_stack.cpp
@@ -2,9 +2,7 @@
 
 namespace search {
 
-ImageStack::ImageStack(const std::vector<LayeredImage>& imgs) {
-    images = imgs;
-}
+ImageStack::ImageStack(const std::vector<LayeredImage>& imgs) { images = imgs; }
 
 LayeredImage& ImageStack::get_single_image(int index) {
     if (index < 0 || index > images.size()) throw std::out_of_range("ImageStack index out of bounds.");

--- a/src/kbmod/search/pydocs/stack_search_docs.h
+++ b/src/kbmod/search/pydocs/stack_search_docs.h
@@ -28,7 +28,6 @@ static const auto DOC_StackSearch_set_min_lh = R"doc(
       The minimum likelihood value for a trajectory to be returned.
   )doc";
 
-
 static const auto DOC_StackSearch_enable_gpu_sigmag_filter = R"doc(
   Enable on-GPU sigma-G filtering.
 

--- a/src/kbmod/search/pydocs/trajectory_list_docs.h
+++ b/src/kbmod/search/pydocs/trajectory_list_docs.h
@@ -85,6 +85,23 @@ static const auto DOC_TrajectoryList_get_batch = R"doc(
   ``RunTimeError`` if start < 0 or count <= 0 or if the data is on GPU.
   )doc";
 
+static const auto DOC_TrajectoryList_resize = R"doc(
+  Forcibly resize the array. If the size is decreased, the extra entries
+  are dropped from the back. If the size is increased, extra (blank)
+  trajectories are added to the back.
+      
+  The data must reside on the CPU.
+
+  Parameters
+  ----------
+  new_size : `int`
+      The new size of the list.
+
+  Raises
+  ------
+  ``RunTimeError`` if new_size < 0 or data is on GPU.
+  )doc";
+
 static const auto DOC_TrajectoryList_move_to_cpu = R"doc(
   Move the data from GPU to CPU. If the data is already on the CPU
   this is a no-op.
@@ -114,6 +131,34 @@ static const auto DOC_TrajectoryList_sort_by_likelihood = R"doc(
 static const auto DOC_TrajectoryList_sort_by_obs_count = R"doc(
   Sort the data in order of decreasing obs_count. The data must reside on the CPU.
 
+  Raises
+  ------
+  Raises a ``RuntimeError`` the data is on GPU.
+  )doc";
+
+static const auto DOC_TrajectoryList_filter_by_likelihood = R"doc(
+  Sort the data in order of decreasing likelihood and drop everything less than
+  a given threshold. The data must reside on the CPU.
+
+  Parameters
+  ----------
+  min_likelihood : `float`
+      The threshold on minimum likelihood.
+      
+  Raises
+  ------
+  Raises a ``RuntimeError`` the data is on GPU.
+  )doc";
+
+static const auto DOC_TrajectoryList_filter_by_obs_count = R"doc(
+  Sort the data in order of decreasing obs_count and drop everything less than
+  a given threshold. The data must reside on the CPU.
+
+  Parameters
+  ----------
+  min_obs_count : `int`
+      The threshold on minimum number of observations.
+      
   Raises
   ------
   Raises a ``RuntimeError`` the data is on GPU.

--- a/src/kbmod/search/pydocs/trajectory_list_docs.h
+++ b/src/kbmod/search/pydocs/trajectory_list_docs.h
@@ -1,0 +1,124 @@
+#ifndef TRAJECTORY_LIST_DOCS_
+#define TRAJECTORY_LIST_DOCS_
+
+namespace pydocs {
+
+static const auto DOC_TrajectoryList = R"doc(
+  A list of trajectories that can be transferred between CPU or GPU.
+  )doc";
+
+static const auto DOC_TrajectoryList_on_gpu = R"doc(
+  Whether the data currently resides on the GPU (True) or CPU (False)
+  )doc";
+
+static const auto DOC_TrajectoryList_get_size = R"doc(
+  Return the size of the list.
+  )doc";
+
+static const auto DOC_TrajectoryList_get_trajectory = R"doc(
+  Get a reference trajectory from the list. The data must reside on the CPU.
+
+  Parameters
+  ----------
+  index : `int`
+      The index of the entry.
+
+  Returns
+  -------
+  trj : `Trajectory`
+      The corresponding Trajectory object.
+
+  Raises
+  ------
+  Raises a ``RuntimeError`` if the index is invalid or the data currently resides
+  on the GPU.
+  )doc";
+
+static const auto DOC_TrajectoryList_set_trajectory = R"doc(
+  Set a trajectory in the list. The data must reside on the CPU.
+
+  Parameters
+  ----------
+  index : `int`
+      The index of the entry.
+  new_value : `Trajectory`
+      The corresponding Trajectory object.
+
+  Raises
+  ------
+  Raises a ``RuntimeError`` if the index is invalid or the data currently resides
+  on the GPU.
+  )doc";
+
+static const auto DOC_TrajectoryList_get_list = R"doc(
+  Return the full list of trajectories. The data must reside on the CPU.
+
+  Returns
+  -------
+  result : `list`
+      The list of trajectories
+
+  Raises
+  ------
+  Raises a ``RuntimeError`` if the data currently resides on the GPU.
+  )doc";
+
+static const auto DOC_TrajectoryList_get_batch = R"doc(
+  Return a batch of results. The data must reside on the CPU.
+
+  Parameters
+  ----------
+  start : `int`
+      The starting index of the results to retrieve. Returns
+      an empty list if start is past the end of the cache.
+  count : `int`
+      The maximum number of results to retrieve. Returns fewer
+      results if there are not enough in the cache.
+
+  Returns
+  -------
+  results : `List`
+      A list of ``Trajectory`` objects for the cached results.
+
+  Raises
+  ------
+  ``RunTimeError`` if start < 0 or count <= 0 or if the data is on GPU.
+  )doc";
+
+static const auto DOC_TrajectoryList_move_to_cpu = R"doc(
+  Move the data from GPU to CPU. If the data is already on the CPU
+  this is a no-op.
+
+  Raises
+  ------
+  Raises a ``RuntimeError`` if invalid state encountered.
+  )doc";
+
+static const auto DOC_TrajectoryList_move_to_gpu = R"doc(
+  Move the data from CPU to GPU. If the data is already on the GPU
+  this is a no-op.
+
+  Raises
+  ------
+  Raises a ``RuntimeError`` if invalid state encountered.
+  )doc";
+
+static const auto DOC_TrajectoryList_sort_by_likelihood = R"doc(
+  Sort the data in order of decreasing likelihood. The data must reside on the CPU.
+
+  Raises
+  ------
+  Raises a ``RuntimeError`` the data is on GPU.
+  )doc";
+
+static const auto DOC_TrajectoryList_sort_by_obs_count = R"doc(
+  Sort the data in order of decreasing obs_count. The data must reside on the CPU.
+
+  Raises
+  ------
+  Raises a ``RuntimeError`` the data is on GPU.
+  )doc";
+
+}  // namespace pydocs
+
+#endif /* TRAJECTORY_LIST_DOCS_ */

--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -2,14 +2,14 @@
 
 namespace search {
 #ifdef HAVE_CUDA
-extern "C" void deviceSearchFilter(PsiPhiArray& psi_phi_array, SearchParameters params, int num_trajectories,
-                                   Trajectory* trj_to_search, int num_results, Trajectory* best_results);
+extern "C" void deviceSearchFilter(PsiPhiArray& psi_phi_array, SearchParameters params,
+                                   TrajectoryList& trj_to_search, TrajectoryList& results);
 
 extern "C" void evaluateTrajectory(PsiPhiArrayMeta psi_phi_meta, void* psi_phi_vect, float* image_times,
                                    SearchParameters params, Trajectory* candidate);
 #endif
 
-StackSearch::StackSearch(ImageStack& imstack) : stack(imstack) {
+StackSearch::StackSearch(ImageStack& imstack) : stack(imstack), results(0) {
     debug_info = false;
     psi_phi_generated = false;
 
@@ -80,7 +80,7 @@ void StackSearch::enable_gpu_encoding(int encode_num_bytes) {
 }
 
 void StackSearch::set_start_bounds_x(int x_min, int x_max) {
-    if (x_min > x_max) {
+    if (x_min >= x_max) {
         throw std::runtime_error("Invalid search bounds for the x pixel.");
     }
     params.x_start_min = x_min;
@@ -88,7 +88,7 @@ void StackSearch::set_start_bounds_x(int x_min, int x_max) {
 }
 
 void StackSearch::set_start_bounds_y(int y_min, int y_max) {
-    if (y_min > y_max) {
+    if (y_min >= y_max) {
         throw std::runtime_error("Invalid search bounds for the y pixel.");
     }
     params.y_start_min = y_min;
@@ -156,17 +156,24 @@ void StackSearch::search(std::vector<Trajectory>& search_list, int min_observati
     prepare_psi_phi();
     psi_phi_timer.stop();
 
-    // Allocate a vector for the results.
-    int num_search_pixels =
-            ((params.x_start_max - params.x_start_min) * (params.y_start_max - params.y_start_min));
+    // Allocate a vector for the results and move it onto the GPU.
+    int search_width = params.x_start_max - params.x_start_min;
+    int search_height = params.y_start_max - params.y_start_min;
+    int num_search_pixels = search_width * search_height;
     int max_results = num_search_pixels * RESULTS_PER_PIXEL;
     if (debug_info) {
         std::cout << "Searching X=[" << params.x_start_min << ", " << params.x_start_max << "]"
                   << " Y=[" << params.y_start_min << ", " << params.y_start_max << "]\n";
         std::cout << "Allocating space for " << max_results << " results.\n";
     }
-    results = std::vector<Trajectory>(max_results);
-    if (debug_info) std::cout << search_list.size() << " trajectories... \n" << std::flush;
+    results = TrajectoryList(max_results);
+    results.move_to_gpu();
+
+    // Allocate space for the search list and move that to the GPU.
+    int num_to_search = search_list.size();
+    if (debug_info) std::cout << "Searching " << num_to_search << " trajectories... \n" << std::flush;
+    TrajectoryList gpu_search_list = TrajectoryList(search_list);
+    gpu_search_list.move_to_gpu();
 
     // Set the minimum number of observations.
     params.min_observations = min_observations;
@@ -174,15 +181,19 @@ void StackSearch::search(std::vector<Trajectory>& search_list, int min_observati
     // Do the actual search on the GPU.
     DebugTimer search_timer = DebugTimer("Running search", debug_info);
 #ifdef HAVE_CUDA
-    deviceSearchFilter(psi_phi_array, params, search_list.size(), search_list.data(), max_results,
-                       results.data());
+    deviceSearchFilter(psi_phi_array, params, gpu_search_list, results);
 #else
     throw std::runtime_error("Non-GPU search is not implemented.");
 #endif
     search_timer.stop();
 
+    // Move both lists back to CPU to unallocate GPU space (this will happen automatically
+    // for gpu_search_list when the object goes out of scope, but we do it explicitly here).
+    results.move_to_cpu();
+    gpu_search_list.move_to_cpu();
+
     DebugTimer sort_timer = DebugTimer("Sorting results", debug_info);
-    sort_results();
+    results.sort_by_likelihood();
     sort_timer.stop();
     core_timer.stop();
 }
@@ -217,24 +228,14 @@ std::vector<float> StackSearch::get_phi_curves(Trajectory& trj) {
     return extract_psi_or_phi_curve(trj, false);
 }
 
-void StackSearch::sort_results() {
-    __gnu_parallel::sort(results.begin(), results.end(),
-                         [](Trajectory a, Trajectory b) { return b.lh < a.lh; });
-}
-
 std::vector<Trajectory> StackSearch::get_results(int start, int count) {
-    if (start < 0) throw std::runtime_error("start must be 0 or greater");
-    if (count <= 0) throw std::runtime_error("count must be greater than 0");
-
-    if (start + count >= results.size()) {
-        count = results.size() - start;
-    }
-    return std::vector<Trajectory>(results.begin() + start, results.begin() + start + count);
+    return results.get_batch(start, count);
 }
 
 // This function is used only for testing by injecting known result trajectories.
-void StackSearch::set_results(const std::vector<Trajectory>& new_results) { results = new_results; }
-void StackSearch::clear_results() { results.clear(); }
+void StackSearch::set_results(const std::vector<Trajectory>& new_results) {
+    results = TrajectoryList(new_results);
+}
 
 #ifdef Py_PYTHON_H
 static void stack_search_bindings(py::module& m) {
@@ -273,8 +274,7 @@ static void stack_search_bindings(py::module& m) {
             .def("prepare_psi_phi", &ks::prepare_psi_phi, pydocs::DOC_StackSearch_prepare_psi_phi)
             .def("clear_psi_phi", &ks::clear_psi_phi, pydocs::DOC_StackSearch_clear_psi_phi)
             .def("get_results", &ks::get_results, pydocs::DOC_StackSearch_get_results)
-            .def("set_results", &ks::set_results, pydocs::DOC_StackSearch_set_results)
-            .def("clear_results", &ks::clear_results, pydocs::DOC_StackSearch_clear_results);
+            .def("set_results", &ks::set_results, pydocs::DOC_StackSearch_set_results);
 }
 #endif /* Py_PYTHON_H */
 

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -20,6 +20,7 @@
 #include "psi_phi_array_utils.h"
 #include "pydocs/stack_search_docs.h"
 #include "stamp_creator.h"
+#include "trajectory_list.h"
 
 namespace search {
 using Point = indexing::Point;
@@ -62,13 +63,10 @@ public:
 
     // Helper functions for testing
     void set_results(const std::vector<Trajectory>& new_results);
-    void clear_results();
 
     virtual ~StackSearch(){};
 
 protected:
-    void sort_results();
-
     std::vector<float> extract_psi_or_phi_curve(Trajectory& trj, bool extract_psi);
 
     // Core data and search parameters
@@ -80,8 +78,8 @@ protected:
     bool psi_phi_generated;
     PsiPhiArray psi_phi_array;
 
-    // Cached data for grid search. TODO: see if we can remove this.
-    std::vector<Trajectory> results;
+    // Results from the grid search.
+    TrajectoryList results;
 };
 
 } /* namespace search */

--- a/src/kbmod/search/trajectory_list.cpp
+++ b/src/kbmod/search/trajectory_list.cpp
@@ -1,0 +1,129 @@
+#include "trajectory_list.h"
+#include "pydocs/trajectory_list_docs.h"
+
+#include <parallel/algorithm>
+#include <algorithm>
+
+namespace search {
+
+// Declaration of CUDA functions that will be linked in.
+#ifdef HAVE_CUDA
+extern "C" Trajectory *allocate_gpu_trajectory_list(long unsigned num_trj);
+
+extern "C" void free_gpu_trajectory_list(Trajectory *gpu_ptr);
+
+extern "C" void copy_trajectory_list(Trajectory *cpu_ptr, Trajectory *gpu_ptr, long unsigned num_trj,
+                                     bool to_gpu);
+#endif
+
+// -------------------------------------------------------
+// --- Implementation of core data structure functions ---
+// -------------------------------------------------------
+
+TrajectoryList::TrajectoryList(int max_list_size) {
+    if (max_list_size <= 0) {
+        throw std::runtime_error("Invalid TrajectoryList size.");
+    }
+    max_size = max_list_size;
+
+    // Start with the data on CPU.
+    data_on_gpu = false;
+    cpu_list.resize(max_size);
+    gpu_list_ptr = nullptr;
+}
+
+TrajectoryList::~TrajectoryList() {
+#ifdef HAVE_CUDA
+    if (gpu_list_ptr != nullptr) {
+        free_gpu_trajectory_list(gpu_list_ptr);
+        gpu_list_ptr = nullptr;
+    }
+#endif
+}
+
+std::vector<Trajectory> TrajectoryList::get_batch(int start, int count) {
+    if (data_on_gpu) throw std::runtime_error("Data on GPU");
+    if (start < 0) throw std::runtime_error("start must be 0 or greater");
+    if (count <= 0) throw std::runtime_error("count must be greater than 0");
+
+    if (start + count >= max_size) {
+        count = max_size - start;
+    }
+    return std::vector<Trajectory>(cpu_list.begin() + start, cpu_list.begin() + start + count);
+}
+
+void TrajectoryList::sort_by_likelihood() {
+    if (data_on_gpu) throw std::runtime_error("Data on GPU");
+    __gnu_parallel::sort(cpu_list.begin(), cpu_list.end(),
+                         [](Trajectory a, Trajectory b) { return b.lh < a.lh; });
+}
+
+void TrajectoryList::sort_by_obs_count() {
+    if (data_on_gpu) throw std::runtime_error("Data on GPU");
+    __gnu_parallel::sort(cpu_list.begin(), cpu_list.end(),
+                         [](Trajectory a, Trajectory b) { return b.obs_count < a.obs_count; });
+}
+
+void TrajectoryList::move_to_gpu() {
+    if (data_on_gpu) return;  // Nothing to do.
+
+    // Error checking.
+    if (gpu_list_ptr != nullptr) throw std::runtime_error("GPU data already allocated.");
+    if (cpu_list.size() != max_size) throw std::runtime_error("List size mismatch.");
+
+        // Allocate the GPU array and copy the data onto GPU.
+#ifdef HAVE_CUDA
+    gpu_list_ptr = allocate_gpu_trajectory_list(max_size);
+    copy_trajectory_list(cpu_list.data(), gpu_list_ptr, max_size, true);
+#else
+    throw std::runtime_error("CUDA installation to move things on or off GPU.");
+#endif
+    data_on_gpu = true;
+}
+
+void TrajectoryList::move_to_cpu() {
+    if (!data_on_gpu) return;  // Nothing to do.
+
+    // Error checking.
+    if (gpu_list_ptr == nullptr) throw std::runtime_error("No GPU data allocated.");
+    if (cpu_list.size() != max_size) throw std::runtime_error("List size mismatch.");
+
+        // Copy the data to CPU and free the GPU array.
+#ifdef HAVE_CUDA
+    copy_trajectory_list(cpu_list.data(), gpu_list_ptr, max_size, false);
+    free_gpu_trajectory_list(gpu_list_ptr);
+    gpu_list_ptr = nullptr;
+#else
+    throw std::runtime_error("CUDA installation to move things on or off GPU.");
+#endif
+
+    data_on_gpu = false;
+}
+
+// -------------------------------------------
+// --- Python definitions --------------------
+// -------------------------------------------
+
+#ifdef Py_PYTHON_H
+static void trajectory_list_binding(py::module &m) {
+    using trjl = search::TrajectoryList;
+
+    py::class_<trjl>(m, "TrajectoryList", pydocs::DOC_TrajectoryList)
+            .def(py::init<int>())
+            .def_property_readonly("on_gpu", &trjl::on_gpu, pydocs::DOC_TrajectoryList_on_gpu)
+            .def("__len__", &trjl::get_size)
+            .def("get_size", &trjl::get_size, pydocs::DOC_TrajectoryList_get_size)
+            .def("get_trajectory", &trjl::get_trajectory, py::return_value_policy::reference_internal,
+                 pydocs::DOC_TrajectoryList_get_trajectory)
+            .def("set_trajectory", &trjl::set_trajectory, pydocs::DOC_TrajectoryList_set_trajectory)
+            .def("get_list", &trjl::get_list, pydocs::DOC_TrajectoryList_get_list)
+            .def("get_batch", &trjl::get_batch, pydocs::DOC_TrajectoryList_get_batch)
+            .def("sort_by_likelihood", &trjl::sort_by_likelihood,
+                 pydocs::DOC_TrajectoryList_sort_by_likelihood)
+            .def("sort_by_obs_count", &trjl::sort_by_obs_count, pydocs::DOC_TrajectoryList_sort_by_obs_count)
+            .def("move_to_cpu", &trjl::move_to_cpu, pydocs::DOC_TrajectoryList_move_to_cpu)
+            .def("move_to_gpu", &trjl::move_to_gpu, pydocs::DOC_TrajectoryList_move_to_gpu);
+}
+#endif
+
+} /* namespace search */

--- a/src/kbmod/search/trajectory_list.h
+++ b/src/kbmod/search/trajectory_list.h
@@ -2,9 +2,8 @@
  * trajectory_list.h
  *
  * The data structure for the raw results (a list of trajectories). The
- * data structure handles memory allocationon both the CPU and GPU and
- * transfering data between the two. It maintains ownership of the pointers
- * until clear() is called the object's destructor is called.
+ * data structure handles memory allocation on both the CPU and GPU and
+ * transfering data between the two.
  *
  * Created on: March 7, 2024
  */
@@ -21,6 +20,7 @@ namespace search {
 class TrajectoryList {
 public:
     explicit TrajectoryList(int max_list_size);
+    explicit TrajectoryList(const std::vector<Trajectory>& prev_list);
     virtual ~TrajectoryList();
 
     // --- Getter functions ----------------
@@ -53,6 +53,9 @@ public:
     inline bool on_gpu() const { return data_on_gpu; }
     void move_to_gpu();
     void move_to_cpu();
+
+    // Array access functions. For use when passing to the GPU only.
+    inline Trajectory* get_gpu_list_ptr() { return gpu_list_ptr; }
 
 private:
     int max_size;

--- a/src/kbmod/search/trajectory_list.h
+++ b/src/kbmod/search/trajectory_list.h
@@ -43,11 +43,17 @@ public:
         return cpu_list;
     }
 
+    // Forcibly resize. May add blank data.
+    void resize(int new_size);
+
+    // Get a batch of results.
     std::vector<Trajectory> get_batch(int start, int count);
 
-    // Processing functions
+    // Processing functions for sorting or filtering.
     void sort_by_likelihood();
     void sort_by_obs_count();
+    void filter_by_likelihood(float min_likelihood);
+    void filter_by_obs_count(int min_obs_count);
 
     // Data allocation functions.
     inline bool on_gpu() const { return data_on_gpu; }

--- a/src/kbmod/search/trajectory_list.h
+++ b/src/kbmod/search/trajectory_list.h
@@ -1,0 +1,67 @@
+/*
+ * trajectory_list.h
+ *
+ * The data structure for the raw results (a list of trajectories). The
+ * data structure handles memory allocationon both the CPU and GPU and
+ * transfering data between the two. It maintains ownership of the pointers
+ * until clear() is called the object's destructor is called.
+ *
+ * Created on: March 7, 2024
+ */
+
+#ifndef TRAJECTORY_LIST_DS_
+#define TRAJECTORY_LIST_DS_
+
+#include <vector>
+
+#include "common.h"
+
+namespace search {
+
+class TrajectoryList {
+public:
+    explicit TrajectoryList(int max_list_size);
+    virtual ~TrajectoryList();
+
+    // --- Getter functions ----------------
+    inline int get_size() const { return max_size; }
+
+    inline Trajectory& get_trajectory(int index) {
+        if (index < 0 || index > max_size) throw std::runtime_error("Index out of bounds.");
+        if (data_on_gpu) throw std::runtime_error("Data on GPU");
+        return cpu_list[index];
+    }
+
+    inline void set_trajectory(int index, const Trajectory& new_value) {
+        if (index < 0 || index > max_size) throw std::runtime_error("Index out of bounds.");
+        if (data_on_gpu) throw std::runtime_error("Data on GPU");
+        cpu_list[index] = new_value;
+    }
+
+    inline std::vector<Trajectory>& get_list() {
+        if (data_on_gpu) throw std::runtime_error("Data on GPU");
+        return cpu_list;
+    }
+
+    std::vector<Trajectory> get_batch(int start, int count);
+
+    // Processing functions
+    void sort_by_likelihood();
+    void sort_by_obs_count();
+
+    // Data allocation functions.
+    inline bool on_gpu() const { return data_on_gpu; }
+    void move_to_gpu();
+    void move_to_cpu();
+
+private:
+    int max_size;
+    bool data_on_gpu;
+
+    std::vector<Trajectory> cpu_list;
+    Trajectory* gpu_list_ptr = nullptr;
+};
+
+} /* namespace search */
+
+#endif /* TRAJECTORY_LIST_DS_ */

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -130,11 +130,6 @@ class test_search(unittest.TestCase):
         self.assertRaises(RuntimeError, self.search.get_results, -1, 5)
         self.assertRaises(RuntimeError, self.search.get_results, 0, 0)
 
-        # Check that clear works.
-        self.search.clear_results()
-        results = self.search.get_results(0, 10)
-        self.assertEqual(len(results), 0)
-
     def test_load_and_filter_results_lh(self):
         time_list = [i / self.img_count for i in range(self.img_count)]
         fake_ds = FakeDataSet(

--- a/tests/test_trajectory_list.py
+++ b/tests/test_trajectory_list.py
@@ -20,7 +20,6 @@ class test_trajectory_list(unittest.TestCase):
         self.assertEqual(len(self.trj_list.get_list()), self.max_size)
 
         # Cannot create a zero or negative length list.
-        self.assertRaises(RuntimeError, TrajectoryList, 0)
         self.assertRaises(RuntimeError, TrajectoryList, -1)
 
     def test_get_set(self):

--- a/tests/test_trajectory_list.py
+++ b/tests/test_trajectory_list.py
@@ -1,0 +1,111 @@
+import unittest
+
+from kbmod.search import HAS_GPU, Trajectory, TrajectoryList
+from kbmod.trajectory_utils import make_trajectory
+
+
+class test_trajectory_list(unittest.TestCase):
+    def setUp(self):
+        self.max_size = 10
+        self.trj_list = TrajectoryList(self.max_size)
+        for i in range(self.max_size):
+            self.trj_list.set_trajectory(i, make_trajectory(x=i))
+
+    def test_create(self):
+        self.assertFalse(self.trj_list.on_gpu)
+        self.assertEqual(self.trj_list.get_size(), self.max_size)
+        self.assertEqual(len(self.trj_list), self.max_size)
+        for i in range(self.max_size):
+            self.assertIsNotNone(self.trj_list.get_trajectory(i))
+        self.assertEqual(len(self.trj_list.get_list()), self.max_size)
+
+        # Cannot create a zero or negative length list.
+        self.assertRaises(RuntimeError, TrajectoryList, 0)
+        self.assertRaises(RuntimeError, TrajectoryList, -1)
+
+    def test_get_set(self):
+        for i in range(self.max_size):
+            self.trj_list.set_trajectory(i, make_trajectory(y=i))
+        for i in range(self.max_size):
+            self.assertEqual(self.trj_list.get_trajectory(i).y, i)
+
+        # The retrieved trajectories are modifiable
+        trj = self.trj_list.get_trajectory(1)
+        trj.x = 101
+        self.assertEqual(self.trj_list.get_trajectory(1).x, 101)
+
+        # Cannot get or set out of bounds.
+        self.assertRaises(RuntimeError, self.trj_list.get_trajectory, self.max_size + 1)
+        self.assertRaises(RuntimeError, self.trj_list.get_trajectory, -1)
+
+        new_trj = make_trajectory(x=10)
+        self.assertRaises(RuntimeError, self.trj_list.set_trajectory, self.max_size + 1, new_trj)
+        self.assertRaises(RuntimeError, self.trj_list.set_trajectory, -1, new_trj)
+
+    def test_get_batch(self):
+        for i in range(self.max_size):
+            self.trj_list.set_trajectory(i, make_trajectory(x=i))
+        subset = self.trj_list.get_batch(3, 2)
+        self.assertEqual(len(subset), 2)
+        self.assertEqual(subset[0].x, 3)
+        self.assertEqual(subset[1].x, 4)
+
+        # We can run off the end.
+        subset = self.trj_list.get_batch(3, 100)
+        self.assertEqual(len(subset), 7)
+
+        # We cannot use an invalid starting index or batch size
+        self.assertRaises(RuntimeError, self.trj_list.get_batch, -1, 3)
+        self.assertRaises(RuntimeError, self.trj_list.get_batch, 3, -1)
+
+    def test_sort(self):
+        lh = [100.0, 110.0, 90.0, 120.0, 125.0]
+        obs_count = [10, 9, 8, 6, 7]
+        lh_order = [4, 3, 1, 0, 2]
+        obs_order = [0, 1, 2, 4, 3]
+
+        trjs = TrajectoryList(5)
+        for i in range(5):
+            trj = make_trajectory(x=i, lh=lh[i], obs_count=obs_count[i])
+            trjs.set_trajectory(i, trj)
+
+        trjs.sort_by_likelihood()
+        for i in range(5):
+            self.assertEqual(trjs.get_trajectory(i).x, lh_order[i])
+
+        trjs.sort_by_obs_count()
+        for i in range(5):
+            self.assertEqual(trjs.get_trajectory(i).x, obs_order[i])
+
+    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    def test_move_to_from_gpu(self):
+        for i in range(self.max_size):
+            self.trj_list.set_trajectory(i, make_trajectory(x=i))
+
+        # Move to GPU.
+        self.trj_list.move_to_gpu()
+        self.assertTrue(self.trj_list.on_gpu)
+
+        # We cannot get or set.
+        self.assertRaises(RuntimeError, self.trj_list.get_trajectory, 0)
+
+        new_trj = make_trajectory(x=10)
+        self.assertRaises(RuntimeError, self.trj_list.set_trajectory, 0, new_trj)
+
+        # Moving to GPU again does not do anything.
+        self.trj_list.move_to_gpu()
+        self.assertTrue(self.trj_list.on_gpu)
+
+        # Move back to CPU.
+        self.trj_list.move_to_cpu()
+        self.assertFalse(self.trj_list.on_gpu)
+        self.trj_list.set_trajectory(0, new_trj)
+        self.assertEqual(self.trj_list.get_trajectory(0).x, 10)
+
+        # Moving back to CPU again doesn't do anything.
+        self.trj_list.move_to_cpu()
+        self.assertFalse(self.trj_list.on_gpu)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a data structure that allows lists of trajectories to be synced back and forth from CPU to GPU. This is keeping results on the GPU after the initial run for subsequent filtering passes.

Each `TrajectoryList` maintains its data on either GPU or CPU. While on GPU the list remains fixed sized and can only be edited by GPU functions. While on CPU the data can be edited by outside functions, resized, etc.