### PR TITLE
Add a bit to determine whether a trajectory is valid

### DIFF
--- a/src/kbmod/search/common.h
+++ b/src/kbmod/search/common.h
@@ -48,6 +48,8 @@ struct Trajectory {
     short y;
     // Number of images summed
     short obs_count;
+    // Whether the trajectory is valid. Used for on-GPU filtering.
+    bool valid = true;
 
     // Get pixel positions from a zero-shifted time.
     float get_x_pos(float time) const { return x + time * vx; }
@@ -57,14 +59,7 @@ struct Trajectory {
     const std::string to_string() const {
         return "lh: " + std::to_string(lh) + " flux: " + std::to_string(flux) + " x: " + std::to_string(x) +
                " y: " + std::to_string(y) + " vx: " + std::to_string(vx) + " vy: " + std::to_string(vy) +
-               " obs_count: " + std::to_string(obs_count);
-    }
-
-    // returns a yaml-compliant string
-    const std::string to_yaml() const {
-        return "{lh: " + std::to_string(lh) + ", flux: " + std::to_string(flux) +
-               ", x: " + std::to_string(x) + ", y: " + std::to_string(y) + ", vx: " + std::to_string(vx) +
-               ", vy: " + std::to_string(vy) + ", obs_count: " + std::to_string(obs_count) + "}";
+               " obs_count: " + std::to_string(obs_count) + " valid: " + std::to_string(valid);
     }
 };
 
@@ -152,19 +147,20 @@ static void trajectory_bindings(py::module &m) {
             .def_readwrite("x", &tj::x)
             .def_readwrite("y", &tj::y)
             .def_readwrite("obs_count", &tj::obs_count)
+            .def_readwrite("valid", &tj::valid)
             .def("get_x_pos", &tj::get_x_pos, pydocs::DOC_Trajectory_get_x_pos)
             .def("get_y_pos", &tj::get_y_pos, pydocs::DOC_Trajectory_get_y_pos)
             .def("__repr__", [](const tj &t) { return "Trajectory(" + t.to_string() + ")"; })
             .def("__str__", &tj::to_string)
             .def(py::pickle(
                     [](const tj &p) {  // __getstate__
-                        return py::make_tuple(p.vx, p.vy, p.lh, p.flux, p.x, p.y, p.obs_count);
+                        return py::make_tuple(p.vx, p.vy, p.lh, p.flux, p.x, p.y, p.obs_count, p.valid);
                     },
                     [](py::tuple t) {  // __setstate__
-                        if (t.size() != 7) throw std::runtime_error("Invalid state!");
+                        if (t.size() != 8) throw std::runtime_error("Invalid state!");
                         tj trj = {t[0].cast<float>(), t[1].cast<float>(), t[2].cast<float>(),
                                   t[3].cast<float>(), t[4].cast<short>(), t[5].cast<short>(),
-                                  t[6].cast<short>()};
+                                  t[6].cast<short>(), t[7].cast<bool>()};
                         return trj;
                     }));
 }

--- a/src/kbmod/search/pydocs/common_docs.h
+++ b/src/kbmod/search/pydocs/common_docs.h
@@ -23,6 +23,8 @@ static const auto DOC_Trajectory = R"doc(
         Flux (accumulated?)
     obs_count : `int`
         Number of observations trajectory was seen in.
+    valid : `bool`
+        Whether the trajectory is valid. Used for filtering.
   )doc";
 
 static const auto DOC_Trajectory_get_x_pos = R"doc(

--- a/src/kbmod/trajectory_utils.py
+++ b/src/kbmod/trajectory_utils.py
@@ -52,6 +52,7 @@ def make_trajectory(x=0, y=0, vx=0.0, vy=0.0, flux=0.0, lh=0.0, obs_count=0):
     trj.flux = flux
     trj.lh = lh
     trj.obs_count = obs_count
+    trj.valid = True
     return trj
 
 
@@ -111,6 +112,10 @@ def trajectory_from_np_object(result):
     trj.flux = float(result["flux"][0])
     trj.lh = float(result["lh"][0])
     trj.obs_count = int(result["num_obs"][0])
+    if "valid" in result.dtype.names:
+        trj.valid = bool(result["valid"][0])
+    else:
+        trj.valid = True
     return trj
 
 
@@ -135,6 +140,10 @@ def trajectory_from_dict(trj_dict):
     trj.flux = float(trj_dict["flux"])
     trj.lh = float(trj_dict["lh"])
     trj.obs_count = int(trj_dict["obs_count"])
+    if "valid" in trj_dict:
+        trj.valid = bool(trj_dict["valid"])
+    else:
+        trj.valid = True
     return trj
 
 
@@ -177,5 +186,6 @@ def trajectory_to_yaml(trj):
         "flux": trj.flux,
         "lh": trj.lh,
         "obs_count": trj.obs_count,
+        "valid": trj.valid,
     }
     return dump(yaml_dict)


### PR DESCRIPTION
Add a bit to the core `Trajectory` data structure so that we can do filtering on a list of trajectories without having to overload another field (e.g. setting `obs_count=0`). This will use a small amount of extra space in both memory and file storage.

Also removes the C++ `to_yaml()` function as that was never used. Instead we do all YAML conversion through Python.