### PR TITLE
adds `invert_correct_parallax` function

### DIFF
--- a/src/kbmod/reprojection_utils.py
+++ b/src/kbmod/reprojection_utils.py
@@ -82,6 +82,8 @@ def invert_correct_parallax(coord, obstime, point_on_earth, geocentric_distance,
         The location on Earth of the observation.
     geocentric_distance : `float`
         The distance from Earth to the object (generally a result from `correct_parallax`).
+    heliocentric_distance : `float`
+        The distance from the solar system barycenter to the object (generally an input for `correct_parallax`).
 
     Returns
     ----------
@@ -138,7 +140,8 @@ def fit_barycentric_wcs(
     Returns
     ----------
     An `astropy.wcs.WCS` representing the original image in "Explicity Barycentric Distance" (EBD)
-    space, i.e. where the points have been corrected for parallax.
+    space, i.e. where the points have been corrected for parallax, as well as the average best fit
+    geocentric distance of the object.
     """
     rng = np.random.default_rng(seed)
 

--- a/src/kbmod/reprojection_utils.py
+++ b/src/kbmod/reprojection_utils.py
@@ -6,7 +6,7 @@ from astropy.wcs.utils import fit_wcs_from_points
 from scipy.optimize import minimize
 
 
-def correct_parallax(coord, obstime, point_on_earth, guess_distance):
+def correct_parallax(coord, obstime, point_on_earth, heliocentric_distance):
     """Calculate the parallax corrected postions for a given object at a given time and distance from Earth.
 
     Attributes
@@ -17,12 +17,12 @@ def correct_parallax(coord, obstime, point_on_earth, guess_distance):
         The observation time.
     point_on_earth : `astropy.coordinate.EarthLocation`
         The location on Earth of the observation.
-    guess_distance : `float`
-        The guess distance to the object from Earth.
+    heliocentric_distance : `float`
+        The guess distance to the object from the Sun.
 
     Returns
     ----------
-    An `astropy.coordinate.SkyCoord` containing the ra and dec of the pointin ICRS.
+    An `astropy.coordinate.SkyCoord` containing the ra and dec of the point in ICRS, and the best fit geocentric distance (float).
 
     References
     ----------
@@ -38,9 +38,9 @@ def correct_parallax(coord, obstime, point_on_earth, guess_distance):
     # the object has an unknown distance from earth
     los_earth_obj = coord.transform_to(GCRS(obstime=obstime, obsgeoloc=loc))
 
-    cost = lambda d: np.abs(
-        guess_distance
-        - GCRS(ra=los_earth_obj.ra, dec=los_earth_obj.dec, distance=d * u.AU, obstime=obstime, obsgeoloc=loc)
+    cost = lambda geocentric_distance: np.abs(
+        heliocentric_distance
+        - GCRS(ra=los_earth_obj.ra, dec=los_earth_obj.dec, distance=geocentric_distance * u.AU, obstime=obstime, obsgeoloc=loc)
         .transform_to(ICRS())
         .distance.to(u.AU)
         .value
@@ -48,18 +48,59 @@ def correct_parallax(coord, obstime, point_on_earth, guess_distance):
 
     fit = minimize(
         cost,
-        (guess_distance,),
+        (heliocentric_distance,),
     )
 
     answer = GCRS(
         ra=los_earth_obj.ra, dec=los_earth_obj.dec, distance=fit.x[0] * u.AU, obstime=obstime, obsgeoloc=loc
     ).transform_to(ICRS())
 
-    return answer
+    return answer, fit.x[0]
+
+def invert_correct_parallax(coord, obstime, point_on_earth, geocentric_distance, heliocentric_distance):
+    """Calculate the original ICRS coordinates of a point in EBD space, i.e. a result from `correct_parallax`.
+
+    Attributes
+    ----------
+    coord : `astropy.coordinate.SkyCoord`
+        The coordinate to be corrected for.
+    obstime : `astropy.time.Time` or `string`
+        The observation time.
+    point_on_earth : `astropy.coordinate.EarthLocation`
+        The location on Earth of the observation.
+    geocentric_distance : `float`
+        The distance from Earth to the object (generally a result from `correct_parallax`).
+
+    Returns
+    ----------
+    An `astropy.coordinate.SkyCoord` containing the ra and dec of the point in ICRS.
+
+    References
+    ----------
+    .. [1] `Jupyter Notebook <https://github.com/maxwest-uw/notebooks/blob/main/uncorrecting_parallax.ipynb>`_
+    """
+    loc = (
+        point_on_earth.x.to(u.m).value,
+        point_on_earth.y.to(u.m).value,
+        point_on_earth.z.to(u.m).value,
+    ) * u.m
+    icrs_with_dist = ICRS(ra=coord.ra, dec=coord.dec, distance=heliocentric_distance * u.au)
+
+    gcrs_no_dist = icrs_with_dist.transform_to(GCRS(obsgeoloc=loc, obstime=obstime))
+    gcrs_with_dist = GCRS(
+        ra=gcrs_no_dist.ra,
+        dec=gcrs_no_dist.dec,
+        distance=geocentric_distance,
+        obsgeoloc=loc,
+        obstime=obstime
+    )
+
+    original_icrs = gcrs_with_dist.transform_to(ICRS())
+    return original_icrs
 
 
 def fit_barycentric_wcs(
-    original_wcs, width, height, distance, obstime, point_on_earth, npoints=10, seed=None
+    original_wcs, width, height, heliocentric_distance, obstime, point_on_earth, npoints=10, seed=None
 ):
     """Given a ICRS WCS and an object's distance from the Sun,
     return a new WCS that has been corrected for parallax motion.
@@ -72,7 +113,7 @@ def fit_barycentric_wcs(
         The image's width (typically NAXIS1).
     height : `int`
         The image's height (typically NAXIS2).
-    distance : `float`
+    heliocentric_distance : `float`
         The distance of the object from the sun, in AU.
     obstime : `astropy.time.Time` or `string`
         The observation time.
@@ -104,12 +145,17 @@ def fit_barycentric_wcs(
     sampled_coordinates = SkyCoord(sampled_ra, sampled_dec, unit="deg")
 
     ebd_corrected_points = []
+    geocentric_distances = []
     for coord in sampled_coordinates:
-        ebd_corrected_points.append(correct_parallax(coord, obstime, point_on_earth, distance))
+        coord, geo_dist = correct_parallax(coord, obstime, point_on_earth, heliocentric_distance)
+        ebd_corrected_points.append(coord)
+        geocentric_distances.append(geo_dist)
 
     ebd_corrected_points = SkyCoord(ebd_corrected_points)
     xy = (sampled_x_points, sampled_y_points)
     ebd_wcs = fit_wcs_from_points(
         xy, ebd_corrected_points, proj_point="center", projection="TAN", sip_degree=3
     )
-    return ebd_wcs
+    geocentric_distance = np.average(geocentric_distances)
+
+    return ebd_wcs, geocentric_distance

--- a/src/kbmod/reprojection_utils.py
+++ b/src/kbmod/reprojection_utils.py
@@ -51,8 +51,8 @@ def correct_parallax(coord, obstime, point_on_earth, heliocentric_distance):
         (heliocentric_distance,),
     )
 
-    answer = GCRS(
-        ra=los_earth_obj.ra, dec=los_earth_obj.dec, distance=fit.x[0] * u.AU, obstime=obstime, obsgeoloc=loc
+    answer = SkyCoord(
+        ra=los_earth_obj.ra, dec=los_earth_obj.dec, distance=fit.x[0] * u.AU, obstime=obstime, obsgeoloc=loc, frame="gcrs"
     ).transform_to(ICRS())
 
     return answer, fit.x[0]

--- a/src/kbmod/reprojection_utils.py
+++ b/src/kbmod/reprojection_utils.py
@@ -75,7 +75,7 @@ def invert_correct_parallax(coord, obstime, point_on_earth, geocentric_distance,
     Attributes
     ----------
     coord : `astropy.coordinate.SkyCoord`
-        The coordinate to be corrected for.
+        The EBD coordinate that we want to find the original position of in non parallax corrected space of.
     obstime : `astropy.time.Time` or `string`
         The observation time.
     point_on_earth : `astropy.coordinate.EarthLocation`
@@ -87,16 +87,17 @@ def invert_correct_parallax(coord, obstime, point_on_earth, geocentric_distance,
 
     Returns
     ----------
-    An `astropy.coordinate.SkyCoord` containing the ra and dec of the point in ICRS.
+    An `astropy.coordinate.SkyCoord` containing the ra and dec of the point in ICRS. corresponding to the
+    position in the original observation (before `correct_parallax`).
 
     References
     ----------
     .. [1] `Jupyter Notebook <https://github.com/maxwest-uw/notebooks/blob/main/uncorrecting_parallax.ipynb>`_
     """
     loc = (
-        point_on_earth.x.to(u.m).value,
-        point_on_earth.y.to(u.m).value,
-        point_on_earth.z.to(u.m).value,
+        point_on_earth.x,
+        point_on_earth.y,
+        point_on_earth.z,
     ) * u.m
     icrs_with_dist = ICRS(ra=coord.ra, dec=coord.dec, distance=heliocentric_distance * u.au)
 

--- a/src/kbmod/reprojection_utils.py
+++ b/src/kbmod/reprojection_utils.py
@@ -40,7 +40,13 @@ def correct_parallax(coord, obstime, point_on_earth, heliocentric_distance):
 
     cost = lambda geocentric_distance: np.abs(
         heliocentric_distance
-        - GCRS(ra=los_earth_obj.ra, dec=los_earth_obj.dec, distance=geocentric_distance * u.AU, obstime=obstime, obsgeoloc=loc)
+        - GCRS(
+            ra=los_earth_obj.ra,
+            dec=los_earth_obj.dec,
+            distance=geocentric_distance * u.AU,
+            obstime=obstime,
+            obsgeoloc=loc,
+        )
         .transform_to(ICRS())
         .distance.to(u.AU)
         .value
@@ -52,10 +58,16 @@ def correct_parallax(coord, obstime, point_on_earth, heliocentric_distance):
     )
 
     answer = SkyCoord(
-        ra=los_earth_obj.ra, dec=los_earth_obj.dec, distance=fit.x[0] * u.AU, obstime=obstime, obsgeoloc=loc, frame="gcrs"
+        ra=los_earth_obj.ra,
+        dec=los_earth_obj.dec,
+        distance=fit.x[0] * u.AU,
+        obstime=obstime,
+        obsgeoloc=loc,
+        frame="gcrs",
     ).transform_to(ICRS())
 
     return answer, fit.x[0]
+
 
 def invert_correct_parallax(coord, obstime, point_on_earth, geocentric_distance, heliocentric_distance):
     """Calculate the original ICRS coordinates of a point in EBD space, i.e. a result from `correct_parallax`.
@@ -88,11 +100,7 @@ def invert_correct_parallax(coord, obstime, point_on_earth, geocentric_distance,
 
     gcrs_no_dist = icrs_with_dist.transform_to(GCRS(obsgeoloc=loc, obstime=obstime))
     gcrs_with_dist = GCRS(
-        ra=gcrs_no_dist.ra,
-        dec=gcrs_no_dist.dec,
-        distance=geocentric_distance,
-        obsgeoloc=loc,
-        obstime=obstime
+        ra=gcrs_no_dist.ra, dec=gcrs_no_dist.dec, distance=geocentric_distance, obsgeoloc=loc, obstime=obstime
     )
 
     original_icrs = gcrs_with_dist.transform_to(ICRS())

--- a/tests/test_reprojection_utils.py
+++ b/tests/test_reprojection_utils.py
@@ -63,8 +63,8 @@ class test_reprojection_utils(unittest.TestCase):
         npt.assert_almost_equal(corrected_coord2.ra.value, expected_ra)
         npt.assert_almost_equal(corrected_coord2.dec.value, expected_dec)
 
-        assert type(corrected_coord1) == SkyCoord
-        assert type(corrected_coord2) == SkyCoord
+        assert type(corrected_coord1) is SkyCoord
+        assert type(corrected_coord2) is SkyCoord
 
     def test_invert_correct_parallax(self):
         corrected_coord1, geo_dist1 = correct_parallax(

--- a/tests/test_reprojection_utils.py
+++ b/tests/test_reprojection_utils.py
@@ -6,7 +6,7 @@ from astropy.coordinates import EarthLocation, SkyCoord, solar_system_ephemeris
 from astropy.time import Time
 from astropy.wcs import WCS
 
-from kbmod.reprojection_utils import correct_parallax, fit_barycentric_wcs
+from kbmod.reprojection_utils import correct_parallax, invert_correct_parallax, fit_barycentric_wcs
 
 
 class test_reprojection_utils(unittest.TestCase):
@@ -25,26 +25,26 @@ class test_reprojection_utils(unittest.TestCase):
         self.loc = EarthLocation.of_site(self.site)
         self.distance = 41.1592725489203
 
-    def test_parallax_equinox(self):
-        icrs_ra1 = 88.74513571
-        icrs_dec1 = 23.43426475
-        time1 = Time("2023-03-20T16:00:00", format="isot", scale="utc")
+        self.icrs_ra1 = 88.74513571
+        self.icrs_dec1 = 23.43426475
+        self.icrs_time1 = Time("2023-03-20T16:00:00", format="isot", scale="utc")
 
-        icrs_ra2 = 91.24261107
-        icrs_dec2 = 23.43437467
-        time2 = Time("2023-09-24T04:00:00", format="isot", scale="utc")
+        self.icrs_ra2 = 91.24261107
+        self.icrs_dec2 = 23.43437467
+        self.icrs_time2 = Time("2023-09-24T04:00:00", format="isot", scale="utc")
 
-        sc1 = SkyCoord(ra=icrs_ra1, dec=icrs_dec1, unit="deg")
-        sc2 = SkyCoord(ra=icrs_ra2, dec=icrs_dec2, unit="deg")
+        self.sc1 = SkyCoord(ra=self.icrs_ra1, dec=self.icrs_dec1, unit="deg")
+        self.sc2 = SkyCoord(ra=self.icrs_ra2, dec=self.icrs_dec2, unit="deg")
 
         with solar_system_ephemeris.set("de432s"):
-            loc = EarthLocation.of_site("ctio")
+            self.eq_loc = EarthLocation.of_site("ctio")
 
-        corrected_coord1 = correct_parallax(
-            coord=sc1,
-            obstime=time1,
-            point_on_earth=loc,
-            guess_distance=50.0,
+    def test_parallax_equinox(self):
+        corrected_coord1, _ = correct_parallax(
+            coord=self.sc1,
+            obstime=self.icrs_time1,
+            point_on_earth=self.eq_loc,
+            heliocentric_distance=50.0,
         )
 
         expected_ra = 90.0
@@ -53,15 +53,62 @@ class test_reprojection_utils(unittest.TestCase):
         npt.assert_almost_equal(corrected_coord1.ra.value, expected_ra)
         npt.assert_almost_equal(corrected_coord1.dec.value, expected_dec)
 
-        corrected_coord2 = correct_parallax(
-            coord=sc2,
-            obstime=time2,
-            point_on_earth=loc,
-            guess_distance=50.0,
+        corrected_coord2, _ = correct_parallax(
+            coord=self.sc2,
+            obstime=self.icrs_time2,
+            point_on_earth=self.eq_loc,
+            heliocentric_distance=50.0,
         )
 
         npt.assert_almost_equal(corrected_coord2.ra.value, expected_ra)
         npt.assert_almost_equal(corrected_coord2.dec.value, expected_dec)
+
+    def test_invert_correct_parallax(self):
+        corrected_coord1, geo_dist1 = correct_parallax(
+            coord=self.sc1,
+            obstime=self.icrs_time1,
+            point_on_earth=self.eq_loc,
+            heliocentric_distance=50.,
+        )
+
+        fresh_sc1 = SkyCoord(
+            ra=corrected_coord1.ra.degree,
+            dec=corrected_coord1.dec.degree,
+            unit="deg"
+        )
+
+        uncorrected_coord1 = invert_correct_parallax(
+            coord=fresh_sc1,
+            obstime=self.icrs_time1,
+            point_on_earth=self.eq_loc,
+            geocentric_distance=geo_dist1,
+            heliocentric_distance=50.
+        )
+
+        assert self.sc1.separation(uncorrected_coord1).arcsecond < 0.001
+
+        corrected_coord2, geo_dist2 = correct_parallax(
+            coord=self.sc2,
+            obstime=self.icrs_time2,
+            point_on_earth=self.eq_loc,
+            heliocentric_distance=50.,
+        )
+
+        fresh_sc2 = SkyCoord(
+            ra=corrected_coord2.ra.degree,
+            dec=corrected_coord2.dec.degree,
+            unit="deg"
+        )
+
+        uncorrected_coord2 = invert_correct_parallax(
+            coord=fresh_sc2,
+            obstime=self.icrs_time2,
+            point_on_earth=self.eq_loc,
+            geocentric_distance=geo_dist2,
+            heliocentric_distance=50.
+        )
+
+        assert self.sc2.separation(uncorrected_coord2).arcsecond < 0.001
 
     def test_fit_barycentric_wcs(self):
         x_points = np.array([247, 1252, 1052, 980, 420, 1954, 730, 1409, 1491, 803])
@@ -99,7 +146,7 @@ class test_reprojection_utils(unittest.TestCase):
 
         expected_sc = SkyCoord(ra=expected_ra, dec=expected_dec, unit="deg")
 
-        corrected_wcs = fit_barycentric_wcs(
+        corrected_wcs, geo_dist = fit_barycentric_wcs(
             self.test_wcs,
             self.nx,
             self.ny,
@@ -115,9 +162,10 @@ class test_reprojection_utils(unittest.TestCase):
         # assert we have sub-milliarcsecond precision
         assert np.all(seps < 0.001)
         assert corrected_wcs.array_shape == (self.ny, self.nx)
+        npt.assert_almost_equal(geo_dist, 40.18622, decimal=4)
 
     def test_fit_barycentric_wcs_consistency(self):
-        corrected_wcs = fit_barycentric_wcs(
+        corrected_wcs, geo_dist = fit_barycentric_wcs(
             self.test_wcs, self.nx, self.ny, self.distance, self.time, self.loc, seed=24601
         )
 
@@ -134,3 +182,5 @@ class test_reprojection_utils(unittest.TestCase):
         npt.assert_almost_equal(corrected_wcs.wcs.cd[0][1], 3.459611876675614e-08)
         npt.assert_almost_equal(corrected_wcs.wcs.cd[1][0], 3.401472764249802e-08)
         npt.assert_almost_equal(corrected_wcs.wcs.cd[1][1], 5.4242245855217796e-05)
+
+        npt.assert_almost_equal(geo_dist, 40.18622524245729)

--- a/tests/test_reprojection_utils.py
+++ b/tests/test_reprojection_utils.py
@@ -63,6 +63,9 @@ class test_reprojection_utils(unittest.TestCase):
         npt.assert_almost_equal(corrected_coord2.ra.value, expected_ra)
         npt.assert_almost_equal(corrected_coord2.dec.value, expected_dec)
 
+        assert type(corrected_coord1) == SkyCoord
+        assert type(corrected_coord2) == SkyCoord
+
     def test_invert_correct_parallax(self):
         corrected_coord1, geo_dist1 = correct_parallax(
             coord=self.sc1,

--- a/tests/test_reprojection_utils.py
+++ b/tests/test_reprojection_utils.py
@@ -71,21 +71,17 @@ class test_reprojection_utils(unittest.TestCase):
             coord=self.sc1,
             obstime=self.icrs_time1,
             point_on_earth=self.eq_loc,
-            heliocentric_distance=50.,
+            heliocentric_distance=50.0,
         )
 
-        fresh_sc1 = SkyCoord(
-            ra=corrected_coord1.ra.degree,
-            dec=corrected_coord1.dec.degree,
-            unit="deg"
-        )
+        fresh_sc1 = SkyCoord(ra=corrected_coord1.ra.degree, dec=corrected_coord1.dec.degree, unit="deg")
 
         uncorrected_coord1 = invert_correct_parallax(
             coord=fresh_sc1,
             obstime=self.icrs_time1,
             point_on_earth=self.eq_loc,
             geocentric_distance=geo_dist1,
-            heliocentric_distance=50.
+            heliocentric_distance=50.0,
         )
 
         assert self.sc1.separation(uncorrected_coord1).arcsecond < 0.001
@@ -94,21 +90,17 @@ class test_reprojection_utils(unittest.TestCase):
             coord=self.sc2,
             obstime=self.icrs_time2,
             point_on_earth=self.eq_loc,
-            heliocentric_distance=50.,
+            heliocentric_distance=50.0,
         )
 
-        fresh_sc2 = SkyCoord(
-            ra=corrected_coord2.ra.degree,
-            dec=corrected_coord2.dec.degree,
-            unit="deg"
-        )
+        fresh_sc2 = SkyCoord(ra=corrected_coord2.ra.degree, dec=corrected_coord2.dec.degree, unit="deg")
 
         uncorrected_coord2 = invert_correct_parallax(
             coord=fresh_sc2,
             obstime=self.icrs_time2,
             point_on_earth=self.eq_loc,
             geocentric_distance=geo_dist2,
-            heliocentric_distance=50.
+            heliocentric_distance=50.0,
         )
 
         assert self.sc2.separation(uncorrected_coord2).arcsecond < 0.001


### PR DESCRIPTION
resolves #557 , resolves #558 

- creates the `invert_correct_parallax` function, which can take a coordinates in EBD space and returns the position in the original "uncorrected" icrs reference frame.
- also fixes an issue where `correct_parallax` would output as something other than a `SkyCoord`.
- also changes some of the naming around the different "distance" variables (now `heliocentric_distance` and `geocentric_distance`, respectively) to improve readability.