### PR TITLE
make_trajectory doesn't fail when reading as floats

### DIFF
--- a/src/kbmod/trajectory_utils.py
+++ b/src/kbmod/trajectory_utils.py
@@ -46,13 +46,13 @@ def make_trajectory(x=0, y=0, vx=0.0, vy=0.0, flux=0.0, lh=0.0, obs_count=0):
         The resulting Trajectory object.
     """
     trj = Trajectory()
-    trj.x = x
-    trj.y = y
+    trj.x = int(x)
+    trj.y = int(y)
     trj.vx = vx
     trj.vy = vy
     trj.flux = flux
     trj.lh = lh
-    trj.obs_count = obs_count
+    trj.obs_count = int(obs_count)
     trj.valid = True
     return trj
 
@@ -227,6 +227,7 @@ def update_trajectory_from_psi_phi(trj, psi_curve, phi_curve, index_valid=None, 
     """Update the trajectory's statistic information from a psi_curve and
     phi_curve. Uses an optional index_valid mask (True/False) to mask out
     pixels.
+
     Parameters
     ----------
     trj : `Trajectory`
@@ -239,10 +240,12 @@ def update_trajectory_from_psi_phi(trj, psi_curve, phi_curve, index_valid=None, 
         An array of Booleans indicating whether the time step is valid.
     in_place : `bool`
         Update the input trajectory in-place.
+
     Returns
     -------
     result : `Trajectory`
         The updated trajectory. May be the same as trj if in_place=True.
+
     Raises
     ------
     Raises a ValueError if the input arrays are not the same size.


### PR DESCRIPTION
Sometimes floats can be passed into `make_trajectory` if it is ready data from a file, astropy Table, etc.