### PR TITLE
Add contains to RawImage Python interface

### DIFF
--- a/src/kbmod/search/pydocs/raw_image_docs.h
+++ b/src/kbmod/search/pydocs/raw_image_docs.h
@@ -119,6 +119,40 @@ static const auto DOC_RawImage_set_pixel = R"doc(
       Value to set the pixels to.
   )doc";
 
+static const auto DOC_RawImage_contains_index = R"doc(
+  True if the given index falls within the image dimensions.
+  Note that the x and y ordering is the inverse of contains_point().
+
+  Parameters
+  ----------
+  i : `int`
+      Row index (y position)
+  j : `int`
+      Col index (x position)
+
+  Returns
+  -------
+  result : `bool`
+      ``True`` when point falls within the image dimensions.
+  )doc";
+
+static const auto DOC_RawImage_contains_point = R"doc(
+  True if the given point falls within the image dimensions.
+  Note that the x and y ordering is the inverse of contains_index().
+      
+  Parameters
+  ----------
+  x : `float`
+      The real valued x position.
+  y : `float`
+      The real valued y position.
+
+  Returns
+  -------
+  result : `bool`
+      ``True`` when point falls within the image dimensions.
+  )doc";
+
 static const auto DOC_RawImage_mask_pixel = R"doc(
   Sets image pixel at an invalid value that indicates it is masked.
 

--- a/src/kbmod/search/raw_image.cpp
+++ b/src/kbmod/search/raw_image.cpp
@@ -479,6 +479,10 @@ static void raw_image_bindings(py::module& m) {
             .def("set_pixel", &rie::set_pixel, pydocs::DOC_RawImage_set_pixel)
             .def("mask_pixel", &rie::mask_pixel, pydocs::DOC_RawImage_mask_pixel)
             .def("set_all", &rie::set_all, pydocs::DOC_RawImage_set_all)
+            .def("contains_index", py::overload_cast<const indexing::Index&>(&rie::contains, py::const_),
+                 pydocs::DOC_RawImage_contains_index)
+            .def("contains_point", py::overload_cast<const indexing::Point&>(&rie::contains, py::const_),
+                 pydocs::DOC_RawImage_contains_point)
             // python interface adapters (avoids having to construct Index & Point)
             .def("get_pixel",
                  [](rie& cls, int i, int j) {
@@ -495,6 +499,14 @@ static void raw_image_bindings(py::module& m) {
             .def("mask_pixel",
                  [](rie& cls, int i, int j) {
                      cls.mask_pixel({i, j});
+                 })
+            .def("contains_index",
+                 [](rie& cls, int i, int j) {
+                     return cls.contains(indexing::Index({i, j}));
+                 })
+            .def("contains_point",
+                 [](rie& cls, float x, float y) {
+                     return cls.contains(indexing::Point({x, y}));
                  })
             // methods
             .def("l2_allclose", &rie::l2_allclose, pydocs::DOC_RawImage_l2_allclose)

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -84,6 +84,23 @@ class test_RawImage(unittest.TestCase):
         self.assertFalse(pixel_value_valid(img.get_pixel(5, -1)))
         self.assertFalse(pixel_value_valid(img.get_pixel(self.height, 5)))
 
+    def test_contains(self):
+        img = RawImage(img=self.array, obs_time=10.0)
+        self.assertTrue(img.contains_index(0, 0))
+        self.assertTrue(img.contains_index(1, 2))
+        self.assertFalse(img.contains_index(1, -1))
+        self.assertFalse(img.contains_index(-1, 1))
+        self.assertFalse(img.contains_index(1, self.width))
+        self.assertFalse(img.contains_index(self.height, 1))
+
+        # Works with floats
+        self.assertTrue(img.contains_point(0.0, 0.0))
+        self.assertTrue(img.contains_point(1.0, 2.0))
+        self.assertFalse(img.contains_point(1.0, -1.0))
+        self.assertFalse(img.contains_point(-1.0, 1.0))
+        self.assertFalse(img.contains_point(self.width + 1e-4, 1.0))
+        self.assertFalse(img.contains_point(1.0, self.height + 1e-4))
+
     def test_validity_checker(self):
         img = RawImage(img=np.array([[0, 0], [0, 0]]).astype(np.float32), obs_time=10.0)
         self.assertTrue(img.pixel_has_data(0, 0))


### PR DESCRIPTION
Make the `contains` function available through the Python interface. The functionality here is already available through getting the Eigen object, but this just makes for a more consistent interface.