### PR TITLE
use proper WorkUnit per image wcs accessor

### DIFF
--- a/notebooks/reprojection/reproject_demo.ipynb
+++ b/notebooks/reprojection/reproject_demo.ipynb
@@ -99,16 +99,16 @@
     "original_images = wunit.im_stack.get_images()\n",
     "\n",
     "o_image0 = CCDData(original_images[0].get_science().image, unit=\"adu\")\n",
-    "o_image0.wcs = wunit.per_image_wcs[0]\n",
+    "o_image0.wcs = wunit.get_wcs(0)\n",
     "\n",
     "o_image1 = CCDData(original_images[1].get_science().image, unit=\"adu\")\n",
-    "o_image1.wcs = wunit.per_image_wcs[1]\n",
+    "o_image1.wcs = wunit.get_wcs(1)\n",
     "\n",
     "o_image2 = CCDData(original_images[2].get_science().image, unit=\"adu\")\n",
-    "o_image2.wcs = wunit.per_image_wcs[2]\n",
+    "o_image2.wcs = wunit.get_wcs(2)\n",
     "\n",
     "o_image3 = CCDData(original_images[3].get_science().image, unit=\"adu\")\n",
-    "o_image3.wcs = wunit.per_image_wcs[3]\n",
+    "o_image3.wcs = wunit.get_wcs(3)\n",
     "\n",
     "plot_images(wunit.get_all_obstimes(), o_image0, o_image1, o_image2, o_image3)"
    ]
@@ -118,7 +118,7 @@
    "id": "dbd3ff9f-62ef-42c8-820f-ca26214d4214",
    "metadata": {},
    "source": [
-    "A couple of important attributes to point ou:\n",
+    "A couple of important attributes to point out:\n",
     "- Each images has a different WCS. The center ra/dec value shifted up and to the right ~5 pixels in each successive images, except for the last one which is below image 3.\n",
     "- The `obstime` is increasing for each one, except for the last one which has the same obstime as image 3.\n",
     "- They all have a synthetic object in them, moving across the field of view. The last image has a presumambly different object.\n",
@@ -139,7 +139,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "common = wunit.per_image_wcs[0]\n",
+    "common = wunit.get_wcs(0)\n",
     "\n",
     "uwunit = reprojection.reproject_work_unit(wunit, common)"
    ]
@@ -195,7 +195,7 @@
     "original_img = wunit.im_stack.get_single_image(2)\n",
     "o_d = original_img.get_mask().image\n",
     "original_image2_mask = CCDData(o_d, unit=\"adu\")\n",
-    "original_image2_mask.wcs = wunit.per_image_wcs[2]\n",
+    "original_image2_mask.wcs = wunit.get_wcs(2)\n",
     "\n",
     "image2_mask = CCDData(images[2].get_mask().image, unit=\"adu\")\n",
     "image2_mask.wcs = uwunit.wcs\n",
@@ -220,7 +220,7 @@
   "kernelspec": {
    "display_name": "kbmod",
    "language": "python",
-   "name": "kbmod"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -232,7 +232,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
gets the re projection notebook back in a working state