### PR TITLE
Make PsiPhiArray more flexible

### DIFF
--- a/src/kbmod/search/kernels.cu
+++ b/src/kbmod/search/kernels.cu
@@ -7,7 +7,6 @@
 
 #ifndef KERNELS_CU_
 #define KERNELS_CU_
-#define GPU_LC_FILTER 1
 #define MAX_NUM_IMAGES 140
 #define MAX_STAMP_IMAGES 200
 
@@ -24,7 +23,40 @@
 
 namespace search {
 
-__host__ __device__ bool device_pixel_valid(float value) { return ((value != NO_DATA) && !isnan(value)); }
+// ---------------------------------------
+// --- Memory Functions ------------------
+// ---------------------------------------
+
+extern "C" float *move_floats_to_gpu(std::vector<float> &data) {
+    unsigned long memory_size = data.size() * sizeof(float);
+
+    float *gpu_ptr;
+    checkCudaErrors(cudaMalloc((void **)&gpu_ptr, memory_size));
+    checkCudaErrors(cudaMemcpy(gpu_ptr, data.data(), memory_size, cudaMemcpyHostToDevice));
+
+    return gpu_ptr;
+}
+
+extern "C" void free_gpu_float_array(float *gpu_ptr) {
+    if (gpu_ptr == nullptr) throw std::runtime_error("Trying to free nullptr.");
+    checkCudaErrors(cudaFree(gpu_ptr));
+}
+
+extern "C" void *move_void_array_to_gpu(void *data_array, long unsigned memory_size) {
+    if (data_array == nullptr) throw std::runtime_error("No data given.");
+    if (memory_size == 0) throw std::runtime_error("Invalid size.");
+
+    void *gpu_ptr;
+    checkCudaErrors(cudaMalloc((void **)&gpu_ptr, memory_size));
+    checkCudaErrors(cudaMemcpy(gpu_ptr, data_array, memory_size, cudaMemcpyHostToDevice));
+
+    return gpu_ptr;
+}
+
+extern "C" void free_gpu_void_array(void *gpu_ptr) {
+    if (gpu_ptr == nullptr) throw std::runtime_error("Trying to free nullptr.");
+    checkCudaErrors(cudaFree(gpu_ptr));
+}
 
 extern "C" Trajectory *allocate_gpu_trajectory_list(long unsigned num_trj) {
     Trajectory *gpu_ptr;
@@ -46,46 +78,11 @@ extern "C" void copy_trajectory_list(Trajectory *cpu_ptr, Trajectory *gpu_ptr, l
     }
 }
 
-extern "C" void device_allocate_psi_phi_arrays(PsiPhiArray *data) {
-    if (data == nullptr) {
-        throw std::runtime_error("No data given.");
-    }
-    if (!data->cpu_array_allocated() || !data->cpu_time_array_allocated()) {
-        throw std::runtime_error("CPU data is not allocated.");
-    }
-    if (data->gpu_array_allocated() || data->gpu_time_array_allocated()) {
-        throw std::runtime_error("GPU data is already allocated.");
-    }
+// ---------------------------------------
+// --- Data Access Functions -------------
+// ---------------------------------------
 
-    // Allocate space for the psi/phi data.
-    void *device_array_ptr;
-    checkCudaErrors(cudaMalloc((void **)&device_array_ptr, data->get_total_array_size()));
-    checkCudaErrors(cudaMemcpy(device_array_ptr, data->get_cpu_array_ptr(), data->get_total_array_size(),
-                               cudaMemcpyHostToDevice));
-    data->set_gpu_array_ptr(device_array_ptr);
-
-    // Allocate space for the times data.
-    float *device_times_ptr;
-    long unsigned time_bytes = data->get_num_times() * sizeof(float);
-    checkCudaErrors(cudaMalloc((void **)&device_times_ptr, time_bytes));
-    checkCudaErrors(
-            cudaMemcpy(device_times_ptr, data->get_cpu_time_array_ptr(), time_bytes, cudaMemcpyHostToDevice));
-    data->set_gpu_time_array_ptr(device_times_ptr);
-}
-
-extern "C" void device_free_psi_phi_arrays(PsiPhiArray *data) {
-    if (data == nullptr) {
-        throw std::runtime_error("No data given.");
-    }
-    if (data->gpu_array_allocated()) {
-        checkCudaErrors(cudaFree(data->get_gpu_array_ptr()));
-        data->set_gpu_array_ptr(nullptr);
-    }
-    if (data->gpu_time_array_allocated()) {
-        checkCudaErrors(cudaFree(data->get_gpu_time_array_ptr()));
-        data->set_gpu_time_array_ptr(nullptr);
-    }
-}
+__host__ __device__ bool device_pixel_valid(float value) { return ((value != NO_DATA) && !isnan(value)); }
 
 __host__ __device__ PsiPhi read_encoded_psi_phi(PsiPhiArrayMeta &params, void *psi_phi_vect, int time,
                                                 int row, int col) {
@@ -117,6 +114,10 @@ __host__ __device__ PsiPhi read_encoded_psi_phi(PsiPhiArrayMeta &params, void *p
 
     return result;
 }
+
+// ---------------------------------------
+// --- Computation Functions -------------
+// ---------------------------------------
 
 extern "C" __device__ __host__ void SigmaGFilteredIndicesCU(float *values, int num_values, float sgl0,
                                                             float sgl1, float sigmag_coeff, float width,
@@ -341,10 +342,13 @@ extern "C" void deviceSearchFilter(PsiPhiArray &psi_phi_array, SearchParameters 
     }
 
     // Check that the device vectors have already been allocated.
-    if (psi_phi_array.gpu_array_allocated() == false) {
+    if (!psi_phi_array.on_gpu()) {
+        throw std::runtime_error("PsiPhi data is not on GPU.");
+    }
+    if (psi_phi_array.get_gpu_array_ptr() == nullptr) {
         throw std::runtime_error("PsiPhi data has not been created.");
     }
-    if (psi_phi_array.gpu_time_array_allocated() == false) {
+    if (psi_phi_array.get_gpu_time_array_ptr() == nullptr) {
         throw std::runtime_error("GPU time data has not been created.");
     }
 
@@ -369,8 +373,8 @@ extern "C" void deviceSearchFilter(PsiPhiArray &psi_phi_array, SearchParameters 
 
     // Launch Search
     searchFilterImages<<<blocks, threads>>>(psi_phi_array.get_meta_data(), psi_phi_array.get_gpu_array_ptr(),
-                                            static_cast<float *>(psi_phi_array.get_gpu_time_array_ptr()),
-                                            params, num_trajectories, device_tests, device_results);
+                                            psi_phi_array.get_gpu_time_array_ptr(), params, num_trajectories,
+                                            device_tests, device_results);
     cudaDeviceSynchronize();
 }
 

--- a/src/kbmod/search/psi_phi_array.cpp
+++ b/src/kbmod/search/psi_phi_array.cpp
@@ -6,16 +6,22 @@ namespace search {
 
 // Declaration of CUDA functions that will be linked in.
 #ifdef HAVE_CUDA
-extern "C" void device_allocate_psi_phi_arrays(PsiPhiArray* data);
-
-extern "C" void device_free_psi_phi_arrays(PsiPhiArray* data);
+extern "C" float* move_floats_to_gpu(std::vector<float>& data);
+extern "C" void free_gpu_float_array(float* gpu_ptr);
+extern "C" void* move_void_array_to_gpu(void* data_array, long unsigned memory_size);
+extern "C" void free_gpu_void_array(void* gpu_ptr);
 #endif
 
 // -------------------------------------------------------
 // --- Implementation of core data structure functions ---
 // -------------------------------------------------------
 
-PsiPhiArray::PsiPhiArray() {}
+PsiPhiArray::PsiPhiArray() {
+    data_on_gpu = false;
+    cpu_array_ptr = nullptr;
+    gpu_array_ptr = nullptr;
+    gpu_time_array = nullptr;
+}
 
 PsiPhiArray::~PsiPhiArray() { clear(); }
 
@@ -25,17 +31,8 @@ void PsiPhiArray::clear() {
         free(cpu_array_ptr);
         cpu_array_ptr = nullptr;
     }
-    if (cpu_time_array != nullptr) {
-        free(cpu_time_array);
-        cpu_time_array = nullptr;
-    }
-#ifdef HAVE_CUDA
-    if ((gpu_array_ptr != nullptr) || (gpu_time_array != nullptr)) {
-        device_free_psi_phi_arrays(this);
-        gpu_array_ptr = nullptr;
-        gpu_time_array = nullptr;
-    }
-#endif
+    cpu_time_array.clear();
+    clear_from_gpu();
 
     // Reset the meta data except the encoding information.
     meta_data.num_times = 0;
@@ -52,6 +49,62 @@ void PsiPhiArray::clear() {
     meta_data.phi_min_val = FLT_MAX;
     meta_data.phi_max_val = -FLT_MAX;
     meta_data.phi_scale = 1.0;
+}
+
+void PsiPhiArray::clear_from_gpu() {
+    if (!data_on_gpu) {
+        if ((gpu_array_ptr != nullptr) || (gpu_time_array != nullptr)) {
+            throw std::runtime_error("Inconsistent GPU flags and pointers");
+        }
+        return;
+    }
+    if ((gpu_array_ptr == nullptr) || (gpu_time_array == nullptr)) {
+        throw std::runtime_error("Inconsistent GPU flags and pointers");
+    }
+
+#ifdef HAVE_CUDA
+    free_gpu_float_array(gpu_time_array);
+    free_gpu_void_array(gpu_array_ptr);
+#endif
+
+    gpu_array_ptr = nullptr;
+    gpu_time_array = nullptr;
+    data_on_gpu = false;
+}
+
+void PsiPhiArray::move_to_gpu(bool debug) {
+    if (data_on_gpu) {
+        if ((gpu_array_ptr == nullptr) || (gpu_time_array == nullptr)) {
+            throw std::runtime_error("Inconsistent GPU flags and pointers");
+        }
+        return;
+    }
+    if (cpu_array_ptr == nullptr) std::runtime_error("CPU data not allocated.");
+    if (gpu_array_ptr != nullptr) std::runtime_error("GPU psi/phi already allocated.");
+    if (gpu_time_array != nullptr) std::runtime_error("GPU time already allocated.");
+    if (cpu_time_array.size() != meta_data.num_times) {
+        std::runtime_error("Inconsistent number of times.");
+    }
+
+#ifdef HAVE_CUDA
+    // Create a copy of the encoded data in GPU memory.
+    if (debug) {
+        printf("Allocating GPU memory for PsiPhi array using %lu bytes.\n", get_total_array_size());
+        printf("Allocating GPU memory for times array using %lu bytes.\n", get_num_times() * sizeof(float));
+    }
+
+    gpu_array_ptr = move_void_array_to_gpu(cpu_array_ptr, get_total_array_size());
+    if (gpu_array_ptr == nullptr) {
+        throw std::runtime_error("Unable to allocate GPU PsiPhi array.");
+    }
+
+    gpu_time_array = move_floats_to_gpu(cpu_time_array);
+    if (gpu_time_array == nullptr) {
+        throw std::runtime_error("Unable to allocate GPU time array.");
+    }
+
+    data_on_gpu = true;
+#endif
 }
 
 void PsiPhiArray::set_meta_data(int new_num_bytes, int new_num_times, int new_height, int new_width) {
@@ -102,6 +155,8 @@ void PsiPhiArray::set_phi_scaling(float min_val, float max_val, float scale_val)
     meta_data.phi_scale = scale_val;
 }
 
+void PsiPhiArray::set_time_array(const std::vector<float>& times) { cpu_time_array = times; }
+
 PsiPhi PsiPhiArray::read_psi_phi(int time, int row, int col) {
     PsiPhi result = {NO_DATA, NO_DATA};
 
@@ -137,7 +192,6 @@ PsiPhi PsiPhiArray::read_psi_phi(int time, int row, int col) {
 }
 
 float PsiPhiArray::read_time(int time_index) {
-    if (cpu_time_array == nullptr) throw std::runtime_error("Read from unallocated times array.");
     if ((time_index < 0) || (time_index >= meta_data.num_times)) {
         throw std::runtime_error("Out of bounds read for time step.");
     }
@@ -263,24 +317,6 @@ void fill_psi_phi_array(PsiPhiArray& result_data, int num_bytes, const std::vect
     int height = phi_imgs[0].get_height();
     result_data.set_meta_data(num_bytes, num_times, height, width);
 
-    // Check that we are not processing any bad data (NaNs or infs). We do this once
-    // before allocating space, encoding, etc.
-    for (int t = 0; t < num_times; ++t) {
-        for (int row = 0; row < height; ++row) {
-            for (int col = 0; col < width; ++col) {
-                float psi_val = psi_imgs[t].get_pixel({row, col});
-                if (std::isnan(psi_val) || std::isinf(psi_val)) {
-                    throw std::runtime_error("Invalid value found in PSI array");
-                }
-
-                float phi_val = phi_imgs[t].get_pixel({row, col});
-                if (std::isnan(phi_val) || std::isinf(phi_val)) {
-                    throw std::runtime_error("Invalid value found in PHI array");
-                }
-            }
-        }
-    }
-
     if (result_data.get_num_bytes() == 1 || result_data.get_num_bytes() == 2) {
         // Compute the scaling parameters needed for encoding.
         std::array<float, 3> psi_params =
@@ -313,32 +349,11 @@ void fill_psi_phi_array(PsiPhiArray& result_data, int num_bytes, const std::vect
     }
 
     // Copy the time array.
-    const long unsigned times_bytes = result_data.get_num_times() * sizeof(float);
-    if (debug) printf("Allocating %lu bytes on the CPU for times.\n", times_bytes);
-
-    float* times_array = (float*)malloc(times_bytes);
-    if (times_array == nullptr) throw std::runtime_error("Unable to allocate space for CPU times.");
-    for (int i = 0; i < result_data.get_num_times(); ++i) {
-        times_array[i] = zeroed_times[i];
-    }
-    result_data.set_cpu_time_array_ptr(times_array);
-
-#ifdef HAVE_CUDA
-    // Create a copy of the encoded data in GPU memory.
     if (debug) {
-        printf("Allocating GPU memory for PsiPhi array using %lu bytes.\n",
-               result_data.get_total_array_size());
-        printf("Allocating GPU memory for times array using %lu bytes.\n", times_bytes);
+        const long unsigned times_bytes = result_data.get_num_times() * sizeof(float);
+        printf("Allocating %lu bytes on the CPU for times.\n", times_bytes);
     }
-
-    device_allocate_psi_phi_arrays(&result_data);
-    if (result_data.get_gpu_array_ptr() == nullptr) {
-        throw std::runtime_error("Unable to allocate GPU PsiPhi array.");
-    }
-    if (result_data.get_gpu_time_array_ptr() == nullptr) {
-        throw std::runtime_error("Unable to allocate GPU time array.");
-    }
-#endif
+    result_data.set_time_array(zeroed_times);
 }
 
 void fill_psi_phi_array_from_image_stack(PsiPhiArray& result_data, ImageStack& stack, int num_bytes,
@@ -382,6 +397,7 @@ static void psi_phi_array_binding(py::module& m) {
 
     py::class_<ppa>(m, "PsiPhiArray", pydocs::DOC_PsiPhiArray)
             .def(py::init<>())
+            .def_property_readonly("on_gpu", &ppa::on_gpu, pydocs::DOC_PsiPhiArray_on_gpu)
             .def_property_readonly("num_bytes", &ppa::get_num_bytes, pydocs::DOC_PsiPhiArray_get_num_bytes)
             .def_property_readonly("num_times", &ppa::get_num_times, pydocs::DOC_PsiPhiArray_get_num_times)
             .def_property_readonly("width", &ppa::get_width, pydocs::DOC_PsiPhiArray_get_width)
@@ -407,12 +423,12 @@ static void psi_phi_array_binding(py::module& m) {
                                    pydocs::DOC_PsiPhiArray_get_cpu_array_allocated)
             .def_property_readonly("gpu_array_allocated", &ppa::gpu_array_allocated,
                                    pydocs::DOC_PsiPhiArray_get_gpu_array_allocated)
-            .def_property_readonly("cpu_time_array_allocated", &ppa::cpu_time_array_allocated,
-                                   pydocs::DOC_PsiPhiArray_get_cpu_time_array_allocated)
-            .def_property_readonly("gpu_time_array_allocated", &ppa::gpu_time_array_allocated,
-                                   pydocs::DOC_PsiPhiArray_get_gpu_time_array_allocated)
             .def("set_meta_data", &ppa::set_meta_data, pydocs::DOC_PsiPhiArray_set_meta_data)
+            .def("set_time_array", &ppa::set_time_array, pydocs::DOC_PsiPhiArray_set_time_array)
+            .def("move_to_gpu", &ppa::move_to_gpu, py::arg("debug") = false,
+                 pydocs::DOC_PsiPhiArray_move_to_gpu)
             .def("clear", &ppa::clear, pydocs::DOC_PsiPhiArray_clear)
+            .def("clear_from_gpu", &ppa::clear_from_gpu, pydocs::DOC_PsiPhiArray_clear_from_gpu)
             .def("read_psi_phi", &ppa::read_psi_phi, pydocs::DOC_PsiPhiArray_read_psi_phi)
             .def("read_time", &ppa::read_time, pydocs::DOC_PsiPhiArray_read_time);
     m.def("compute_scale_params_from_image_vect", &search::compute_scale_params_from_image_vect);

--- a/src/kbmod/search/pydocs/psi_phi_array_docs.h
+++ b/src/kbmod/search/pydocs/psi_phi_array_docs.h
@@ -18,6 +18,10 @@ static const auto DOC_PsiPhiArray = R"doc(
   An encoded array of Psi and Phi values along with their meta data.
   )doc";
 
+static const auto DOC_PsiPhiArray_on_gpu = R"doc(
+  A Boolean indicating whether a copy of the data is on the GPU.
+  )doc";
+
 static const auto DOC_PsiPhiArray_get_num_bytes = R"doc(
   The target number of bytes to use for encoding the data (1 for uint8, 2 for uint16,
   or 4 for float32). Might differ from actual number of bytes (block_size).
@@ -95,6 +99,24 @@ static const auto DOC_PsiPhiArray_clear = R"doc(
   Clear all data and free the arrays.
   )doc";
 
+static const auto DOC_PsiPhiArray_move_to_gpu = R"doc(
+  Move the image and time data to the GPU. Allocates space and copies
+  the data.
+
+  Raises
+  ------
+  Raises a ``RuntimeError`` if the data or settings are invalid.
+  )doc";
+
+static const auto DOC_PsiPhiArray_clear_from_gpu = R"doc(
+  Free the image and time data from the GPU memory. Does not copy the
+  data.
+
+  Raises
+  ------
+  Raises a ``RuntimeError`` the data or settings are invalid.
+  )doc";
+
 static const auto DOC_PsiPhiArray_read_psi_phi = R"doc(
   Read a PsiPhi value from the CPU array.
 
@@ -141,6 +163,15 @@ static const auto DOC_PsiPhiArray_set_meta_data = R"doc(
         The height of each image in pixels.
     new_width : `int`
         The width of each image in pixels.
+  )doc";
+
+static const auto DOC_PsiPhiArray_set_time_array = R"doc(
+    Set the zeroed times.
+
+    Parameters
+    ----------
+    times : `list`
+        A list of ``float`` with zeroed times.
   )doc";
 
 static const auto DOC_PsiPhiArray_fill_psi_phi_array = R"doc(

--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -109,8 +109,8 @@ void StackSearch::prepare_psi_phi() {
 
     // Perform additional error checking that the arrays are allocated (checked even if
     // using the cached values).
-    if (!psi_phi_array.cpu_array_allocated() || !psi_phi_array.cpu_time_array_allocated()) {
-        throw std::runtime_error("PsiPhiArray arrays unallocated after prepare_psi_phi_array.");
+    if (!psi_phi_array.cpu_array_allocated()) {
+        throw std::runtime_error("PsiPhiArray array unallocated after prepare_psi_phi_array.");
     }
 }
 
@@ -154,6 +154,7 @@ void StackSearch::search(std::vector<Trajectory>& search_list, int min_observati
 
     DebugTimer psi_phi_timer = DebugTimer("Creating psi/phi buffers", debug_info);
     prepare_psi_phi();
+    psi_phi_array.move_to_gpu();
     psi_phi_timer.stop();
 
     // Allocate a vector for the results and move it onto the GPU.
@@ -187,8 +188,9 @@ void StackSearch::search(std::vector<Trajectory>& search_list, int min_observati
 #endif
     search_timer.stop();
 
-    // Move both lists back to CPU to unallocate GPU space (this will happen automatically
+    // Move data back to CPU to unallocate GPU space (this will happen automatically
     // for gpu_search_list when the object goes out of scope, but we do it explicitly here).
+    psi_phi_array.clear_from_gpu();
     results.move_to_cpu();
     gpu_search_list.move_to_cpu();
 

--- a/tests/test_psi_phi_array.py
+++ b/tests/test_psi_phi_array.py
@@ -137,6 +137,7 @@ class test_psi_phi_array(unittest.TestCase):
     def test_fill_psi_phi_array(self):
         for num_bytes in [2, 4]:
             arr = PsiPhiArray()
+            self.assertFalse(arr.cpu_array_allocated)
             fill_psi_phi_array(
                 arr, num_bytes, [self.psi_1, self.psi_2], [self.phi_1, self.phi_2], self.zeroed_times, False
             )
@@ -154,12 +155,21 @@ class test_psi_phi_array(unittest.TestCase):
                 self.assertEqual(arr.block_size, num_bytes)
             self.assertEqual(arr.total_array_size, arr.num_entries * arr.block_size)
 
-            # Check that we allocate the arrays
+            # Check that we allocate the arrays on the CPU, but not the GPU
             self.assertTrue(arr.cpu_array_allocated)
-            self.assertTrue(arr.cpu_time_array_allocated)
+            self.assertFalse(arr.on_gpu)
+            self.assertFalse(arr.gpu_array_allocated)
+
+            # If the test has a GPU move the data to the GPU and confirm it got there.
+            # Then clear it and make sure it is freed.
             if HAS_GPU:
+                arr.move_to_gpu()
+                self.assertTrue(arr.on_gpu)
                 self.assertTrue(arr.gpu_array_allocated)
-                self.assertTrue(arr.gpu_time_array_allocated)
+
+                arr.clear_from_gpu()
+                self.assertFalse(arr.on_gpu)
+                self.assertFalse(arr.gpu_array_allocated)
 
             # Check that we can correctly read the values from the CPU.
             for time in range(self.num_times):
@@ -174,74 +184,6 @@ class test_psi_phi_array(unittest.TestCase):
             # Check that the arrays are set to NULL after we clear it (memory should be freed too).
             arr.clear()
             self.assertFalse(arr.cpu_array_allocated)
-            self.assertFalse(arr.cpu_time_array_allocated)
-            if HAS_GPU:
-                self.assertFalse(arr.gpu_array_allocated)
-                self.assertFalse(arr.gpu_time_array_allocated)
-
-    def test_fill_invalid(self):
-        arr = PsiPhiArray()
-        old_value = self.psi_1.get_pixel(4, 3)
-
-        # Fails with NaN in psi
-        self.psi_1.set_pixel(4, 3, math.nan)
-        self.assertRaises(
-            RuntimeError,
-            fill_psi_phi_array,
-            arr,
-            4,
-            [self.psi_1, self.psi_2],
-            [self.phi_1, self.phi_2],
-            self.zeroed_times,
-            False,
-        )
-
-        # Fails with inf in psi
-        self.psi_1.set_pixel(4, 3, math.inf)
-        self.assertRaises(
-            RuntimeError,
-            fill_psi_phi_array,
-            arr,
-            4,
-            [self.psi_1, self.psi_2],
-            [self.phi_1, self.phi_2],
-            self.zeroed_times,
-            False,
-        )
-
-        # Reset the psi array and make sure the array builds. Then clear it so we try
-        # to rebuild.
-        self.psi_1.set_pixel(4, 3, old_value)
-        fill_psi_phi_array(
-            arr, 4, [self.psi_1, self.psi_2], [self.phi_1, self.phi_2], self.zeroed_times, False
-        )
-        arr.clear()
-
-        # Fails with NaN in phi
-        self.phi_1.set_pixel(2, 3, math.nan)
-        self.assertRaises(
-            RuntimeError,
-            fill_psi_phi_array,
-            arr,
-            4,
-            [self.psi_1, self.psi_2],
-            [self.phi_1, self.phi_2],
-            self.zeroed_times,
-            False,
-        )
-
-        # Fails with inf in psi
-        self.phi_1.set_pixel(2, 3, math.inf)
-        self.assertRaises(
-            RuntimeError,
-            fill_psi_phi_array,
-            arr,
-            4,
-            [self.psi_1, self.psi_2],
-            [self.phi_1, self.phi_2],
-            self.zeroed_times,
-            False,
-        )
 
     def test_fill_psi_phi_array_from_image_stack(self):
         # Build a fake image stack.
@@ -275,16 +217,25 @@ class test_psi_phi_array(unittest.TestCase):
         self.assertEqual(arr.block_size, 4)
         self.assertEqual(arr.total_array_size, arr.num_entries * arr.block_size)
 
-        # Check that we allocated the arrays.
+        # Check that we allocated the correct arrays.
         self.assertTrue(arr.cpu_array_allocated)
-        self.assertTrue(arr.cpu_time_array_allocated)
+        self.assertFalse(arr.on_gpu)
+        self.assertFalse(arr.gpu_array_allocated)
+
         if HAS_GPU:
+            arr.move_to_gpu()
+            self.assertTrue(arr.on_gpu)
             self.assertTrue(arr.gpu_array_allocated)
-            self.assertTrue(arr.gpu_time_array_allocated)
 
         # Since we filled the images with random data, we only test the times.
         for time in range(num_times):
             self.assertAlmostEqual(arr.read_time(time), 2.0 * time)
+
+        # Clear clears everything.
+        arr.clear()
+        self.assertFalse(arr.cpu_array_allocated)
+        self.assertFalse(arr.on_gpu)
+        self.assertFalse(arr.gpu_array_allocated)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Redesign the interface to `PsiPhiArray` to make allow the user to choose when to sync data to the GPU or clear it from the GPU. (making it more flexible and consistent with #509). This will allow a workflow such as: 

sync_data to gpu -> do search -> clear data from gpu -> do other stuff -> generate psi/phi curves on CPU

without having to regenerate all the psi and phi data on CPU as well.  A new `on_gpu()` function tells the user whether the data has been synced or not.

The change replaces the kernel function `device_allocate_psi_phi_arrays` (which had a lot of `PsiPhiArray` specific logic) with more general functions `move_floats_to_gpu` and `move_void_array_to_gpu`. Moves the previous error checking logic into the `PsiPhiArray` class.

Also includes a few smaller changes:
- Remove the psi / phi NaN check (and corresponding test) in preparation for PR #504 
- Remove an unused constant `GPU_LC_FILTER`