### PR TITLE
Fix small bug

### DIFF
--- a/src/kbmod/filters/stamp_filters.py
+++ b/src/kbmod/filters/stamp_filters.py
@@ -432,8 +432,8 @@ def get_coadds_and_filter_results(result_data, im_stack, stamp_params, chunk_siz
         # Create a subslice of the results and the Boolean indices.
         # Note that the sum stamp type does not filter out lc_index.
         trj_slice = trj_list[start_idx:end_idx]
-        if stamp_params.stamp_type != StampType.STAMP_SUM and "index_valid" in result_data.colnames:
-            bool_slice = result_data["index_valid"][start_idx:end_idx]
+        if stamp_params.stamp_type != StampType.STAMP_SUM and "obs_valid" in result_data.colnames:
+            bool_slice = result_data["obs_valid"][start_idx:end_idx]
         else:
             # Use all the indices for each trajectory.
             bool_slice = [[True] * im_stack.img_count() for _ in range(slice_size)]

--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -381,7 +381,8 @@ class Results:
         self.table["obs_valid"] = obs_valid
 
         # Update the track likelihoods given this new information.
-        self._update_likelihood()
+        if "psi_curve" in self.colnames and "phi_curve" in self.colnames:
+            self._update_likelihood()
         return self
 
     def _append_filtered(self, table, label=None):

--- a/tests/test_stamp_filters.py
+++ b/tests/test_stamp_filters.py
@@ -288,6 +288,56 @@ class test_stamp_filters(unittest.TestCase):
         self.assertEqual(keep["stamp"][0].shape, (11, 11))
         self.assertEqual(keep["stamp"][1].shape, (11, 11))
 
+    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    def test_get_coadds_and_filter_with_invalid(self):
+        image_count = 10
+        fake_times = create_fake_times(image_count, 57130.2, 1, 0.01, 1)
+        ds = FakeDataSet(
+            25,  # width
+            35,  # height
+            fake_times,  # time stamps
+            1.0,  # noise level
+            0.5,  # psf value
+            True,  # Use a fixed seed for testing
+        )
+
+        # Insert a single fake object with known parameters.
+        trj = make_trajectory(8, 7, 2.0, 1.0, flux=250.0)
+        ds.insert_object(trj)
+
+        valid1 = [True] * image_count
+        valid2 = [True] * image_count
+        # Completely mess up some of the images.
+        for i in [1, 3, 6, 7, 9]:
+            ds.stack.get_single_image(i).get_science().set_all(1000.0)
+            valid2[i] = False
+
+        # Create the Results with nearly identical trajectories,
+        # but different valid observations
+        trj2 = make_trajectory(8, 7, 2.0, 1.001, flux=250.0)
+        keep = Results.from_trajectories([trj, trj2])
+        keep.update_obs_valid(np.array([valid1, valid2]))
+
+        # Create the stamp parameters we need.
+        config_dict = {
+            "center_thresh": 0.03,
+            "do_stamp_filter": True,
+            "mom_lims": [35.5, 35.5, 1.0, 1.0, 1.0],
+            "peak_offset": [1.5, 1.5],
+            "stamp_type": "cpp_mean",
+            "stamp_radius": 5,
+        }
+        config = SearchConfiguration.from_dict(config_dict)
+
+        # Do the filtering.
+        get_coadds_and_filter_results(keep, ds.stack, config, chunk_size=2, debug=False)
+
+        # The check that the correct indices and number of stamps are saved.
+        self.assertTrue("stamp" in keep.colnames)
+        self.assertEqual(len(keep), 1)
+        self.assertEqual(keep["vx"][0], trj2.vx)
+        self.assertEqual(keep["vy"][0], trj2.vy)
+
     def test_append_all_stamps(self):
         image_count = 10
         fake_times = create_fake_times(image_count, 57130.2, 1, 0.01, 1)


### PR DESCRIPTION
In #549 I left one of the instances of the column name `index_valid` instead of `obs_valid`. This corrects that and adds a test to confirm it works.

It also adds a `if` condition that allows the user to set `obs_valid` without setting the psi or phi curves, which is useful for testing.

This needs to go in before #563.