### PR TITLE
Batch search inside stack search

### DIFF
--- a/src/kbmod/batch_search.py
+++ b/src/kbmod/batch_search.py
@@ -1,0 +1,40 @@
+class BatchSearchManager:
+    def __init__(self, stack_search, search_list, min_observations):
+        """
+        Initialize the context manager with an instance of StackSearch,
+        the list of trajectories to search, and the minimum number of observations.
+
+        Parameters:
+        - stack_search: Instance of the StackSearch class.
+        - search_list: List of trajectories to search.
+        - min_observations: Minimum number of observations for the search.
+        """
+        self.stack_search = stack_search
+        self.search_list = search_list
+        self.min_observations = min_observations
+
+    def __enter__(self):
+        """
+        This method is called when entering the context managed by the `with` statement.
+        It prepares the batch search by calling `prepare_batch_search` on the StackSearch instance.
+        """
+        # Initialize or prepare memory for the batch search.
+        self.stack_search.prepare_batch_search(self.search_list, self.min_observations)
+        # Return the object that should be used within the `with` block. Here, it's the StackSearch instance.
+        return self.stack_search
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """
+        This method is called when exiting the context.
+        It cleans up resources by calling `finish_search` on the StackSearch instance.
+
+        Parameters:
+        - exc_type: The exception type if an exception was raised in the `with` block.
+        - exc_value: The exception value if an exception was raised.
+        - traceback: The traceback object if an exception was raised.
+        """
+        # Clean up resources or delete initialized memory.
+        self.stack_search.finish_search()
+        # Returning False means any exception raised within the `with` block will be propagated.
+        # To suppress exceptions, return True.
+        return False

--- a/src/kbmod/search/pydocs/stack_search_docs.h
+++ b/src/kbmod/search/pydocs/stack_search_docs.h
@@ -177,6 +177,34 @@ static const auto DOC_StackSearch_get_results = R"doc(
   ``RunTimeError`` if start < 0 or count <= 0.
   )doc";
 
+static const auto DOC_StackSearch_prepare_batch_search = R"doc(
+  Prepare the search for a batch of trajectories.
+
+  Parameters
+  ----------
+  search_list : `List`
+      A list of ``Trajectory`` objects to search.
+  )doc";
+
+static const auto DOC_StackSearch_search_batch = R"doc(
+  Perform a batch search of the trajectories in the list.
+
+  Returns
+  -------
+  results : `List`
+      A list of ``Trajectory`` search results
+  )doc";
+
+static const auto DOC_StackSearch_finish_search = R"doc(
+  Clears memory used for the batch search.
+
+  This method should be called after a batch search is completed to ensure that any resources allocated during the search are properly freed.
+
+  Returns
+  -------
+  None
+  )doc";
+
 static const auto DOC_StackSearch_set_results = R"doc(
   Set the cached results. Used for testing.
 

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -48,6 +48,9 @@ public:
     // The primary search functions
     void evaluate_single_trajectory(Trajectory& trj);
     Trajectory search_linear_trajectory(short x, short y, float vx, float vy);
+    void prepare_batch_search(std::vector<Trajectory>& search_list, int min_observations);
+    void finish_search();
+    std::vector<Trajectory> search_batch();
     void search(std::vector<Trajectory>& search_list, int min_observations);
 
     // Gets the vector of result trajectories from the grid search.
@@ -80,6 +83,9 @@ protected:
 
     // Results from the grid search.
     TrajectoryList results;
+
+    // Trajectories that are being searched.
+    TrajectoryList gpu_search_list;
 };
 
 } /* namespace search */


### PR DESCRIPTION
This tackles #356 

The idea is that you'd replace the full in-memory search:

```
min_observations = ... # Some min observations
candidates = ... # Some trajectories
stack = ImageStack(im_list)
search = StackSearch(stack)
search.search(candidates, min_observations)
```

With a batched version: 

```
 with BatchSearchManager(StackSearch(stack), candidates, min_observations) as batch_search:
    batch_results = []
    for i in range(0, width, 5):
        batch_search.set_start_bounds_x(i, i + 5)
        for j in range(0, height, 5):
            batch_search.set_start_bounds_y(j, j + 5)
            batch_results.extend(batch_search.search_batch())

```


The steps are:
1. Use the `BatchSearchManager` context manager to obtain a managed `batch_search` object
2. Loop through the whole grid by breaking it into smaller subsets