### PR TITLE
Add More TrajectoryList Filtering

### DIFF
--- a/src/kbmod/search/pydocs/trajectory_list_docs.h
+++ b/src/kbmod/search/pydocs/trajectory_list_docs.h
@@ -164,6 +164,15 @@ static const auto DOC_TrajectoryList_filter_by_obs_count = R"doc(
   Raises a ``RuntimeError`` the data is on GPU.
   )doc";
 
+static const auto DOC_TrajectoryList_filter_by_valid = R"doc(
+  Filter out all trajectories with the ``valid`` attribute set to ``False``.
+  Ordering is not preserved. The data must reside on the CPU.
+      
+  Raises
+  ------
+  Raises a ``RuntimeError`` the data is on GPU.
+  )doc";
+
 }  // namespace pydocs
 
 #endif /* TRAJECTORY_LIST_DOCS_ */

--- a/src/kbmod/search/trajectory_list.cpp
+++ b/src/kbmod/search/trajectory_list.cpp
@@ -109,6 +109,14 @@ void TrajectoryList::filter_by_obs_count(int min_obs_count) {
     resize(index);
 }
 
+void TrajectoryList::filter_by_valid() {
+    if (data_on_gpu) throw std::runtime_error("Data on GPU");
+
+    auto new_end = std::partition(cpu_list.begin(), cpu_list.end(), [](Trajectory x) { return x.valid; });
+    int new_size = std::distance(cpu_list.begin(), new_end);
+    resize(new_size);
+}
+
 void TrajectoryList::move_to_gpu() {
     if (data_on_gpu) return;  // Nothing to do.
 
@@ -159,6 +167,7 @@ static void trajectory_list_binding(py::module &m) {
 
     py::class_<trjl>(m, "TrajectoryList", pydocs::DOC_TrajectoryList)
             .def(py::init<int>())
+            .def(py::init<std::vector<Trajectory> &>())
             .def_property_readonly("on_gpu", &trjl::on_gpu, pydocs::DOC_TrajectoryList_on_gpu)
             .def("__len__", &trjl::get_size)
             .def("resize", &trjl::resize, pydocs::DOC_TrajectoryList_resize)
@@ -175,6 +184,7 @@ static void trajectory_list_binding(py::module &m) {
                  pydocs::DOC_TrajectoryList_filter_by_likelihood)
             .def("filter_by_obs_count", &trjl::filter_by_obs_count,
                  pydocs::DOC_TrajectoryList_filter_by_obs_count)
+            .def("filter_by_valid", &trjl::filter_by_valid, pydocs::DOC_TrajectoryList_filter_by_valid)
             .def("move_to_cpu", &trjl::move_to_cpu, pydocs::DOC_TrajectoryList_move_to_cpu)
             .def("move_to_gpu", &trjl::move_to_gpu, pydocs::DOC_TrajectoryList_move_to_gpu);
 }

--- a/src/kbmod/search/trajectory_list.h
+++ b/src/kbmod/search/trajectory_list.h
@@ -54,6 +54,7 @@ public:
     void sort_by_obs_count();
     void filter_by_likelihood(float min_likelihood);
     void filter_by_obs_count(int min_obs_count);
+    void filter_by_valid();
 
     // Data allocation functions.
     inline bool on_gpu() const { return data_on_gpu; }

--- a/tests/test_trajectory_list.py
+++ b/tests/test_trajectory_list.py
@@ -98,10 +98,14 @@ class test_trajectory_list(unittest.TestCase):
             trjs.set_trajectory(i, make_trajectory(x=i, lh=lh[i]))
 
         trjs.filter_by_likelihood(110.0)
-        expected = [4, 5, 3, 1]
+        expected = set([4, 5, 3, 1])
+
+        # Test that each remaining result appears once in the expected set.
         self.assertEqual(len(trjs), len(expected))
-        for i in range(len(expected)):
-            self.assertEqual(trjs.get_trajectory(i).x, expected[i])
+        for i in range(len(trjs)):
+            idx = trjs.get_trajectory(i).x
+            self.assertTrue(idx in expected)
+            expected.remove(idx)
 
     def test_filter_on_obs_count(self):
         vals = [10, 7, 8, 9, 12, 15, 1, 2, 19, 3]
@@ -110,10 +114,32 @@ class test_trajectory_list(unittest.TestCase):
             trjs.set_trajectory(i, make_trajectory(x=i, obs_count=vals[i]))
 
         trjs.filter_by_obs_count(10)
-        expected = [8, 5, 4, 0]
+        expected = set([8, 5, 4, 0])
+
+        # Test that each remaining result appears once in the expected set.
         self.assertEqual(len(trjs), len(expected))
-        for i in range(len(expected)):
-            self.assertEqual(trjs.get_trajectory(i).x, expected[i])
+        for i in range(len(trjs)):
+            idx = trjs.get_trajectory(i).x
+            self.assertTrue(idx in expected)
+            expected.remove(idx)
+
+    def test_filter_on_valid(self):
+        vals = [True, False, False, True, True, False, True, True, False]
+        trjs = TrajectoryList(len(vals))
+        for i in range(len(vals)):
+            trj = make_trajectory(x=i)
+            trj.valid = vals[i]
+            trjs.set_trajectory(i, trj)
+
+        trjs.filter_by_valid()
+        expected = set([0, 3, 4, 6, 7])
+
+        # Test that each remaining result appears once in the expected set.
+        self.assertEqual(len(trjs), len(expected))
+        for i in range(len(trjs)):
+            idx = trjs.get_trajectory(i).x
+            self.assertTrue(idx in expected)
+            expected.remove(idx)
 
     @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
     def test_move_to_from_gpu(self):

--- a/tests/test_trajectory_list.py
+++ b/tests/test_trajectory_list.py
@@ -22,6 +22,12 @@ class test_trajectory_list(unittest.TestCase):
         # Cannot create a zero or negative length list.
         self.assertRaises(RuntimeError, TrajectoryList, -1)
 
+        # Create from a list
+        trj_list2 = TrajectoryList([make_trajectory(x=2 * i) for i in range(8)])
+        self.assertEqual(trj_list2.get_size(), 8)
+        for i in range(8):
+            self.assertEqual(trj_list2.get_trajectory(i).x, 2 * i)
+
     def test_resize(self):
         # Resizing down drops values at the end.
         self.trj_list.resize(5)


### PR DESCRIPTION
Add the ability to filter a `TrajectoryList` by the `Trajectory`'s `valid` bit.

Also make the vector-based constructor accessible via python.