### PR TITLE
Simplifying dataId handling for portability, plus other fixes

### DIFF
--- a/notebooks/region_search/Region Searching Workbook.ipynb
+++ b/notebooks/region_search/Region Searching Workbook.ipynb
@@ -61,6 +61,7 @@
     "from matplotlib import pyplot as plt\n",
     "from matplotlib.cm import get_cmap\n",
     "from matplotlib.colors import Normalize\n",
+    "import matplotlib.colors as mcolors\n",
     "\n",
     "import progressbar\n",
     "\n",
@@ -483,8 +484,8 @@
       "src_schema,8\n",
       "\n",
       "Read 46 datasetTypes from disk.\n",
-      "CPU times: user 2.02 ms, sys: 2.03 ms, total: 4.05 ms\n",
-      "Wall time: 10.4 ms\n"
+      "CPU times: user 1.66 ms, sys: 0 ns, total: 1.66 ms\n",
+      "Wall time: 1.58 ms\n"
      ]
     }
    ],
@@ -591,13 +592,117 @@
   {
    "cell_type": "code",
    "execution_count": 14,
+   "id": "9f3f393e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def clean_dataId(dataId, verbose=True):\n",
+    "    \"\"\"\n",
+    "    We need a way to extract a portable (non-LSST object) version of the DataId.\n",
+    "    A dataId normally looks like a dictionary with keys of instrument, detector, visit.\n",
+    "    4/22/2024 COC\n",
+    "    \"\"\"\n",
+    "    fields = [\"instrument\", \"detector\", \"visit\"]\n",
+    "    clean_id = {}\n",
+    "    #\n",
+    "    if type(dataId) == type({}) and list(dataId.keys()) == fields:\n",
+    "        if verbose:\n",
+    "            print(f\"dataId was already a properly formatted dict: {dataId}.\")\n",
+    "        return dataId\n",
+    "    #\n",
+    "    try:\n",
+    "        dataId = dataId.values_tuple()\n",
+    "    except AttributeError as msg:\n",
+    "        if verbose:\n",
+    "            print(f\"dataId did not have a values_tuple() attribute. Message was {msg}.\")\n",
+    "        pass\n",
+    "    #\n",
+    "    if type(dataId) == type((1, 1, 1)):\n",
+    "        for i, label in enumerate(fields):\n",
+    "            clean_id[label] = dataId[i]\n",
+    "        if verbose:\n",
+    "            print(f\"Derived {clean_id} from tuple {dataId}.\")\n",
+    "        return clean_id\n",
+    "    #\n",
+    "    for i, label in enumerate(fields):\n",
+    "        try:\n",
+    "            clean_id[label] = dataId[label]\n",
+    "        except KeyError as msg:\n",
+    "            print(f\"KeyError for {label} with dataId= {dataId}. Message was: {msg}.\")\n",
+    "            break\n",
+    "    #\n",
+    "    if clean_id == {}:\n",
+    "        raise ValueError(f\"Failed to create clean_id for dataId={dataId}.\")\n",
+    "    #\n",
+    "    return clean_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "b7d7482e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def dataId_to_dataIdStr(dataId, force_clean=False, verbose=False):\n",
+    "    \"\"\"\n",
+    "    We will store a shortened, concatenated version of this unique triple.\n",
+    "    This is needed because dict values in a column are not hashable.\n",
+    "    Example: \"{instrument: 'DECam', detector: 1, visit: 898287}\" becomes \"DECam_1_898287\"\n",
+    "    4/23/2024 COC\n",
+    "    \"\"\"\n",
+    "    if force_clean:\n",
+    "        dataId = clean_dataId(dataId=dataId, verbose=verbose)\n",
+    "    #\n",
+    "    dataId_str = f\"{dataId['instrument']}_{dataId['detector']}_{dataId['visit']}\"\n",
+    "    #\n",
+    "    if verbose:\n",
+    "        print(f\"dataId {dataId} became: {dataId_str}\")\n",
+    "    #\n",
+    "    return dataId_str"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "c0fc27d8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dataId was already a properly formatted dict: {'instrument': 'DECam', 'detector': 1, 'visit': 898287}.\n",
+      "dataId {'instrument': 'DECam', 'detector': 1, 'visit': 898287} became: DECam_1_898287\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'DECam_1_898287'"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# test with the case of a dataId that is already a valid dict\n",
+    "dataId_to_dataIdStr(\n",
+    "    dataId={\"instrument\": \"DECam\", \"detector\": 1, \"visit\": 898287}, force_clean=True, verbose=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
    "id": "c47e5588",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_vdr_data(butler, desired_collections, desired_datasetTypes):\n",
+    "def get_vdr_data(butler, desired_collections, desired_datasetTypes, verbose=False):\n",
     "    \"\"\"\n",
-    "\n",
     "    Made as function 2/6/2024 COC.\n",
     "    \"\"\"\n",
     "    # VDR === Visit Detector Region\n",
@@ -615,7 +720,7 @@
     "            \"visit_detector_region\", datasets=dt, collections=desired_collections\n",
     "        )\n",
     "        for ref in datasetRefs:\n",
-    "            vdr_dict[\"data_id\"].append(ref.dataId)\n",
+    "            vdr_dict[\"data_id\"].append(clean_dataId(ref.dataId, verbose=verbose))\n",
     "            vdr_dict[\"region\"].append(\n",
     "                ref.region\n",
     "            )  # keeping as objects for now; should .encode() for caching/export\n",
@@ -634,7 +739,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "id": "eb222e02",
    "metadata": {},
    "outputs": [
@@ -642,8 +747,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.83 s, sys: 59.7 ms, total: 2.89 s\n",
-      "Wall time: 3.44 s\n"
+      "CPU times: user 2.05 s, sys: 79.6 ms, total: 2.13 s\n",
+      "Wall time: 2.64 s\n"
      ]
     }
    ],
@@ -657,7 +762,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
+   "id": "d7d6ada2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "lsst.daf.butler.core.dimensions._coordinate._BasicTupleDataCoordinate"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# notice the dataId type is not a plain tuple; so we created a function clean_dataId() to handle this.\n",
+    "type(example_vdr_ref.dataId)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "c2125e49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We also need a string version of the dataId that is hashable. 4/23/2024 COC\n",
+    "df[\"data_id_str\"] = [dataId_to_dataIdStr(dataId=dataId) for dataId in df[\"data_id\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
    "id": "6e9462e1",
    "metadata": {},
    "outputs": [
@@ -685,111 +823,136 @@
        "      <th>data_id</th>\n",
        "      <th>region</th>\n",
        "      <th>detector</th>\n",
+       "      <th>data_id_str</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847372525065534...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898286</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847381014554984...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898287</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847383417970056...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898288</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847382159041213...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898289</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847381374341414...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898290</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
        "      <td>...</td>\n",
        "      <td>...</td>\n",
        "      <td>...</td>\n",
+       "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>47378</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 62, 'visit...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.987608537646486,...</td>\n",
        "      <td>62</td>\n",
+       "      <td>DECam_62_946172</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>47379</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 62, 'visit...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9876085083003562...</td>\n",
        "      <td>62</td>\n",
+       "      <td>DECam_62_946173</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>47380</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 62, 'visit...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9876085761885252...</td>\n",
        "      <td>62</td>\n",
+       "      <td>DECam_62_946174</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>47381</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 62, 'visit...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9876085761885252...</td>\n",
        "      <td>62</td>\n",
+       "      <td>DECam_62_946175</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>47382</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 62, 'visit...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9876086828694174...</td>\n",
        "      <td>62</td>\n",
+       "      <td>DECam_62_946176</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>47383 rows × 3 columns</p>\n",
+       "<p>47383 rows × 4 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "                             data_id   \n",
-       "0      (instrument, detector, visit)  \\\n",
-       "1      (instrument, detector, visit)   \n",
-       "2      (instrument, detector, visit)   \n",
-       "3      (instrument, detector, visit)   \n",
-       "4      (instrument, detector, visit)   \n",
-       "...                              ...   \n",
-       "47378  (instrument, detector, visit)   \n",
-       "47379  (instrument, detector, visit)   \n",
-       "47380  (instrument, detector, visit)   \n",
-       "47381  (instrument, detector, visit)   \n",
-       "47382  (instrument, detector, visit)   \n",
+       "                                                 data_id   \n",
+       "0      {'instrument': 'DECam', 'detector': 1, 'visit'...  \\\n",
+       "1      {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "2      {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "3      {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "4      {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "...                                                  ...   \n",
+       "47378  {'instrument': 'DECam', 'detector': 62, 'visit...   \n",
+       "47379  {'instrument': 'DECam', 'detector': 62, 'visit...   \n",
+       "47380  {'instrument': 'DECam', 'detector': 62, 'visit...   \n",
+       "47381  {'instrument': 'DECam', 'detector': 62, 'visit...   \n",
+       "47382  {'instrument': 'DECam', 'detector': 62, 'visit...   \n",
        "\n",
-       "                                                  region  detector  \n",
-       "0      ConvexPolygon([UnitVector3d(0.9847372525065534...         1  \n",
-       "1      ConvexPolygon([UnitVector3d(0.9847381014554984...         1  \n",
-       "2      ConvexPolygon([UnitVector3d(0.9847383417970056...         1  \n",
-       "3      ConvexPolygon([UnitVector3d(0.9847382159041213...         1  \n",
-       "4      ConvexPolygon([UnitVector3d(0.9847381374341414...         1  \n",
-       "...                                                  ...       ...  \n",
-       "47378  ConvexPolygon([UnitVector3d(0.987608537646486,...        62  \n",
-       "47379  ConvexPolygon([UnitVector3d(0.9876085083003562...        62  \n",
-       "47380  ConvexPolygon([UnitVector3d(0.9876085761885252...        62  \n",
-       "47381  ConvexPolygon([UnitVector3d(0.9876085761885252...        62  \n",
-       "47382  ConvexPolygon([UnitVector3d(0.9876086828694174...        62  \n",
+       "                                                  region  detector   \n",
+       "0      ConvexPolygon([UnitVector3d(0.9847372525065534...         1  \\\n",
+       "1      ConvexPolygon([UnitVector3d(0.9847381014554984...         1   \n",
+       "2      ConvexPolygon([UnitVector3d(0.9847383417970056...         1   \n",
+       "3      ConvexPolygon([UnitVector3d(0.9847382159041213...         1   \n",
+       "4      ConvexPolygon([UnitVector3d(0.9847381374341414...         1   \n",
+       "...                                                  ...       ...   \n",
+       "47378  ConvexPolygon([UnitVector3d(0.987608537646486,...        62   \n",
+       "47379  ConvexPolygon([UnitVector3d(0.9876085083003562...        62   \n",
+       "47380  ConvexPolygon([UnitVector3d(0.9876085761885252...        62   \n",
+       "47381  ConvexPolygon([UnitVector3d(0.9876085761885252...        62   \n",
+       "47382  ConvexPolygon([UnitVector3d(0.9876086828694174...        62   \n",
        "\n",
-       "[47383 rows x 3 columns]"
+       "           data_id_str  \n",
+       "0       DECam_1_898286  \n",
+       "1       DECam_1_898287  \n",
+       "2       DECam_1_898288  \n",
+       "3       DECam_1_898289  \n",
+       "4       DECam_1_898290  \n",
+       "...                ...  \n",
+       "47378  DECam_62_946172  \n",
+       "47379  DECam_62_946173  \n",
+       "47380  DECam_62_946174  \n",
+       "47381  DECam_62_946175  \n",
+       "47382  DECam_62_946176  \n",
+       "\n",
+       "[47383 rows x 4 columns]"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -800,7 +963,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 22,
    "id": "e04e2f35",
    "metadata": {},
    "outputs": [
@@ -818,7 +981,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 23,
    "id": "08d5b443",
    "metadata": {},
    "outputs": [
@@ -835,7 +998,7 @@
        "visit_detector_region.RecordClass(instrument='DECam', detector=62, visit=946176, region=ConvexPolygon([UnitVector3d(0.9876086828694174, -0.13336028508776862, -0.08272922024438323), UnitVector3d(0.9873378171284917, -0.13332652431396907, -0.08595389916869185), UnitVector3d(0.9881047366097594, -0.12752395595185462, -0.08594573955553172), UnitVector3d(0.9883760335240734, -0.12755303452468866, -0.0827226676235914)]))"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -847,7 +1010,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 24,
    "id": "e28031c2",
    "metadata": {},
    "outputs": [
@@ -857,7 +1020,7 @@
        "{instrument: 'DECam', detector: 62, visit: 946176}"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -869,7 +1032,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 25,
    "id": "761f3610",
    "metadata": {},
    "outputs": [
@@ -892,7 +1055,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 26,
    "id": "5d6b2106",
    "metadata": {},
    "outputs": [
@@ -902,7 +1065,7 @@
        "b'p\\xddnE\\x86}\\x9a\\xef?\\x0f\\xc3\\x84\\'\\xf3\\x11\\xc1\\xbf\\x80\\x8a_\\xff\\xbd-\\xb5\\xbf\\x04xUzE\\x98\\xef?\\x94\\x15\\xcf\\xf2\\xd7\\x10\\xc1\\xbf\\x9d\\xa9\\xe4!\\x13\\x01\\xb6\\xbf\\x1d_\\x18\\xd3\\x8d\\x9e\\xef?\\x80\\x87\"z\\xb4R\\xc0\\xbff\\x1d\\x9f<\\x8a\\x00\\xb6\\xbf\\xe4Z\\x84\\xc6\\xc6\\xa0\\xef?\\x1f\\x01\\xe5g\\xa8S\\xc0\\xbf\\xba\\xc9\\x14\\x10P-\\xb5\\xbf'"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -914,7 +1077,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 27,
    "id": "aa653a8b",
    "metadata": {},
    "outputs": [
@@ -924,7 +1087,7 @@
        "False"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -947,7 +1110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 28,
    "id": "acda18f4",
    "metadata": {},
    "outputs": [
@@ -955,8 +1118,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 305 ms, sys: 35.8 ms, total: 340 ms\n",
-      "Wall time: 400 ms\n"
+      "CPU times: user 112 ms, sys: 20.9 ms, total: 133 ms\n",
+      "Wall time: 196 ms\n"
      ]
     }
    ],
@@ -972,7 +1135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 29,
    "id": "bb076b4b",
    "metadata": {},
    "outputs": [],
@@ -995,12 +1158,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 30,
    "id": "0228bb4d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def getInstruments(butler, vdr_ids, first_instrument_only=True):\n",
+    "def getInstruments(butler, vdr_ids, first_instrument_only=True, datasetType=desired_datasetTypes[0]):\n",
     "    \"\"\"Iterate through our records to determine which instrument(s) are involved.\n",
     "    Return a list of the identified instruments.\n",
     "    If first_instrument_only is True, stop as soon as we found an instrument.\n",
@@ -1008,7 +1171,7 @@
     "    # KLUDGE: snag the instrument name of the first record we find in a visitInfo query.\n",
     "    instrument_names = []\n",
     "    for i, dataId in enumerate(vdr_ids):\n",
-    "        visitInfo = butler.get(\"calexp.visitInfo\", dataId=dataId, collections=desired_collections)\n",
+    "        visitInfo = butler.get(f\"{datasetType}.visitInfo\", dataId=dataId, collections=desired_collections)\n",
     "        instrument_name = visitInfo.instrumentLabel\n",
     "        if instrument_name not in instrument_names:\n",
     "            print(f'Found {instrument_name}. Adding to \"desired_instruments\" now.')\n",
@@ -1023,7 +1186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 31,
    "id": "6c3bb244",
    "metadata": {},
    "outputs": [
@@ -1033,8 +1196,8 @@
      "text": [
       "Found DECam. Adding to \"desired_instruments\" now.\n",
       "WARNING: we are not iterating over all rows to find instruments, just taking the first one.\n",
-      "CPU times: user 1.03 s, sys: 199 ms, total: 1.23 s\n",
-      "Wall time: 1.94 s\n"
+      "CPU times: user 1.07 s, sys: 99 ms, total: 1.17 s\n",
+      "Wall time: 1.19 s\n"
      ]
     }
    ],
@@ -1055,7 +1218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 32,
    "id": "dfc37b54",
    "metadata": {},
    "outputs": [
@@ -1063,8 +1226,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.28 s, sys: 203 ms, total: 1.48 s\n",
-      "Wall time: 2.01 s\n"
+      "CPU times: user 947 ms, sys: 96.7 ms, total: 1.04 s\n",
+      "Wall time: 1.06 s\n"
      ]
     }
    ],
@@ -1080,7 +1243,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 33,
+   "id": "477c6e38",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The example_vdr_ref has a .dataId of type <class 'lsst.daf.butler.core.dimensions._coordinate._BasicTupleDataCoordinate'>.\n",
+      "ValuesView({instrument: 'DECam', detector: 62, visit: 946176})\n",
+      "dataId did not have a values_tuple() attribute. Message was '_BasicTupleDataCoordinate' object has no attribute 'values_tuple'.\n",
+      "Our manual vdr ref: {'instrument': 'DECam', 'detector': 62, 'visit': 946176}.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# let us try this without the special DataID Butler object 4/22/2024 COC\n",
+    "print(f\"The example_vdr_ref has a .dataId of type {type(example_vdr_ref.dataId)}.\")  # .values_tuple()\n",
+    "print(example_vdr_ref.dataId.values())\n",
+    "example_vdr_ref_dataId_manual = clean_dataId(dataId=example_vdr_ref.dataId, verbose=True)\n",
+    "# example_vdr_ref_dataId_manual = {}\n",
+    "# for i in ['instrument', 'detector', 'visit']:\n",
+    "#     example_vdr_ref_dataId_manual[i] = example_vdr_ref.dataId[i]\n",
+    "print(f\"Our manual vdr ref: {example_vdr_ref_dataId_manual}.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "d5814458",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example_butler_get_manual_dataId = butler.get(\n",
+    "    desired_datasetTypes[0], collections=desired_collections, dataId=example_vdr_ref_dataId_manual\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "791b60ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "62"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# with our alternate (manual) approach:\n",
+    "example_butler_get_manual_dataId.detector.getId()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
    "id": "789f1d42",
    "metadata": {},
    "outputs": [
@@ -1090,18 +1315,19 @@
        "62"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "# which matches the same attribute via our original query:\n",
     "example_butler_get.detector.getId()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 37,
    "id": "351e8d03",
    "metadata": {},
    "outputs": [
@@ -1111,7 +1337,7 @@
        "'VR'"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1122,17 +1348,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 38,
    "id": "1c1e5431",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f192d39f790>"
+       "<matplotlib.image.AxesImage at 0x7f0e1a87f520>"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1154,7 +1380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 39,
    "id": "ba1b7ab6",
    "metadata": {},
    "outputs": [
@@ -1167,7 +1393,7 @@
        "Pixel Scale: 0.262593 arcsec/pixel"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1179,7 +1405,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 40,
    "id": "4270995e",
    "metadata": {
     "scrolled": true
@@ -1409,7 +1635,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 41,
    "id": "7bbc916e",
    "metadata": {},
    "outputs": [],
@@ -1420,7 +1646,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 42,
    "id": "e0f8f8f9",
    "metadata": {},
    "outputs": [],
@@ -1502,7 +1728,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 43,
    "id": "6dd2ea6a",
    "metadata": {},
    "outputs": [
@@ -1511,8 +1737,8 @@
      "output_type": "stream",
      "text": [
       "Recycled 47383 paths from /astro/users/coc123/kbmod_tmp/uri_cache.lst as overwrite was False.\n",
-      "CPU times: user 47.6 ms, sys: 27 ms, total: 74.7 ms\n",
-      "Wall time: 181 ms\n"
+      "CPU times: user 16.6 ms, sys: 18.7 ms, total: 35.3 ms\n",
+      "Wall time: 34.4 ms\n"
      ]
     }
    ],
@@ -1533,7 +1759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 44,
    "id": "eae8d366",
    "metadata": {},
    "outputs": [
@@ -1543,7 +1769,7 @@
        "'file:///epyc/users/smotherh/DEEP/PointingGroups/butler-repo/PointingGroup021/imdiff_r/20210723T174135Z/deepDiff_differenceExp/20190927/VR/VR_DECam_c0007_6300.0_2600.0/898286/deepDiff_differenceExp_DECam_VR_VR_DECam_c0007_6300_0_2600_0_898286_S29_PointingGroup021_imdiff_r_20210723T174135Z.fits'"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1564,7 +1790,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 45,
    "id": "df7ff31f",
    "metadata": {},
    "outputs": [
@@ -1573,8 +1799,8 @@
      "output_type": "stream",
      "text": [
       "0 DateTime(\"2019-09-27T00:20:59.932016000\", TAI) 120.0 (351.3806941054, -5.2403083277)\n",
-      "CPU times: user 61.8 ms, sys: 10.8 ms, total: 72.6 ms\n",
-      "Wall time: 88.8 ms\n"
+      "CPU times: user 92.1 ms, sys: 8.71 ms, total: 101 ms\n",
+      "Wall time: 125 ms\n"
      ]
     }
    ],
@@ -1590,7 +1816,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 46,
    "id": "3ccadfaa",
    "metadata": {},
    "outputs": [
@@ -1600,7 +1826,7 @@
        "lsst.daf.base.dateTime.dateTime.DateTime"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1612,7 +1838,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 47,
    "id": "d73d8119",
    "metadata": {},
    "outputs": [
@@ -1622,7 +1848,7 @@
        "'2019-09-27T00:20:22.932'"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1635,7 +1861,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 48,
    "id": "4cb53994",
    "metadata": {},
    "outputs": [],
@@ -1644,12 +1870,15 @@
     "\n",
     "\n",
     "# Define get_timestamps at the top level of your module\n",
-    "def get_timestamps(dataIds_chunk, repo_path, desired_collections):\n",
+    "def get_timestamps(dataIds_chunk, repo_path, desired_collections, datasetType=desired_datasetTypes[0]):\n",
+    "    \"\"\"\n",
+    "    Adding datasetType 4/22/2024 COC\n",
+    "    \"\"\"\n",
     "    chunked_data = []\n",
     "    butler = dafButler.Butler(repo_path)\n",
     "    for dataId in dataIds_chunk:\n",
     "        try:\n",
-    "            visitInfo = butler.get(\"calexp.visitInfo\", dataId=dataId, collections=desired_collections)\n",
+    "            visitInfo = butler.get(f\"{datasetType}.visitInfo\", dataId=dataId, collections=desired_collections)\n",
     "            t = Time(str(visitInfo.date).split('\"')[1], format=\"isot\", scale=\"tai\")\n",
     "            tutc = str(t.utc)\n",
     "            chunked_data.append(tutc)\n",
@@ -1700,7 +1929,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 49,
    "id": "7e0d33c0",
    "metadata": {},
    "outputs": [
@@ -1710,8 +1939,8 @@
      "text": [
       "Overwrite is False, so we will read the timestamps from file now...\n",
       "Recycled 47383 from /astro/users/coc123/kbmod_tmp/vdr_timestamps.lst.\n",
-      "CPU times: user 15.4 ms, sys: 3.31 ms, total: 18.7 ms\n",
-      "Wall time: 44.8 ms\n"
+      "CPU times: user 22.5 ms, sys: 2.42 ms, total: 24.9 ms\n",
+      "Wall time: 24.1 ms\n"
      ]
     }
    ],
@@ -1724,7 +1953,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 50,
    "id": "adddf1e4",
    "metadata": {},
    "outputs": [
@@ -1745,7 +1974,7 @@
        "Name: ut, Length: 47383, dtype: object"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1756,7 +1985,171 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 51,
+   "id": "55ffd374",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'2019-09-27T00:20:22.932'"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Checking the format of the ut column shows that it is just a string:\n",
+    "df[\"ut\"].iloc()[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "faea89df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert \"ut\" column to datetime\n",
+    "df[\"ut_datetime\"] = pd.to_datetime(df[\"ut\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "c3beca0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# assert len(df[\"data_id\"]) == len(set(df[\"data_id\"]))\n",
+    "# assert len(df[\"data_id\"]) == len(set([str(df[\"data_id\"].iloc()[i]) for i in range(0,len(df.index))]))\n",
+    "assert df[\"data_id\"].apply(str).is_unique"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "b45d3fa2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def look_for_duplicates(df, verbose=True):\n",
+    "    \"\"\"\n",
+    "    As a reality check, we make sure there are no duplicate pairs of identical dataId + UT.\n",
+    "    3/11/2024 COC\n",
+    "    \"\"\"\n",
+    "    if verbose:\n",
+    "        print(f\"Starting look_for_duplicates()...\")\n",
+    "    # make sure no duplicate URIs first (easy + fast)\n",
+    "    if len(df[\"uri\"]) != len(set(df[\"uri\"])):\n",
+    "        raise AttributeError(\n",
+    "            f'There were only {len(set(df[\"uri\"]))} unique URIs. Should have been {len(df[\"uri\"])}.'\n",
+    "        )\n",
+    "    #\n",
+    "    if (\n",
+    "        not df[\"data_id\"].apply(str).is_unique\n",
+    "    ):  # len(df[\"data_id\"]) != len(set([str(df[\"data_id\"].iloc()[i]) for i in range(0,len(df.index))])):\n",
+    "        raise AttributeError(f\"Encountered non-unique set of dataIds.\")\n",
+    "    #\n",
+    "    dataId_uts = df[\"ut\"].astype(str) + df[\"data_id\"].astype(\n",
+    "        str\n",
+    "    )  # e.g., \"2019-09-27T00:20:22.932{instrument: 'DECam', detector: 1, visit: 898286}\"\n",
+    "    if len(dataId_uts) != len(set(dataId_uts)):\n",
+    "        raise AttributeError(f\"dataID + UT combinations were not unique\")\n",
+    "    if verbose:\n",
+    "        print(f\"No duplication found amongst the {len(df.index)} dataframe rows.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "83fe7b61",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting look_for_duplicates()...\n",
+      "No duplication found amongst the 47383 dataframe rows.\n"
+     ]
+    }
+   ],
+   "source": [
+    "look_for_duplicates(df=df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "381e68de",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['data_id', 'region', 'detector', 'data_id_str', 'uri', 'ut',\n",
+       "       'ut_datetime'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "1f33735a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"2019-09-27T00:20:22.932{'instrument': 'DECam', 'detector': 1, 'visit': 898286}\""
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataId_uts = df[\"ut\"].astype(str) + df[\"data_id\"].astype(str)\n",
+    "dataId_uts.iloc()[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "72aa75be",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(dataId_uts) == len(set(dataId_uts))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
    "id": "a789a331",
    "metadata": {},
    "outputs": [],
@@ -1792,7 +2185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 60,
    "id": "e45d7199",
    "metadata": {},
    "outputs": [],
@@ -1815,7 +2208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 61,
    "id": "9b278b50",
    "metadata": {},
    "outputs": [
@@ -1828,7 +2221,7 @@
        " (352.64644359666477, -4.7450820235469715)]"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1841,7 +2234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 62,
    "id": "b37bfe47",
    "metadata": {},
    "outputs": [],
@@ -1864,7 +2257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 63,
    "id": "ef329736",
    "metadata": {},
    "outputs": [
@@ -1875,7 +2268,7 @@
        " (-4.930880058593892, -4.7450820235469715))"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1898,7 +2291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 64,
    "id": "4c89be9e",
    "metadata": {},
    "outputs": [],
@@ -1917,7 +2310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 65,
    "id": "8e1e764c",
    "metadata": {},
    "outputs": [
@@ -1927,7 +2320,7 @@
        "(352.477974357993, -4.837981041070432)"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1938,7 +2331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 66,
    "id": "8e54db29",
    "metadata": {},
    "outputs": [
@@ -1946,8 +2339,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 405 ms, sys: 19.1 ms, total: 424 ms\n",
-      "Wall time: 423 ms\n"
+      "CPU times: user 277 ms, sys: 1.25 ms, total: 278 ms\n",
+      "Wall time: 278 ms\n"
      ]
     }
    ],
@@ -1958,7 +2351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 67,
    "id": "64908868",
    "metadata": {},
    "outputs": [
@@ -1968,7 +2361,7 @@
        "47383"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1979,7 +2372,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 68,
    "id": "625de417",
    "metadata": {},
    "outputs": [
@@ -1989,7 +2382,7 @@
        "(351.0694028401149, -4.336598368890197)"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2000,7 +2393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 69,
    "id": "67b57215",
    "metadata": {},
    "outputs": [
@@ -2008,17 +2401,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.65 s, sys: 13.5 ms, total: 1.66 s\n",
-      "Wall time: 1.66 s\n"
+      "CPU times: user 1.26 s, sys: 27.4 ms, total: 1.29 s\n",
+      "Wall time: 1.29 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.PathCollection at 0x7f19296e7640>"
+       "<matplotlib.collections.PathCollection at 0x7f0e1064b580>"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2057,17 +2450,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 70,
    "id": "c2dc4e1a",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{instrument: 'DECam', detector: 1, visit: 898286}"
+       "{'instrument': 'DECam', 'detector': 1, 'visit': 898286}"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2079,17 +2472,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 71,
    "id": "580ac4ed",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.PathCollection at 0x7f19296b1df0>"
+       "<matplotlib.collections.PathCollection at 0x7f0e105dab80>"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2115,7 +2508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 72,
    "id": "6ee544b8",
    "metadata": {},
    "outputs": [],
@@ -2138,7 +2531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 73,
    "id": "2c770982",
    "metadata": {},
    "outputs": [],
@@ -2184,7 +2577,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 140,
+   "execution_count": 74,
    "id": "2fcdd8b3",
    "metadata": {},
    "outputs": [],
@@ -2225,7 +2618,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 75,
    "id": "c0916372",
    "metadata": {},
    "outputs": [
@@ -2242,7 +2635,7 @@
        "(189361, 1895.111766130883)"
       ]
      },
-     "execution_count": 59,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2253,7 +2646,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 76,
    "id": "47c447c5",
    "metadata": {},
    "outputs": [
@@ -2292,7 +2685,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 77,
    "id": "048e38e1",
    "metadata": {},
    "outputs": [],
@@ -2369,7 +2762,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 78,
    "id": "25710a99",
    "metadata": {},
    "outputs": [
@@ -2378,8 +2771,8 @@
      "output_type": "stream",
      "text": [
       "Recycling /astro/users/coc123/kbmod_tmp/overlapping_sets.pickle as overwrite=False.\n",
-      "CPU times: user 288 ms, sys: 53.2 ms, total: 341 ms\n",
-      "Wall time: 371 ms\n"
+      "CPU times: user 263 ms, sys: 31.5 ms, total: 295 ms\n",
+      "Wall time: 293 ms\n"
      ]
     }
    ],
@@ -2394,7 +2787,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 79,
    "id": "5f2d5a03",
    "metadata": {},
    "outputs": [
@@ -2420,7 +2813,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 80,
+   "id": "38d96b97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create lookup tables for data_id_str to center_coord and ut_datetime for vast speed-ups.\n",
+    "id_to_coord = df.set_index(\"data_id_str\")[\"center_coord\"].to_dict()\n",
+    "id_to_date = df.set_index(\"data_id_str\")[\"ut_datetime\"].dt.date.to_dict()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
    "id": "9ed24e28",
    "metadata": {},
    "outputs": [
@@ -2428,17 +2833,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 555 ms, sys: 8.22 ms, total: 563 ms\n",
-      "Wall time: 562 ms\n"
+      "CPU times: user 26.4 ms, sys: 4.71 ms, total: 31.1 ms\n",
+      "Wall time: 29.1 ms\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.PathCollection at 0x7f19294b4490>"
+       "<matplotlib.collections.PathCollection at 0x7f0e127591f0>"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 81,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2455,14 +2860,10 @@
    ],
    "source": [
     "%%time\n",
-    "\n",
     "# Looking at the processed data.\n",
     "\n",
-    "# Create a lookup table for data_id to center_coord\n",
-    "id_to_coord = df.set_index(\"data_id\")[\"center_coord\"].to_dict()\n",
-    "\n",
     "# Preparing for bulk plotting (if every point uses the same label, adjust as needed)\n",
-    "coords = [id_to_coord[overlapping_sets[p][0]] for p in overlapping_sets]\n",
+    "coords = [id_to_coord[dataId_to_dataIdStr(overlapping_sets[p][0])] for p in overlapping_sets]\n",
     "x_coords, y_coords = zip(*coords)  # Assuming coords are tuples or lists\n",
     "\n",
     "# Plotting in bulk\n",
@@ -2471,28 +2872,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
-   "id": "55ffd374",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'2019-09-27T00:20:22.932'"
-      ]
-     },
-     "execution_count": 65,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df[\"ut\"].iloc()[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 82,
    "id": "fcd39c41",
    "metadata": {},
    "outputs": [
@@ -2500,15 +2880,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<timed exec>:14: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.\n"
+      "<timed exec>:7: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 6.15 s, sys: 482 ms, total: 6.64 s\n",
-      "Wall time: 6.1 s\n"
+      "CPU times: user 5.5 s, sys: 532 ms, total: 6.03 s\n",
+      "Wall time: 5.48 s\n"
      ]
     },
     {
@@ -2527,13 +2907,6 @@
     "\n",
     "# TIMING NOTE: this requires about 7 seconds\n",
     "\n",
-    "# Convert \"ut\" column to datetime\n",
-    "df[\"ut_datetime\"] = pd.to_datetime(df[\"ut\"])\n",
-    "\n",
-    "# Create lookup tables for data_id to center_coord and ut_datetime\n",
-    "id_to_coord = df.set_index(\"data_id\")[\"center_coord\"].to_dict()\n",
-    "id_to_date = df.set_index(\"data_id\")[\"ut_datetime\"].dt.date.to_dict()\n",
-    "\n",
     "# Extract unique dates and create a color map\n",
     "unique_dates = sorted(set(id_to_date.values()))\n",
     "date_to_color = {date: i for i, date in enumerate(unique_dates)}\n",
@@ -2541,8 +2914,8 @@
     "cmap = get_cmap(\"tab20\", len(unique_dates))  # Choose a colormap that fits the data\n",
     "\n",
     "# Preparing data for plotting\n",
-    "coords = [id_to_coord[overlapping_sets[p][0]] for p in overlapping_sets]\n",
-    "dates = [id_to_date[overlapping_sets[p][0]] for p in overlapping_sets]\n",
+    "coords = [id_to_coord[dataId_to_dataIdStr(overlapping_sets[p][0])] for p in overlapping_sets]\n",
+    "dates = [id_to_date[dataId_to_dataIdStr(overlapping_sets[p][0])] for p in overlapping_sets]\n",
     "colors = [cmap(norm(date_to_color[date])) for date in dates]\n",
     "\n",
     "# Plotting\n",
@@ -2573,55 +2946,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
-   "id": "418c97ee",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Index(['data_id', 'region', 'detector', 'uri', 'ut', 'center_coord',\n",
-       "       'ut_datetime'],\n",
-       "      dtype='object')"
-      ]
-     },
-     "execution_count": 67,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df.columns"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 83,
    "id": "d06ed515",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[datetime.date(2019, 8, 28),\n",
-       " datetime.date(2019, 8, 29),\n",
-       " datetime.date(2019, 8, 30),\n",
-       " datetime.date(2019, 9, 27),\n",
-       " datetime.date(2019, 9, 28),\n",
-       " datetime.date(2019, 9, 29),\n",
-       " datetime.date(2020, 10, 17),\n",
-       " datetime.date(2020, 10, 19)]"
-      ]
-     },
-     "execution_count": 68,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-08-28\n",
+      "2019-08-29\n",
+      "2019-08-30\n",
+      "2019-09-27\n",
+      "2019-09-28\n",
+      "2019-09-29\n",
+      "2020-10-17\n",
+      "2020-10-19\n"
+     ]
     }
    ],
    "source": [
     "# Here are the unique dates found in the discrete dataset\n",
     "unique_dates = sorted(set(id_to_date.values()))\n",
-    "unique_dates"
+    "print(\"\\n\".join([str(dt) for dt in unique_dates]))"
    ]
   },
   {
@@ -2634,24 +2981,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 84,
    "id": "58158f47",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "data_id                             (instrument, detector, visit)\n",
+       "data_id         {'instrument': 'DECam', 'detector': 1, 'visit'...\n",
        "region          ConvexPolygon([UnitVector3d(0.9847372525065534...\n",
        "detector                                                        1\n",
+       "data_id_str                                        DECam_1_898286\n",
        "uri             file:///epyc/users/smotherh/DEEP/PointingGroup...\n",
        "ut                                        2019-09-27T00:20:22.932\n",
-       "center_coord              (351.0694028401149, -4.336598368890197)\n",
        "ut_datetime                            2019-09-27 00:20:22.932000\n",
+       "center_coord              (351.0694028401149, -4.336598368890197)\n",
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2662,7 +3010,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 85,
    "id": "2ff625e7",
    "metadata": {},
    "outputs": [
@@ -2672,18 +3020,18 @@
        "datetime.date(2019, 9, 27)"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 85,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "id_to_date[df[\"data_id\"].iloc()[0]]"
+    "id_to_date[dataId_to_dataIdStr(df[\"data_id\"].iloc()[0])]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 86,
    "id": "c3b48b13",
    "metadata": {},
    "outputs": [
@@ -2693,18 +3041,18 @@
        "(351.0694028401149, -4.336598368890197)"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 86,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "id_to_coord[df[\"data_id\"].iloc()[0]]"
+    "id_to_coord[dataId_to_dataIdStr(df[\"data_id\"].iloc()[0])]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 87,
    "id": "16506478",
    "metadata": {},
    "outputs": [
@@ -2714,7 +3062,7 @@
        "6267"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 87,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2727,7 +3075,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 88,
    "id": "166c9137",
    "metadata": {},
    "outputs": [
@@ -2735,8 +3083,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 762 ms, sys: 7.39 ms, total: 769 ms\n",
-      "Wall time: 767 ms\n"
+      "CPU times: user 954 ms, sys: 14.5 ms, total: 969 ms\n",
+      "Wall time: 968 ms\n"
      ]
     },
     {
@@ -2832,6 +3180,525 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 89,
+   "id": "fe95f3f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Skipping set_1 because only one date.\n",
+      "Skipping set_2 because only one date.\n",
+      "Skipping set_3 because only one date.\n",
+      "Skipping set_4 because only one date.\n",
+      "Skipping set_5 because only one date.\n",
+      "Skipping set_6 because only one date.\n",
+      "Skipping set_7 because only one date.\n",
+      "Skipping set_8 because only one date.\n",
+      "Skipping set_9 because only one date.\n",
+      "Skipping set_10 because only one date.\n",
+      "Skipping set_11 because only one date.\n",
+      "Skipping set_12 because only one date.\n",
+      "Skipping set_13 because only one date.\n",
+      "Skipping set_14 because only one date.\n",
+      "Skipping set_15 because only one date.\n",
+      "Skipping set_16 because only one date.\n",
+      "Skipping set_17 because only one date.\n",
+      "Skipping set_18 because only one date.\n",
+      "Skipping set_19 because only one date.\n",
+      "Skipping set_20 because only one date.\n",
+      "Skipping set_21 because only one date.\n",
+      "Skipping set_22 because only one date.\n",
+      "Skipping set_23 because only one date.\n",
+      "Skipping set_24 because only one date.\n",
+      "Skipping set_25 because only one date.\n",
+      "Skipping set_26 because only one date.\n",
+      "Skipping set_27 because only one date.\n",
+      "Skipping set_28 because only one date.\n",
+      "Skipping set_29 because only one date.\n",
+      "Skipping set_30 because only one date.\n",
+      "Skipping set_31 because only one date.\n",
+      "Skipping set_32 because only one date.\n",
+      "Skipping set_33 because only one date.\n",
+      "Skipping set_34 because only one date.\n",
+      "Skipping set_35 because only one date.\n",
+      "Skipping set_36 because only one date.\n",
+      "Skipping set_37 because only one date.\n",
+      "Skipping set_38 because only one date.\n",
+      "Skipping set_39 because only one date.\n",
+      "Skipping set_40 because only one date.\n",
+      "Skipping set_41 because only one date.\n",
+      "Skipping set_42 because only one date.\n",
+      "Skipping set_43 because only one date.\n",
+      "Skipping set_44 because only one date.\n",
+      "Skipping set_45 because only one date.\n",
+      "Skipping set_46 because only one date.\n",
+      "Skipping set_47 because only one date.\n",
+      "Skipping set_48 because only one date.\n",
+      "Skipping set_49 because only one date.\n",
+      "Skipping set_50 because only one date.\n",
+      "Skipping set_51 because only one date.\n",
+      "Skipping set_52 because only one date.\n",
+      "Skipping set_53 because only one date.\n",
+      "Skipping set_54 because only one date.\n",
+      "Skipping set_55 because only one date.\n",
+      "Skipping set_56 because only one date.\n",
+      "Skipping set_57 because only one date.\n",
+      "Skipping set_58 because only one date.\n",
+      "Skipping set_59 because only one date.\n",
+      "Skipping set_60 because only one date.\n",
+      "Skipping set_61 because only one date.\n",
+      "Skipping set_62 because only one date.\n",
+      "Skipping set_63 because only one date.\n",
+      "Skipping set_64 because only one date.\n",
+      "Skipping set_65 because only one date.\n",
+      "Skipping set_66 because only one date.\n",
+      "Skipping set_67 because only one date.\n",
+      "Skipping set_68 because only one date.\n",
+      "Skipping set_69 because only one date.\n",
+      "Skipping set_70 because only one date.\n",
+      "Skipping set_71 because only one date.\n",
+      "Skipping set_72 because only one date.\n",
+      "Skipping set_73 because only one date.\n",
+      "Skipping set_74 because only one date.\n",
+      "Skipping set_75 because only one date.\n",
+      "Skipping set_76 because only one date.\n",
+      "Skipping set_77 because only one date.\n",
+      "Skipping set_78 because only one date.\n",
+      "Skipping set_79 because only one date.\n",
+      "Skipping set_80 because only one date.\n",
+      "Skipping set_81 because only one date.\n",
+      "Skipping set_82 because only one date.\n",
+      "Skipping set_83 because only one date.\n",
+      "Skipping set_84 because only one date.\n",
+      "Skipping set_85 because only one date.\n",
+      "Skipping set_86 because only one date.\n",
+      "Skipping set_87 because only one date.\n",
+      "Skipping set_88 because only one date.\n",
+      "Skipping set_89 because only one date.\n",
+      "Skipping set_90 because only one date.\n",
+      "Skipping set_91 because only one date.\n",
+      "Skipping set_92 because only one date.\n",
+      "Skipping set_93 because only one date.\n",
+      "Skipping set_94 because only one date.\n",
+      "Skipping set_95 because only one date.\n",
+      "Skipping set_96 because only one date.\n",
+      "Skipping set_97 because only one date.\n",
+      "Skipping set_98 because only one date.\n",
+      "Skipping set_99 because only one date.\n",
+      "Skipping set_100 because only one date.\n",
+      "Skipping set_101 because only one date.\n",
+      "Skipping set_102 because only one date.\n",
+      "Skipping set_103 because only one date.\n",
+      "Skipping set_104 because only one date.\n",
+      "Skipping set_105 because only one date.\n",
+      "Skipping set_106 because only one date.\n",
+      "Skipping set_107 because only one date.\n",
+      "Skipping set_108 because only one date.\n",
+      "Skipping set_109 because only one date.\n",
+      "Skipping set_110 because only one date.\n",
+      "Skipping set_111 because only one date.\n",
+      "Skipping set_112 because only one date.\n",
+      "Skipping set_113 because only one date.\n",
+      "Skipping set_114 because only one date.\n",
+      "Skipping set_115 because only one date.\n",
+      "Skipping set_116 because only one date.\n",
+      "Skipping set_117 because only one date.\n",
+      "Skipping set_118 because only one date.\n",
+      "Skipping set_119 because only one date.\n",
+      "Skipping set_120 because only one date.\n",
+      "Skipping set_121 because only one date.\n",
+      "Skipping set_122 because only one date.\n",
+      "Skipping set_123 because only one date.\n",
+      "Skipping set_124 because only one date.\n",
+      "Skipping set_125 because only one date.\n",
+      "Skipping set_126 because only one date.\n",
+      "Skipping set_127 because only one date.\n",
+      "Skipping set_128 because only one date.\n",
+      "Skipping set_129 because only one date.\n",
+      "Skipping set_130 because only one date.\n",
+      "Skipping set_131 because only one date.\n",
+      "Skipping set_132 because only one date.\n",
+      "Skipping set_133 because only one date.\n",
+      "Skipping set_134 because only one date.\n",
+      "Skipping set_135 because only one date.\n",
+      "Skipping set_136 because only one date.\n",
+      "Skipping set_137 because only one date.\n",
+      "Skipping set_138 because only one date.\n",
+      "Skipping set_139 because only one date.\n",
+      "Skipping set_140 because only one date.\n",
+      "Skipping set_141 because only one date.\n",
+      "Skipping set_142 because only one date.\n",
+      "Skipping set_143 because only one date.\n",
+      "Skipping set_144 because only one date.\n",
+      "Skipping set_145 because only one date.\n",
+      "Skipping set_146 because only one date.\n",
+      "Skipping set_147 because only one date.\n",
+      "Skipping set_148 because only one date.\n",
+      "Skipping set_149 because only one date.\n",
+      "Skipping set_150 because only one date.\n",
+      "Skipping set_151 because only one date.\n",
+      "Skipping set_152 because only one date.\n",
+      "Skipping set_153 because only one date.\n",
+      "Skipping set_154 because only one date.\n",
+      "Skipping set_155 because only one date.\n",
+      "Skipping set_156 because only one date.\n",
+      "Skipping set_157 because only one date.\n",
+      "Skipping set_158 because only one date.\n",
+      "Skipping set_159 because only one date.\n",
+      "Skipping set_160 because only one date.\n",
+      "Skipping set_161 because only one date.\n",
+      "Skipping set_162 because only one date.\n",
+      "Skipping set_163 because only one date.\n",
+      "Skipping set_164 because only one date.\n",
+      "Skipping set_165 because only one date.\n",
+      "Skipping set_166 because only one date.\n",
+      "Skipping set_167 because only one date.\n",
+      "Skipping set_168 because only one date.\n",
+      "Skipping set_169 because only one date.\n",
+      "Skipping set_170 because only one date.\n",
+      "Skipping set_171 because only one date.\n",
+      "Skipping set_172 because only one date.\n",
+      "Skipping set_173 because only one date.\n",
+      "Skipping set_174 because only one date.\n",
+      "Skipping set_175 because only one date.\n",
+      "Skipping set_176 because only one date.\n",
+      "Skipping set_177 because only one date.\n",
+      "Skipping set_178 because only one date.\n",
+      "Skipping set_179 because only one date.\n",
+      "Skipping set_180 because only one date.\n",
+      "Skipping set_181 because only one date.\n",
+      "Skipping set_182 because only one date.\n",
+      "Skipping set_183 because only one date.\n",
+      "Skipping set_184 because only one date.\n",
+      "Skipping set_185 because only one date.\n",
+      "Skipping set_186 because only one date.\n",
+      "Skipping set_187 because only one date.\n",
+      "Skipping set_188 because only one date.\n",
+      "Skipping set_189 because only one date.\n",
+      "Skipping set_190 because only one date.\n",
+      "Skipping set_191 because only one date.\n",
+      "Skipping set_192 because only one date.\n",
+      "Skipping set_193 because only one date.\n",
+      "Skipping set_194 because only one date.\n",
+      "Skipping set_195 because only one date.\n",
+      "Skipping set_196 because only one date.\n",
+      "Skipping set_197 because only one date.\n",
+      "Skipping set_198 because only one date.\n",
+      "Skipping set_199 because only one date.\n",
+      "Skipping set_200 because only one date.\n",
+      "Skipping set_201 because only one date.\n",
+      "Skipping set_202 because only one date.\n",
+      "Skipping set_203 because only one date.\n",
+      "Skipping set_204 because only one date.\n",
+      "Skipping set_205 because only one date.\n",
+      "Skipping set_206 because only one date.\n",
+      "Skipping set_207 because only one date.\n",
+      "Skipping set_208 because only one date.\n",
+      "Skipping set_209 because only one date.\n",
+      "Skipping set_210 because only one date.\n",
+      "Skipping set_211 because only one date.\n",
+      "Skipping set_212 because only one date.\n",
+      "Skipping set_213 because only one date.\n",
+      "Skipping set_214 because only one date.\n",
+      "Skipping set_215 because only one date.\n",
+      "Skipping set_216 because only one date.\n",
+      "Skipping set_217 because only one date.\n",
+      "Skipping set_218 because only one date.\n",
+      "Skipping set_219 because only one date.\n",
+      "Skipping set_220 because only one date.\n",
+      "Skipping set_221 because only one date.\n",
+      "Skipping set_222 because only one date.\n",
+      "Skipping set_223 because only one date.\n",
+      "Skipping set_224 because only one date.\n",
+      "Skipping set_225 because only one date.\n",
+      "Skipping set_226 because only one date.\n",
+      "Skipping set_227 because only one date.\n",
+      "Skipping set_228 because only one date.\n",
+      "Skipping set_229 because only one date.\n",
+      "Skipping set_230 because only one date.\n",
+      "Skipping set_231 because only one date.\n",
+      "Skipping set_232 because only one date.\n",
+      "Skipping set_233 because only one date.\n",
+      "Skipping set_234 because only one date.\n",
+      "Skipping set_235 because only one date.\n",
+      "Skipping set_236 because only one date.\n",
+      "Skipping set_237 because only one date.\n",
+      "Skipping set_238 because only one date.\n",
+      "Skipping set_239 because only one date.\n",
+      "Skipping set_240 because only one date.\n",
+      "Skipping set_241 because only one date.\n",
+      "Skipping set_242 because only one date.\n",
+      "Skipping set_243 because only one date.\n",
+      "Skipping set_244 because only one date.\n",
+      "Skipping set_245 because only one date.\n",
+      "Skipping set_246 because only one date.\n",
+      "Skipping set_247 because only one date.\n",
+      "Skipping set_248 because only one date.\n",
+      "Skipping set_249 because only one date.\n",
+      "Skipping set_250 because only one date.\n",
+      "Skipping set_251 because only one date.\n",
+      "Skipping set_252 because only one date.\n",
+      "Skipping set_253 because only one date.\n",
+      "Skipping set_254 because only one date.\n",
+      "Skipping set_255 because only one date.\n",
+      "Skipping set_256 because only one date.\n",
+      "Skipping set_257 because only one date.\n",
+      "Skipping set_258 because only one date.\n",
+      "Skipping set_259 because only one date.\n",
+      "Skipping set_260 because only one date.\n",
+      "Skipping set_261 because only one date.\n",
+      "Skipping set_262 because only one date.\n",
+      "Skipping set_263 because only one date.\n",
+      "Skipping set_264 because only one date.\n",
+      "Skipping set_265 because only one date.\n",
+      "Skipping set_266 because only one date.\n",
+      "Skipping set_267 because only one date.\n",
+      "Skipping set_268 because only one date.\n",
+      "Skipping set_269 because only one date.\n",
+      "Skipping set_270 because only one date.\n",
+      "Skipping set_271 because only one date.\n",
+      "Skipping set_272 because only one date.\n",
+      "Skipping set_273 because only one date.\n",
+      "Skipping set_274 because only one date.\n",
+      "Skipping set_275 because only one date.\n",
+      "Skipping set_276 because only one date.\n",
+      "Skipping set_277 because only one date.\n",
+      "Skipping set_278 because only one date.\n",
+      "Skipping set_279 because only one date.\n",
+      "Skipping set_280 because only one date.\n",
+      "Skipping set_281 because only one date.\n",
+      "Skipping set_282 because only one date.\n",
+      "Skipping set_283 because only one date.\n",
+      "Skipping set_284 because only one date.\n",
+      "Skipping set_285 because only one date.\n",
+      "Skipping set_286 because only one date.\n",
+      "Skipping set_287 because only one date.\n",
+      "Skipping set_288 because only one date.\n",
+      "Skipping set_289 because only one date.\n",
+      "Skipping set_290 because only one date.\n",
+      "Skipping set_291 because only one date.\n",
+      "Skipping set_292 because only one date.\n",
+      "Skipping set_293 because only one date.\n",
+      "Skipping set_294 because only one date.\n",
+      "Skipping set_295 because only one date.\n",
+      "Skipping set_296 because only one date.\n",
+      "Skipping set_297 because only one date.\n",
+      "Skipping set_298 because only one date.\n",
+      "Skipping set_299 because only one date.\n",
+      "Skipping set_300 because only one date.\n",
+      "Skipping set_301 because only one date.\n",
+      "Skipping set_302 because only one date.\n",
+      "Skipping set_303 because only one date.\n",
+      "Skipping set_304 because only one date.\n",
+      "Skipping set_305 because only one date.\n",
+      "Skipping set_306 because only one date.\n",
+      "Skipping set_307 because only one date.\n",
+      "Skipping set_308 because only one date.\n",
+      "Skipping set_309 because only one date.\n",
+      "Skipping set_310 because only one date.\n",
+      "Skipping set_311 because only one date.\n",
+      "Skipping set_312 because only one date.\n",
+      "Skipping set_313 because only one date.\n",
+      "Skipping set_314 because only one date.\n",
+      "Skipping set_315 because only one date.\n",
+      "Skipping set_316 because only one date.\n",
+      "Skipping set_317 because only one date.\n",
+      "Skipping set_318 because only one date.\n",
+      "Skipping set_319 because only one date.\n",
+      "Skipping set_320 because only one date.\n",
+      "Skipping set_321 because only one date.\n",
+      "Skipping set_322 because only one date.\n",
+      "Skipping set_323 because only one date.\n",
+      "Skipping set_324 because only one date.\n",
+      "Skipping set_325 because only one date.\n",
+      "Skipping set_326 because only one date.\n",
+      "Skipping set_327 because only one date.\n",
+      "Skipping set_328 because only one date.\n",
+      "Skipping set_329 because only one date.\n",
+      "Skipping set_330 because only one date.\n",
+      "Skipping set_331 because only one date.\n",
+      "Skipping set_332 because only one date.\n",
+      "Skipping set_333 because only one date.\n",
+      "Skipping set_334 because only one date.\n",
+      "Skipping set_335 because only one date.\n",
+      "Skipping set_336 because only one date.\n",
+      "Skipping set_337 because only one date.\n",
+      "Skipping set_338 because only one date.\n",
+      "Skipping set_339 because only one date.\n",
+      "Skipping set_340 because only one date.\n",
+      "Skipping set_341 because only one date.\n",
+      "Skipping set_342 because only one date.\n",
+      "Skipping set_343 because only one date.\n",
+      "Skipping set_344 because only one date.\n",
+      "Skipping set_345 because only one date.\n",
+      "Skipping set_346 because only one date.\n",
+      "Skipping set_347 because only one date.\n",
+      "Skipping set_348 because only one date.\n",
+      "Skipping set_349 because only one date.\n",
+      "Skipping set_350 because only one date.\n",
+      "Skipping set_351 because only one date.\n",
+      "Skipping set_352 because only one date.\n",
+      "Skipping set_353 because only one date.\n",
+      "Skipping set_354 because only one date.\n",
+      "Skipping set_355 because only one date.\n",
+      "Skipping set_356 because only one date.\n",
+      "Skipping set_357 because only one date.\n",
+      "Skipping set_358 because only one date.\n",
+      "Skipping set_359 because only one date.\n",
+      "Skipping set_360 because only one date.\n",
+      "Skipping set_361 because only one date.\n",
+      "Skipping set_362 because only one date.\n",
+      "Skipping set_363 because only one date.\n",
+      "Skipping set_364 because only one date.\n",
+      "Skipping set_365 because only one date.\n",
+      "Skipping set_366 because only one date.\n",
+      "Skipping set_367 because only one date.\n",
+      "Skipping set_368 because only one date.\n",
+      "Skipping set_369 because only one date.\n",
+      "Skipping set_370 because only one date.\n",
+      "Skipping set_371 because only one date.\n",
+      "Skipping set_372 because only one date.\n",
+      "Skipping set_373 because only one date.\n",
+      "Skipping set_374 because only one date.\n",
+      "Skipping set_375 because only one date.\n",
+      "Skipping set_376 because only one date.\n",
+      "Skipping set_377 because only one date.\n",
+      "Skipping set_378 because only one date.\n",
+      "Skipping set_379 because only one date.\n",
+      "Skipping set_380 because only one date.\n",
+      "Skipping set_381 because only one date.\n",
+      "Skipping set_382 because only one date.\n",
+      "Skipping set_383 because only one date.\n",
+      "Skipping set_384 because only one date.\n",
+      "Skipping set_385 because only one date.\n",
+      "Skipping set_386 because only one date.\n",
+      "Skipping set_387 because only one date.\n",
+      "Skipping set_388 because only one date.\n",
+      "Skipping set_389 because only one date.\n",
+      "Skipping set_390 because only one date.\n",
+      "Skipping set_391 because only one date.\n",
+      "Skipping set_392 because only one date.\n",
+      "Skipping set_393 because only one date.\n",
+      "Skipping set_394 because only one date.\n",
+      "Skipping set_395 because only one date.\n",
+      "Skipping set_396 because only one date.\n",
+      "Skipping set_397 because only one date.\n",
+      "Skipping set_398 because only one date.\n",
+      "Skipping set_399 because only one date.\n",
+      "Skipping set_400 because only one date.\n",
+      "Skipping set_401 because only one date.\n",
+      "Skipping set_402 because only one date.\n",
+      "Skipping set_403 because only one date.\n",
+      "Skipping set_404 because only one date.\n",
+      "Skipping set_405 because only one date.\n",
+      "Skipping set_406 because only one date.\n",
+      "Skipping set_407 because only one date.\n",
+      "Skipping set_408 because only one date.\n",
+      "Skipping set_409 because only one date.\n",
+      "Skipping set_410 because only one date.\n",
+      "Skipping set_411 because only one date.\n",
+      "Skipping set_412 because only one date.\n",
+      "Skipping set_413 because only one date.\n",
+      "Skipping set_414 because only one date.\n",
+      "Skipping set_415 because only one date.\n",
+      "Skipping set_416 because only one date.\n",
+      "Skipping set_417 because only one date.\n",
+      "Skipping set_418 because only one date.\n",
+      "Skipping set_419 because only one date.\n",
+      "Skipping set_420 because only one date.\n",
+      "Skipping set_421 because only one date.\n",
+      "Skipping set_422 because only one date.\n",
+      "Skipping set_423 because only one date.\n",
+      "Skipping set_424 because only one date.\n",
+      "Skipping set_425 because only one date.\n",
+      "Skipping set_426 because only one date.\n",
+      "Skipping set_427 because only one date.\n",
+      "Skipping set_428 because only one date.\n",
+      "Skipping set_429 because only one date.\n",
+      "Skipping set_430 because only one date.\n",
+      "Skipping set_431 because only one date.\n",
+      "Skipping set_432 because only one date.\n",
+      "Skipping set_433 because only one date.\n",
+      "Skipping set_434 because only one date.\n",
+      "Skipping set_435 because only one date.\n",
+      "Skipping set_436 because only one date.\n",
+      "Skipping set_437 because only one date.\n",
+      "Skipping set_438 because only one date.\n",
+      "Skipping set_439 because only one date.\n",
+      "Skipping set_440 because only one date.\n",
+      "Skipping set_441 because only one date.\n",
+      "Skipping set_442 because only one date.\n",
+      "Skipping set_443 because only one date.\n",
+      "Skipping set_444 because only one date.\n",
+      "Skipping set_445 because only one date.\n",
+      "Skipping set_446 because only one date.\n",
+      "Skipping set_447 because only one date.\n",
+      "Skipping set_448 because only one date.\n",
+      "Skipping set_449 because only one date.\n",
+      "Skipping set_450 because only one date.\n",
+      "Skipping set_451 because only one date.\n",
+      "Skipping set_452 because only one date.\n",
+      "Skipping set_453 because only one date.\n",
+      "Skipping set_454 because only one date.\n",
+      "Skipping set_455 because only one date.\n",
+      "Skipping set_456 because only one date.\n",
+      "Skipping set_457 because only one date.\n",
+      "Skipping set_458 because only one date.\n",
+      "Skipping set_459 because only one date.\n",
+      "Skipping set_460 because only one date.\n",
+      "Skipping set_461 because only one date.\n",
+      "Skipping set_462 because only one date.\n",
+      "Skipping set_463 because only one date.\n",
+      "Skipping set_464 because only one date.\n",
+      "Skipping set_465 because only one date.\n",
+      "Skipping set_466 because only one date.\n",
+      "Skipping set_467 because only one date.\n",
+      "Skipping set_468 because only one date.\n",
+      "Skipping set_469 because only one date.\n",
+      "Skipping set_470 because only one date.\n",
+      "Skipping set_471 because only one date.\n",
+      "Skipping set_472 because only one date.\n",
+      "Skipping set_473 because only one date.\n",
+      "Skipping set_474 because only one date.\n",
+      "Skipping set_475 because only one date.\n",
+      "Skipping set_476 because only one date.\n",
+      "Skipping set_477 because only one date.\n",
+      "Skipping set_478 because only one date.\n",
+      "Skipping set_479 because only one date.\n",
+      "Skipping set_480 because only one date.\n",
+      "Skipping set_481 because only one date.\n",
+      "Skipping set_482 because only one date.\n",
+      "Skipping set_483 because only one date.\n",
+      "Skipping set_484 because only one date.\n",
+      "Skipping set_485 because only one date.\n",
+      "Skipping set_486 because only one date.\n",
+      "Skipping set_487 because only one date.\n",
+      "Skipping set_488 because only one date.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exploring some timespan considerations 4/18/2024\n",
+    "#\n",
+    "# Note: in this repository (\"Hayden DEEP\") there are no multi-date overlaps.\n",
+    "# ... thus, we will need to revisit this with the broader \"Steven DEEP\" repository. 4/23/2024 COC\n",
+    "overlapping_sets\n",
+    "for overlapping_set in overlapping_sets:\n",
+    "    dates = [id_to_date[dataId_to_dataIdStr(i)] for i in overlapping_sets[overlapping_set]]\n",
+    "    unique_dates = list(set(dates))\n",
+    "    unique_dates.sort()\n",
+    "    if len(unique_dates) < 2:\n",
+    "        print(f\"Skipping {overlapping_set} because only one date.\")\n",
+    "        continue\n",
+    "    counts = [dates.count(i) for i in unique_dates]\n",
+    "    plt.plot_date(unique_dates, counts)\n",
+    "    break"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "a2e81bd6",
    "metadata": {},
@@ -2841,7 +3708,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 90,
    "id": "f3417ffd",
    "metadata": {},
    "outputs": [
@@ -2859,7 +3726,9 @@
     "# Fetch an (RA, Dec) pair from an image set.\n",
     "first_set_name = list(overlapping_sets.keys())[0]\n",
     "first_sets_data_id = overlapping_sets[first_set_name][0]\n",
-    "searching_ra_dec = df.set_index(\"data_id\")[\"center_coord\"].to_dict()[first_sets_data_id]\n",
+    "searching_ra_dec = df.set_index(\"data_id_str\")[\"center_coord\"].to_dict()[\n",
+    "    dataId_to_dataIdStr(first_sets_data_id)\n",
+    "]\n",
     "\n",
     "print(f'\"{first_set_name}\" is the first set name in overlapping_sets.')\n",
     "print(f\"Its first record dataId: {first_sets_data_id}.\")\n",
@@ -2868,7 +3737,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 91,
    "id": "bfb23aef",
    "metadata": {},
    "outputs": [],
@@ -2884,12 +3753,12 @@
     "    all_centers = []\n",
     "    all_labels = []\n",
     "\n",
-    "    id_to_coord = df.set_index(\"data_id\")[\"center_coord\"].to_dict()\n",
+    "    # id_to_coord = df.set_index(\"data_id_str\")[\"center_coord\"].to_dict() # note this was generated already but outside the function\n",
     "\n",
     "    for i, set_name in enumerate(list(overlapping_sets.keys())):\n",
     "        all_labels.append(set_name)\n",
     "        center_data_id = overlapping_sets[set_name][0]\n",
-    "        center_coord = id_to_coord[center_data_id]\n",
+    "        center_coord = id_to_coord[dataId_to_dataIdStr(center_data_id)]\n",
     "        all_centers.append(center_coord)\n",
     "\n",
     "    all_centers = SkyCoord(\n",
@@ -2913,7 +3782,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 92,
    "id": "0b98b0e4",
    "metadata": {},
    "outputs": [
@@ -2930,7 +3799,7 @@
        "['set_1', 'set_3', 'set_4', 'set_68']"
       ]
      },
-     "execution_count": 76,
+     "execution_count": 92,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2952,7 +3821,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 93,
    "id": "447b9b70",
    "metadata": {},
    "outputs": [
@@ -2976,10 +3845,10 @@
    ],
    "source": [
     "matching_regions = []\n",
-    "id_to_region = df.set_index(\"data_id\")[\"region\"].to_dict()\n",
+    "id_to_region = df.set_index(\"data_id_str\")[\"region\"].to_dict()\n",
     "\n",
     "for set_name in ra_dec_search_results:\n",
-    "    matching_regions.append(id_to_region[overlapping_sets[set_name][0]])\n",
+    "    matching_regions.append(id_to_region[dataId_to_dataIdStr(overlapping_sets[set_name][0])])\n",
     "\n",
     "all_corners = [getRegionCorners(region) for region in matching_regions]\n",
     "print(all_corners)\n",
@@ -3034,7 +3903,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 94,
    "id": "b636fef0",
    "metadata": {},
    "outputs": [],
@@ -3066,7 +3935,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 95,
    "id": "90b6aa45",
    "metadata": {},
    "outputs": [
@@ -3075,8 +3944,8 @@
      "output_type": "stream",
      "text": [
       "We found 95 matches within 3.0 arcsec of (351.0695696334572, -4.336293374423113).\n",
-      "CPU times: user 634 ms, sys: 228 µs, total: 634 ms\n",
-      "Wall time: 633 ms\n"
+      "CPU times: user 2.88 s, sys: 23.5 ms, total: 2.9 s\n",
+      "Wall time: 2.9 s\n"
      ]
     },
     {
@@ -3103,62 +3972,68 @@
        "      <th>data_id</th>\n",
        "      <th>region</th>\n",
        "      <th>detector</th>\n",
+       "      <th>data_id_str</th>\n",
        "      <th>uri</th>\n",
        "      <th>ut</th>\n",
-       "      <th>center_coord</th>\n",
        "      <th>ut_datetime</th>\n",
+       "      <th>center_coord</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847372525065534...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898286</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T00:20:22.932</td>\n",
-       "      <td>(351.0694028401149, -4.336598368890197)</td>\n",
        "      <td>2019-09-27 00:20:22.932</td>\n",
+       "      <td>(351.0694028401149, -4.336598368890197)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847381014554984...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898287</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T00:22:51.015</td>\n",
-       "      <td>(351.0695696334572, -4.336293374423113)</td>\n",
        "      <td>2019-09-27 00:22:51.015</td>\n",
+       "      <td>(351.0695696334572, -4.336293374423113)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847383417970056...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898288</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T00:25:19.136</td>\n",
-       "      <td>(351.0696571334576, -4.336293374415341)</td>\n",
        "      <td>2019-09-27 00:25:19.136</td>\n",
+       "      <td>(351.0696571334576, -4.336293374415341)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847382159041213...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898289</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T00:27:47.118</td>\n",
-       "      <td>(351.069611300124, -4.336293374419411)</td>\n",
        "      <td>2019-09-27 00:27:47.118</td>\n",
+       "      <td>(351.069611300124, -4.336293374419411)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847381374341414...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898290</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T00:30:15.537</td>\n",
-       "      <td>(351.0695696451088, -4.336265319377865)</td>\n",
        "      <td>2019-09-27 00:30:15.537</td>\n",
+       "      <td>(351.0695696451088, -4.336265319377865)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
@@ -3169,75 +4044,81 @@
        "      <td>...</td>\n",
        "      <td>...</td>\n",
        "      <td>...</td>\n",
+       "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>90</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847391753851408...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898376</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T04:02:58.424</td>\n",
-       "      <td>(351.06998627728365, -4.3363483733857136)</td>\n",
        "      <td>2019-09-27 04:02:58.424</td>\n",
+       "      <td>(351.06998627728365, -4.3363483733857136)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>91</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847400909178194...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898377</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T04:05:27.654</td>\n",
-       "      <td>(351.0703196106188, -4.336348373356122)</td>\n",
        "      <td>2019-09-27 04:05:27.654</td>\n",
+       "      <td>(351.0703196106188, -4.336348373356122)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>92</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847397935953284...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898378</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T04:07:56.159</td>\n",
-       "      <td>(351.07019878847524, -4.336321429412502)</td>\n",
        "      <td>2019-09-27 04:07:56.159</td>\n",
+       "      <td>(351.07019878847524, -4.336321429412502)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>93</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847392459182945...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898379</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T04:10:25.141</td>\n",
-       "      <td>(351.069986300126, -4.336293374386118)</td>\n",
        "      <td>2019-09-27 04:10:25.141</td>\n",
+       "      <td>(351.069986300126, -4.336293374386118)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>94</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847397036888316...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898380</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T04:12:52.877</td>\n",
-       "      <td>(351.07015296679367, -4.336293374371324)</td>\n",
        "      <td>2019-09-27 04:12:52.877</td>\n",
+       "      <td>(351.07015296679367, -4.336293374371324)</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>95 rows × 7 columns</p>\n",
+       "<p>95 rows × 8 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "                          data_id   \n",
-       "0   (instrument, detector, visit)  \\\n",
-       "1   (instrument, detector, visit)   \n",
-       "2   (instrument, detector, visit)   \n",
-       "3   (instrument, detector, visit)   \n",
-       "4   (instrument, detector, visit)   \n",
-       "..                            ...   \n",
-       "90  (instrument, detector, visit)   \n",
-       "91  (instrument, detector, visit)   \n",
-       "92  (instrument, detector, visit)   \n",
-       "93  (instrument, detector, visit)   \n",
-       "94  (instrument, detector, visit)   \n",
+       "                                              data_id   \n",
+       "0   {'instrument': 'DECam', 'detector': 1, 'visit'...  \\\n",
+       "1   {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "2   {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "3   {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "4   {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "..                                                ...   \n",
+       "90  {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "91  {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "92  {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "93  {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "94  {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
        "\n",
        "                                               region  detector   \n",
        "0   ConvexPolygon([UnitVector3d(0.9847372525065534...         1  \\\n",
@@ -3252,49 +4133,49 @@
        "93  ConvexPolygon([UnitVector3d(0.9847392459182945...         1   \n",
        "94  ConvexPolygon([UnitVector3d(0.9847397036888316...         1   \n",
        "\n",
-       "                                                  uri   \n",
-       "0   file:///epyc/users/smotherh/DEEP/PointingGroup...  \\\n",
-       "1   file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
-       "2   file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
-       "3   file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
-       "4   file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
-       "..                                                ...   \n",
-       "90  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
-       "91  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
-       "92  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
-       "93  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
-       "94  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "       data_id_str                                                uri   \n",
+       "0   DECam_1_898286  file:///epyc/users/smotherh/DEEP/PointingGroup...  \\\n",
+       "1   DECam_1_898287  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "2   DECam_1_898288  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "3   DECam_1_898289  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "4   DECam_1_898290  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "..             ...                                                ...   \n",
+       "90  DECam_1_898376  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "91  DECam_1_898377  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "92  DECam_1_898378  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "93  DECam_1_898379  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "94  DECam_1_898380  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
        "\n",
-       "                         ut                               center_coord   \n",
-       "0   2019-09-27T00:20:22.932    (351.0694028401149, -4.336598368890197)  \\\n",
-       "1   2019-09-27T00:22:51.015    (351.0695696334572, -4.336293374423113)   \n",
-       "2   2019-09-27T00:25:19.136    (351.0696571334576, -4.336293374415341)   \n",
-       "3   2019-09-27T00:27:47.118     (351.069611300124, -4.336293374419411)   \n",
-       "4   2019-09-27T00:30:15.537    (351.0695696451088, -4.336265319377865)   \n",
-       "..                      ...                                        ...   \n",
-       "90  2019-09-27T04:02:58.424  (351.06998627728365, -4.3363483733857136)   \n",
-       "91  2019-09-27T04:05:27.654    (351.0703196106188, -4.336348373356122)   \n",
-       "92  2019-09-27T04:07:56.159   (351.07019878847524, -4.336321429412502)   \n",
-       "93  2019-09-27T04:10:25.141     (351.069986300126, -4.336293374386118)   \n",
-       "94  2019-09-27T04:12:52.877   (351.07015296679367, -4.336293374371324)   \n",
+       "                         ut             ut_datetime   \n",
+       "0   2019-09-27T00:20:22.932 2019-09-27 00:20:22.932  \\\n",
+       "1   2019-09-27T00:22:51.015 2019-09-27 00:22:51.015   \n",
+       "2   2019-09-27T00:25:19.136 2019-09-27 00:25:19.136   \n",
+       "3   2019-09-27T00:27:47.118 2019-09-27 00:27:47.118   \n",
+       "4   2019-09-27T00:30:15.537 2019-09-27 00:30:15.537   \n",
+       "..                      ...                     ...   \n",
+       "90  2019-09-27T04:02:58.424 2019-09-27 04:02:58.424   \n",
+       "91  2019-09-27T04:05:27.654 2019-09-27 04:05:27.654   \n",
+       "92  2019-09-27T04:07:56.159 2019-09-27 04:07:56.159   \n",
+       "93  2019-09-27T04:10:25.141 2019-09-27 04:10:25.141   \n",
+       "94  2019-09-27T04:12:52.877 2019-09-27 04:12:52.877   \n",
        "\n",
-       "               ut_datetime  \n",
-       "0  2019-09-27 00:20:22.932  \n",
-       "1  2019-09-27 00:22:51.015  \n",
-       "2  2019-09-27 00:25:19.136  \n",
-       "3  2019-09-27 00:27:47.118  \n",
-       "4  2019-09-27 00:30:15.537  \n",
-       "..                     ...  \n",
-       "90 2019-09-27 04:02:58.424  \n",
-       "91 2019-09-27 04:05:27.654  \n",
-       "92 2019-09-27 04:07:56.159  \n",
-       "93 2019-09-27 04:10:25.141  \n",
-       "94 2019-09-27 04:12:52.877  \n",
+       "                                 center_coord  \n",
+       "0     (351.0694028401149, -4.336598368890197)  \n",
+       "1     (351.0695696334572, -4.336293374423113)  \n",
+       "2     (351.0696571334576, -4.336293374415341)  \n",
+       "3      (351.069611300124, -4.336293374419411)  \n",
+       "4     (351.0695696451088, -4.336265319377865)  \n",
+       "..                                        ...  \n",
+       "90  (351.06998627728365, -4.3363483733857136)  \n",
+       "91    (351.0703196106188, -4.336348373356122)  \n",
+       "92   (351.07019878847524, -4.336321429412502)  \n",
+       "93     (351.069986300126, -4.336293374386118)  \n",
+       "94   (351.07015296679367, -4.336293374371324)  \n",
        "\n",
-       "[95 rows x 7 columns]"
+       "[95 rows x 8 columns]"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 95,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3310,7 +4191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 96,
    "id": "1874ddaa",
    "metadata": {},
    "outputs": [
@@ -3334,9 +4215,11 @@
     "    alpha=0.5,\n",
     "    label=\"matches\",\n",
     ")\n",
+    "\n",
     "plt.scatter(\n",
     "    searching_ra_dec[0], searching_ra_dec[1], color=\"red\", s=20, alpha=0.5, marker=\"+\", label=\"search center\"\n",
     ")\n",
+    "\n",
     "circle = plt.Circle(\n",
     "    (searching_ra_dec[0], searching_ra_dec[1]),\n",
     "    ra_dec_search_radius.to(u.degree).value,\n",
@@ -3346,12 +4229,15 @@
     "    label=\"search area\",\n",
     "    linestyle=\"--\",\n",
     ")\n",
+    "\n",
     "plt.xlabel(f\"RA\")\n",
     "plt.ylabel(\"Dec\")\n",
     "ax = plt.gca()\n",
     "ax.add_patch(circle)\n",
     "plt.legend()\n",
-    "ax.set_aspect(\"equal\", adjustable=\"box\")"
+    "ax.set_aspect(\"equal\", adjustable=\"box\")\n",
+    "\n",
+    "# TODO consider making this dRA, dDec from minimum (RA, Dec) values 4/23/2024 COC"
    ]
   },
   {
@@ -3366,7 +4252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 97,
    "id": "3db99133",
    "metadata": {},
    "outputs": [
@@ -3387,6 +4273,7 @@
     "plt.scatter(\n",
     "    searching_ra_dec[0], searching_ra_dec[1], color=\"red\", s=20, alpha=0.5, marker=\"+\", label=\"search center\"\n",
     ")\n",
+    "\n",
     "for quad in [getRegionCorners(x) for x in ra_dec_search_results_df[\"region\"]]:\n",
     "    ra_bounds, dec_bounds = getMinMaxRaDec(quad)\n",
     "    #\n",
@@ -3398,6 +4285,7 @@
     "    coords.append((ra_bounds[0], dec_bounds[0]))  # close the \"shape\"\n",
     "    #\n",
     "    plt.plot([x[0] for x in coords], [x[1] for x in coords]),  # label=ra_dec_search_results[i])\n",
+    "\n",
     "circle = plt.Circle(\n",
     "    (searching_ra_dec[0], searching_ra_dec[1]),\n",
     "    ra_dec_search_radius.to(u.degree).value,\n",
@@ -3408,6 +4296,7 @@
     "    linestyle=\"--\",\n",
     "    linewidth=0.1,\n",
     ")\n",
+    "\n",
     "plt.xlabel(f\"RA\")\n",
     "plt.ylabel(\"Dec\")\n",
     "ax = plt.gca()\n",
@@ -3429,7 +4318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 98,
    "id": "fccdee6b",
    "metadata": {},
    "outputs": [],
@@ -3481,7 +4370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 99,
    "id": "cf221f77",
    "metadata": {},
    "outputs": [
@@ -3497,8 +4386,8 @@
       "Overwrite is False, so we will read the timestamps from file now...\n",
       "Recycled 47383 from /astro/users/coc123/kbmod_tmp/vdr_timestamps.lst.\n",
       "Recycling /astro/users/coc123/kbmod_tmp/overlapping_sets.pickle as overwrite=False.\n",
-      "CPU times: user 3.51 s, sys: 263 ms, total: 3.78 s\n",
-      "Wall time: 4.55 s\n"
+      "CPU times: user 4.84 s, sys: 443 ms, total: 5.28 s\n",
+      "Wall time: 6.6 s\n"
      ]
     }
    ],
@@ -3522,7 +4411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 100,
    "id": "45f09318",
    "metadata": {},
    "outputs": [
@@ -3539,7 +4428,7 @@
        "['set_1', 'set_3', 'set_4', 'set_68']"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 100,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3557,7 +4446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 101,
    "id": "8a6c4def",
    "metadata": {},
    "outputs": [
@@ -3592,62 +4481,68 @@
        "      <th>data_id</th>\n",
        "      <th>region</th>\n",
        "      <th>detector</th>\n",
+       "      <th>data_id_str</th>\n",
        "      <th>uri</th>\n",
        "      <th>ut</th>\n",
-       "      <th>center_coord</th>\n",
        "      <th>ut_datetime</th>\n",
+       "      <th>center_coord</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847372525065534...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898286</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T00:20:22.932</td>\n",
-       "      <td>(351.0694028401149, -4.336598368890197)</td>\n",
        "      <td>2019-09-27 00:20:22.932</td>\n",
+       "      <td>(351.0694028401149, -4.336598368890197)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847381014554984...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898287</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T00:22:51.015</td>\n",
-       "      <td>(351.0695696334572, -4.336293374423113)</td>\n",
        "      <td>2019-09-27 00:22:51.015</td>\n",
+       "      <td>(351.0695696334572, -4.336293374423113)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847383417970056...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898288</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T00:25:19.136</td>\n",
-       "      <td>(351.0696571334576, -4.336293374415341)</td>\n",
        "      <td>2019-09-27 00:25:19.136</td>\n",
+       "      <td>(351.0696571334576, -4.336293374415341)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847382159041213...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898289</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T00:27:47.118</td>\n",
-       "      <td>(351.069611300124, -4.336293374419411)</td>\n",
        "      <td>2019-09-27 00:27:47.118</td>\n",
+       "      <td>(351.069611300124, -4.336293374419411)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847381374341414...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898290</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T00:30:15.537</td>\n",
-       "      <td>(351.0695696451088, -4.336265319377865)</td>\n",
        "      <td>2019-09-27 00:30:15.537</td>\n",
+       "      <td>(351.0695696451088, -4.336265319377865)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
@@ -3658,75 +4553,81 @@
        "      <td>...</td>\n",
        "      <td>...</td>\n",
        "      <td>...</td>\n",
+       "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>90</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847391753851408...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898376</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T04:02:58.424</td>\n",
-       "      <td>(351.06998627728365, -4.3363483733857136)</td>\n",
        "      <td>2019-09-27 04:02:58.424</td>\n",
+       "      <td>(351.06998627728365, -4.3363483733857136)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>91</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847400909178194...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898377</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T04:05:27.654</td>\n",
-       "      <td>(351.0703196106188, -4.336348373356122)</td>\n",
        "      <td>2019-09-27 04:05:27.654</td>\n",
+       "      <td>(351.0703196106188, -4.336348373356122)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>92</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847397935953284...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898378</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T04:07:56.159</td>\n",
-       "      <td>(351.07019878847524, -4.336321429412502)</td>\n",
        "      <td>2019-09-27 04:07:56.159</td>\n",
+       "      <td>(351.07019878847524, -4.336321429412502)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>93</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847392459182945...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898379</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T04:10:25.141</td>\n",
-       "      <td>(351.069986300126, -4.336293374386118)</td>\n",
        "      <td>2019-09-27 04:10:25.141</td>\n",
+       "      <td>(351.069986300126, -4.336293374386118)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>94</th>\n",
-       "      <td>(instrument, detector, visit)</td>\n",
+       "      <td>{'instrument': 'DECam', 'detector': 1, 'visit'...</td>\n",
        "      <td>ConvexPolygon([UnitVector3d(0.9847397036888316...</td>\n",
        "      <td>1</td>\n",
+       "      <td>DECam_1_898380</td>\n",
        "      <td>file:///epyc/users/smotherh/DEEP/PointingGroup...</td>\n",
        "      <td>2019-09-27T04:12:52.877</td>\n",
-       "      <td>(351.07015296679367, -4.336293374371324)</td>\n",
        "      <td>2019-09-27 04:12:52.877</td>\n",
+       "      <td>(351.07015296679367, -4.336293374371324)</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>95 rows × 7 columns</p>\n",
+       "<p>95 rows × 8 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "                          data_id   \n",
-       "0   (instrument, detector, visit)  \\\n",
-       "1   (instrument, detector, visit)   \n",
-       "2   (instrument, detector, visit)   \n",
-       "3   (instrument, detector, visit)   \n",
-       "4   (instrument, detector, visit)   \n",
-       "..                            ...   \n",
-       "90  (instrument, detector, visit)   \n",
-       "91  (instrument, detector, visit)   \n",
-       "92  (instrument, detector, visit)   \n",
-       "93  (instrument, detector, visit)   \n",
-       "94  (instrument, detector, visit)   \n",
+       "                                              data_id   \n",
+       "0   {'instrument': 'DECam', 'detector': 1, 'visit'...  \\\n",
+       "1   {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "2   {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "3   {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "4   {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "..                                                ...   \n",
+       "90  {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "91  {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "92  {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "93  {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
+       "94  {'instrument': 'DECam', 'detector': 1, 'visit'...   \n",
        "\n",
        "                                               region  detector   \n",
        "0   ConvexPolygon([UnitVector3d(0.9847372525065534...         1  \\\n",
@@ -3741,49 +4642,49 @@
        "93  ConvexPolygon([UnitVector3d(0.9847392459182945...         1   \n",
        "94  ConvexPolygon([UnitVector3d(0.9847397036888316...         1   \n",
        "\n",
-       "                                                  uri   \n",
-       "0   file:///epyc/users/smotherh/DEEP/PointingGroup...  \\\n",
-       "1   file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
-       "2   file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
-       "3   file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
-       "4   file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
-       "..                                                ...   \n",
-       "90  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
-       "91  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
-       "92  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
-       "93  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
-       "94  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "       data_id_str                                                uri   \n",
+       "0   DECam_1_898286  file:///epyc/users/smotherh/DEEP/PointingGroup...  \\\n",
+       "1   DECam_1_898287  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "2   DECam_1_898288  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "3   DECam_1_898289  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "4   DECam_1_898290  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "..             ...                                                ...   \n",
+       "90  DECam_1_898376  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "91  DECam_1_898377  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "92  DECam_1_898378  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "93  DECam_1_898379  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
+       "94  DECam_1_898380  file:///epyc/users/smotherh/DEEP/PointingGroup...   \n",
        "\n",
-       "                         ut                               center_coord   \n",
-       "0   2019-09-27T00:20:22.932    (351.0694028401149, -4.336598368890197)  \\\n",
-       "1   2019-09-27T00:22:51.015    (351.0695696334572, -4.336293374423113)   \n",
-       "2   2019-09-27T00:25:19.136    (351.0696571334576, -4.336293374415341)   \n",
-       "3   2019-09-27T00:27:47.118     (351.069611300124, -4.336293374419411)   \n",
-       "4   2019-09-27T00:30:15.537    (351.0695696451088, -4.336265319377865)   \n",
-       "..                      ...                                        ...   \n",
-       "90  2019-09-27T04:02:58.424  (351.06998627728365, -4.3363483733857136)   \n",
-       "91  2019-09-27T04:05:27.654    (351.0703196106188, -4.336348373356122)   \n",
-       "92  2019-09-27T04:07:56.159   (351.07019878847524, -4.336321429412502)   \n",
-       "93  2019-09-27T04:10:25.141     (351.069986300126, -4.336293374386118)   \n",
-       "94  2019-09-27T04:12:52.877   (351.07015296679367, -4.336293374371324)   \n",
+       "                         ut             ut_datetime   \n",
+       "0   2019-09-27T00:20:22.932 2019-09-27 00:20:22.932  \\\n",
+       "1   2019-09-27T00:22:51.015 2019-09-27 00:22:51.015   \n",
+       "2   2019-09-27T00:25:19.136 2019-09-27 00:25:19.136   \n",
+       "3   2019-09-27T00:27:47.118 2019-09-27 00:27:47.118   \n",
+       "4   2019-09-27T00:30:15.537 2019-09-27 00:30:15.537   \n",
+       "..                      ...                     ...   \n",
+       "90  2019-09-27T04:02:58.424 2019-09-27 04:02:58.424   \n",
+       "91  2019-09-27T04:05:27.654 2019-09-27 04:05:27.654   \n",
+       "92  2019-09-27T04:07:56.159 2019-09-27 04:07:56.159   \n",
+       "93  2019-09-27T04:10:25.141 2019-09-27 04:10:25.141   \n",
+       "94  2019-09-27T04:12:52.877 2019-09-27 04:12:52.877   \n",
        "\n",
-       "               ut_datetime  \n",
-       "0  2019-09-27 00:20:22.932  \n",
-       "1  2019-09-27 00:22:51.015  \n",
-       "2  2019-09-27 00:25:19.136  \n",
-       "3  2019-09-27 00:27:47.118  \n",
-       "4  2019-09-27 00:30:15.537  \n",
-       "..                     ...  \n",
-       "90 2019-09-27 04:02:58.424  \n",
-       "91 2019-09-27 04:05:27.654  \n",
-       "92 2019-09-27 04:07:56.159  \n",
-       "93 2019-09-27 04:10:25.141  \n",
-       "94 2019-09-27 04:12:52.877  \n",
+       "                                 center_coord  \n",
+       "0     (351.0694028401149, -4.336598368890197)  \n",
+       "1     (351.0695696334572, -4.336293374423113)  \n",
+       "2     (351.0696571334576, -4.336293374415341)  \n",
+       "3      (351.069611300124, -4.336293374419411)  \n",
+       "4     (351.0695696451088, -4.336265319377865)  \n",
+       "..                                        ...  \n",
+       "90  (351.06998627728365, -4.3363483733857136)  \n",
+       "91    (351.0703196106188, -4.336348373356122)  \n",
+       "92   (351.07019878847524, -4.336321429412502)  \n",
+       "93     (351.069986300126, -4.336293374386118)  \n",
+       "94   (351.07015296679367, -4.336293374371324)  \n",
        "\n",
-       "[95 rows x 7 columns]"
+       "[95 rows x 8 columns]"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 101,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3812,7 +4713,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 102,
    "id": "49bc209f",
    "metadata": {},
    "outputs": [],
@@ -3918,7 +4819,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 103,
    "id": "fd12f4a3",
    "metadata": {},
    "outputs": [
@@ -3943,7 +4844,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 104,
    "id": "6004da63",
    "metadata": {},
    "outputs": [
@@ -3963,7 +4864,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 105,
    "id": "0dc3d71d",
    "metadata": {},
    "outputs": [
@@ -3984,7 +4885,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 106,
    "id": "c3f1fd78",
    "metadata": {},
    "outputs": [
@@ -4001,7 +4902,7 @@
        "1440"
       ]
      },
-     "execution_count": 117,
+     "execution_count": 106,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4016,7 +4917,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 107,
    "id": "d018cb09",
    "metadata": {},
    "outputs": [],
@@ -4042,7 +4943,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": 108,
    "id": "db66acde",
    "metadata": {},
    "outputs": [],
@@ -4119,7 +5020,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 109,
    "id": "6e70866c",
    "metadata": {},
    "outputs": [
@@ -4247,8 +5148,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.88 s, sys: 1.47 s, total: 3.35 s\n",
-      "Wall time: 1.73 s\n"
+      "CPU times: user 1.9 s, sys: 1.4 s, total: 3.3 s\n",
+      "Wall time: 1.68 s\n"
      ]
     }
    ],
@@ -4285,7 +5186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": 110,
    "id": "5f4490c1",
    "metadata": {},
    "outputs": [],
@@ -4323,7 +5224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": 111,
    "id": "0a0e7f55",
    "metadata": {},
    "outputs": [],
@@ -4345,7 +5246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 141,
+   "execution_count": 112,
    "id": "e2f4536b",
    "metadata": {},
    "outputs": [],
@@ -4375,7 +5276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": 113,
    "id": "122c1379",
    "metadata": {},
    "outputs": [
@@ -4383,19 +5284,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "[0.7853981633974483, 0.7853981633974483]\n",
       "WARNING: Dec > 90° (91°) so subtracting 180°.\n",
-      "WARNING: RA > 360° (361°) so subtracting 360°.\n"
+      "WARNING: RA > 360° (361°) so subtracting 360°.\n",
+      "[0.017453292519943295, -1.5533430342749532]\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "LonLat.fromRadians(0.017453292519943295, -1.5533430342749532)"
-      ]
-     },
-     "execution_count": 135,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -4406,7 +5299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 142,
+   "execution_count": 114,
    "id": "6e03ae98",
    "metadata": {},
    "outputs": [],
@@ -4471,7 +5364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 143,
+   "execution_count": 115,
    "id": "4b8e1b38",
    "metadata": {},
    "outputs": [
@@ -4481,8 +5374,8 @@
      "text": [
       "Number of patches in (RA, Dec): (150,75).\n",
       "There were 11250 produced, skipping 0 because Dec was outside [-90, 90]. Info: {'npatches': 11250, 'arcminutes': [180, 180], 'overlap': 20}.\n",
-      "CPU times: user 367 ms, sys: 9.06 ms, total: 376 ms\n",
-      "Wall time: 372 ms\n"
+      "CPU times: user 320 ms, sys: 15.5 ms, total: 335 ms\n",
+      "Wall time: 334 ms\n"
      ]
     }
    ],
@@ -4500,7 +5393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 149,
+   "execution_count": 116,
    "id": "7d297ec8",
    "metadata": {},
    "outputs": [
@@ -4510,7 +5403,7 @@
        "Box(NormalizedAngleInterval.fromRadians(0.0, 0.05235987755982989), AngleInterval.fromRadians(-1.5707963267948966, -1.5184364492350666))"
       ]
      },
-     "execution_count": 149,
+     "execution_count": 116,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4522,7 +5415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 147,
+   "execution_count": 117,
    "id": "31068315",
    "metadata": {},
    "outputs": [
@@ -4532,7 +5425,7 @@
        "b'b\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xd6\\xeb{\\xf3\\xe9\\xce\\xaa?\\x18-DT\\xfb!\\xf9\\xbf\\xb9M\\xa8\\x04\\x84K\\xf8\\xbf'"
       ]
      },
-     "execution_count": 147,
+     "execution_count": 117,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4545,7 +5438,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 150,
+   "execution_count": 118,
    "id": "70fb95ef",
    "metadata": {},
    "outputs": [
@@ -4555,7 +5448,7 @@
        "Box(NormalizedAngleInterval.fromRadians(0.0, 0.05235987755982989), AngleInterval.fromRadians(-1.5707963267948966, -1.5184364492350666))"
       ]
      },
-     "execution_count": 150,
+     "execution_count": 118,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4576,7 +5469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
+   "execution_count": 119,
    "id": "9431fdb1",
    "metadata": {},
    "outputs": [
@@ -4593,7 +5486,7 @@
        "visit_detector_region.RecordClass(instrument='DECam', detector=62, visit=946176, region=ConvexPolygon([UnitVector3d(0.9876086828694174, -0.13336028508776862, -0.08272922024438323), UnitVector3d(0.9873378171284917, -0.13332652431396907, -0.08595389916869185), UnitVector3d(0.9881047366097594, -0.12752395595185462, -0.08594573955553172), UnitVector3d(0.9883760335240734, -0.12755303452468866, -0.0827226676235914)]))"
       ]
      },
-     "execution_count": 152,
+     "execution_count": 119,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4605,7 +5498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 153,
+   "execution_count": 120,
    "id": "8f92b9b3",
    "metadata": {},
    "outputs": [],
@@ -4617,7 +5510,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 157,
+   "execution_count": 121,
    "id": "5976ab67",
    "metadata": {},
    "outputs": [
@@ -4638,7 +5531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 164,
+   "execution_count": 122,
    "id": "06edb382",
    "metadata": {},
    "outputs": [
@@ -4646,9 +5539,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Checking matches of reg1 against all records region for matchces...\n",
-      "There were 1 matches:\n",
-      "{instrument: 'DECam', detector: 1, visit: 898286}\n"
+      "Checking overlap matches of reg1 against all records region for matchces...\n",
+      "There were 1 overlap matches:\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898286}\n"
      ]
     }
    ],
@@ -4668,7 +5561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 167,
+   "execution_count": 123,
    "id": "1f8a61e0",
    "metadata": {},
    "outputs": [
@@ -4678,353 +5571,353 @@
      "text": [
       "Checking intersect matches of reg1 against all records region for matchces...\n",
       "There were 347 intersection matches:\n",
-      "{instrument: 'DECam', detector: 1, visit: 898286}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898287}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898288}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898289}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898290}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898291}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898292}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898293}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898294}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898295}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898296}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898297}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898298}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898299}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898300}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898301}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898302}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898303}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898304}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898305}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898306}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898307}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898308}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898309}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898310}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898311}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898312}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898313}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898314}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898315}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898316}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898317}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898318}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898319}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898320}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898321}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898322}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898323}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898324}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898325}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898326}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898327}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898328}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898329}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898330}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898331}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898332}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898333}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898334}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898335}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898336}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898337}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898338}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898339}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898340}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898341}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898342}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898343}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898344}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898345}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898346}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898347}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898348}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898349}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898350}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898351}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898352}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898353}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898354}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898355}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898356}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898357}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898358}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898359}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898360}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898361}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898362}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898363}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898364}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898365}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898366}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898367}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898368}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898369}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898370}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898371}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898372}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898373}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898374}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898375}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898376}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898377}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898378}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898379}\n",
-      "{instrument: 'DECam', detector: 1, visit: 898380}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891455}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891456}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891457}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891458}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891459}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891460}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891461}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891462}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891463}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891464}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891465}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891466}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891467}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891468}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891469}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891470}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891471}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891472}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891473}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891474}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891475}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891476}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891477}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891478}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891479}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891480}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891481}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891482}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891483}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891484}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891485}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891486}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891487}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891488}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891489}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891490}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891491}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891492}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891493}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891494}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891495}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891496}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891497}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891498}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891499}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891500}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891501}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891502}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891503}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891504}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891505}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891506}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891507}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891508}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891509}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891510}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891511}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891512}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891513}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891514}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891515}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891516}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891517}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891518}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891519}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891520}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891521}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891522}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891523}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891524}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891525}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891526}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891527}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891528}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891529}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891530}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891531}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891532}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891533}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891534}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891535}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891536}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891537}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891538}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891539}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891540}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891541}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891542}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891543}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891544}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891545}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891546}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891547}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891548}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891549}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891550}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891551}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891552}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891553}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891554}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891555}\n",
-      "{instrument: 'DECam', detector: 8, visit: 891556}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946689}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946690}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946691}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946692}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946693}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946694}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946695}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946696}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946697}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946698}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946699}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946700}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946701}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946702}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946703}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946704}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946705}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946706}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946707}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946708}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946709}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946710}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946711}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946712}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946713}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946714}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946715}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946716}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946717}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946718}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946719}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946720}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946721}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946722}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946723}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946724}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946725}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946726}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946727}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946728}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946729}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946730}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946731}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946732}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946733}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946734}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946735}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946736}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946737}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946738}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946739}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946740}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946741}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946742}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946743}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946744}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946745}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946746}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946747}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946748}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946749}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946750}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946751}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946752}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946753}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946754}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946755}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946756}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946757}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946758}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946759}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946760}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946761}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946762}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946763}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946764}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946765}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946766}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946767}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946768}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946769}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946770}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946771}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946772}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946773}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946774}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946775}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946776}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946777}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946778}\n",
-      "{instrument: 'DECam', detector: 1, visit: 946779}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946081}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946082}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946083}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946084}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946085}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946086}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946087}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946088}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946089}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946090}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946091}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946092}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946093}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946094}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946095}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946096}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946098}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946099}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946102}\n",
-      "{instrument: 'DECam', detector: 39, visit: 946103}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946081}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946082}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946083}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946084}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946085}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946086}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946087}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946088}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946089}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946090}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946091}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946092}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946093}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946094}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946095}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946096}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946097}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946098}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946099}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946100}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946101}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946102}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946103}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946104}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946105}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946106}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946107}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946108}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946109}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946110}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946112}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946113}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946114}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946115}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946116}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946117}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946118}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946121}\n",
-      "{instrument: 'DECam', detector: 45, visit: 946122}\n"
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898286}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898287}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898288}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898289}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898290}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898291}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898292}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898293}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898294}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898295}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898296}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898297}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898298}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898299}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898300}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898301}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898302}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898303}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898304}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898305}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898306}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898307}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898308}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898309}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898310}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898311}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898312}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898313}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898314}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898315}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898316}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898317}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898318}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898319}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898320}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898321}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898322}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898323}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898324}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898325}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898326}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898327}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898328}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898329}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898330}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898331}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898332}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898333}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898334}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898335}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898336}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898337}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898338}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898339}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898340}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898341}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898342}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898343}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898344}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898345}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898346}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898347}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898348}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898349}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898350}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898351}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898352}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898353}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898354}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898355}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898356}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898357}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898358}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898359}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898360}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898361}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898362}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898363}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898364}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898365}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898366}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898367}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898368}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898369}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898370}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898371}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898372}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898373}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898374}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898375}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898376}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898377}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898378}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898379}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 898380}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891455}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891456}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891457}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891458}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891459}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891460}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891461}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891462}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891463}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891464}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891465}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891466}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891467}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891468}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891469}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891470}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891471}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891472}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891473}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891474}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891475}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891476}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891477}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891478}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891479}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891480}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891481}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891482}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891483}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891484}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891485}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891486}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891487}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891488}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891489}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891490}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891491}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891492}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891493}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891494}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891495}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891496}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891497}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891498}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891499}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891500}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891501}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891502}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891503}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891504}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891505}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891506}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891507}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891508}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891509}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891510}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891511}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891512}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891513}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891514}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891515}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891516}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891517}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891518}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891519}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891520}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891521}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891522}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891523}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891524}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891525}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891526}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891527}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891528}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891529}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891530}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891531}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891532}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891533}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891534}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891535}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891536}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891537}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891538}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891539}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891540}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891541}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891542}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891543}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891544}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891545}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891546}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891547}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891548}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891549}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891550}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891551}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891552}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891553}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891554}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891555}\n",
+      "{'instrument': 'DECam', 'detector': 8, 'visit': 891556}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946689}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946690}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946691}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946692}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946693}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946694}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946695}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946696}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946697}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946698}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946699}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946700}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946701}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946702}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946703}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946704}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946705}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946706}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946707}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946708}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946709}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946710}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946711}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946712}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946713}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946714}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946715}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946716}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946717}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946718}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946719}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946720}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946721}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946722}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946723}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946724}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946725}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946726}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946727}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946728}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946729}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946730}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946731}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946732}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946733}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946734}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946735}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946736}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946737}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946738}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946739}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946740}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946741}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946742}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946743}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946744}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946745}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946746}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946747}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946748}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946749}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946750}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946751}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946752}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946753}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946754}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946755}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946756}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946757}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946758}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946759}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946760}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946761}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946762}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946763}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946764}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946765}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946766}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946767}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946768}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946769}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946770}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946771}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946772}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946773}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946774}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946775}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946776}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946777}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946778}\n",
+      "{'instrument': 'DECam', 'detector': 1, 'visit': 946779}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946081}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946082}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946083}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946084}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946085}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946086}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946087}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946088}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946089}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946090}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946091}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946092}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946093}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946094}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946095}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946096}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946098}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946099}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946102}\n",
+      "{'instrument': 'DECam', 'detector': 39, 'visit': 946103}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946081}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946082}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946083}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946084}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946085}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946086}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946087}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946088}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946089}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946090}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946091}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946092}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946093}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946094}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946095}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946096}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946097}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946098}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946099}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946100}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946101}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946102}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946103}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946104}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946105}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946106}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946107}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946108}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946109}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946110}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946112}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946113}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946114}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946115}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946116}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946117}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946118}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946121}\n",
+      "{'instrument': 'DECam', 'detector': 45, 'visit': 946122}\n"
      ]
     }
    ],
@@ -5043,7 +5936,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 175,
+   "execution_count": 124,
    "id": "aa1e3080",
    "metadata": {},
    "outputs": [
@@ -5078,7 +5971,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": 125,
    "id": "2d4bde26",
    "metadata": {},
    "outputs": [
@@ -5088,8 +5981,8 @@
      "text": [
       "Number of patches in (RA, Dec): (1542,771).\n",
       "There were 55512 produced, skipping 1133370 because Dec was outside [-8.906214566625444, -0.21924681597307893]. Info: {'npatches': 55512, 'arcminutes': [14, 14], 'overlap': 0}.\n",
-      "CPU times: user 5.98 s, sys: 48.1 ms, total: 6.03 s\n",
-      "Wall time: 6.03 s\n"
+      "CPU times: user 6.48 s, sys: 70.5 ms, total: 6.55 s\n",
+      "Wall time: 6.56 s\n"
      ]
     }
    ],
@@ -5113,7 +6006,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 189,
+   "execution_count": 126,
    "id": "7ecd13b5",
    "metadata": {},
    "outputs": [],
@@ -5156,7 +6049,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 190,
+   "execution_count": 127,
    "id": "94956cb8",
    "metadata": {},
    "outputs": [],
@@ -5195,7 +6088,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 192,
+   "execution_count": 128,
    "id": "f8955306",
    "metadata": {},
    "outputs": [
@@ -5204,9 +6097,9 @@
      "output_type": "stream",
      "text": [
       "Starting region matching. Lens: region1 = 55512, region2 = 47383\n",
-      "There were 55512 matches in 192160 matches attempted. [Elapsed time: 105.122 s]\n",
-      "CPU times: user 58.4 s, sys: 7.59 s, total: 1min 6s\n",
-      "Wall time: 1min 45s\n"
+      "There were 192160 matches in the 2630325096 matches executed. [Elapsed time: 97.388 s]\n",
+      "CPU times: user 52.8 s, sys: 11.8 s, total: 1min 4s\n",
+      "Wall time: 1min 37s\n"
      ]
     }
    ],
@@ -5218,7 +6111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 207,
+   "execution_count": 129,
    "id": "809add85",
    "metadata": {},
    "outputs": [
@@ -5226,8 +6119,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 31.4 ms, sys: 2.97 ms, total: 34.4 ms\n",
-      "Wall time: 32.4 ms\n"
+      "CPU times: user 12.7 ms, sys: 4.38 ms, total: 17.1 ms\n",
+      "Wall time: 15.9 ms\n"
      ]
     }
    ],
@@ -5244,7 +6137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 232,
+   "execution_count": 130,
    "id": "36b31a6e",
    "metadata": {},
    "outputs": [
@@ -5254,7 +6147,7 @@
        "264"
       ]
      },
-     "execution_count": 232,
+     "execution_count": 130,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5266,7 +6159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 233,
+   "execution_count": 131,
    "id": "4d2452f1",
    "metadata": {},
    "outputs": [
@@ -5274,8 +6167,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_70035/2951881342.py:33: MatplotlibDeprecationWarning: Unable to determine Axes to steal space for Colorbar. Using gca(), but will raise in the future. Either provide the *cax* argument to use as the Axes for the Colorbar, provide the *ax* argument to steal space from it, or add *mappable* to an Axes.\n",
-      "  plt.colorbar(sm, label='Matching Images')\n"
+      "/tmp/ipykernel_45553/2117250381.py:37: MatplotlibDeprecationWarning: Unable to determine Axes to steal space for Colorbar. Using gca(), but will raise in the future. Either provide the *cax* argument to use as the Axes for the Colorbar, provide the *ax* argument to steal space from it, or add *mappable* to an Axes.\n",
+      "  plt.colorbar(sm, label=\"Matching Images\")\n"
      ]
     },
     {
@@ -5364,7 +6257,15 @@
     "- options to restrict date range\n",
     "- options to restrict time delta\n",
     "- visualize time information\n",
-    "5. Reflex correction."
+    "5. Reflex correction.\n",
+    "6. Deduplicate based on URI? 2/26/2024 COC/WB (or maybe UT + RA + Dec)\n",
+    "7. DP 0.2 testing\n",
+    "- RA, Dec search\n",
+    "- Pulling out all of our metadata\n",
+    "8. Storing results\n",
+    "- what other metadata do we need\n",
+    "9. Region-region intersection function\n",
+    "10. Tracts-and-patches approach"
    ]
   },
   {


### PR DESCRIPTION
The previous dataframe was not portable (i.e., would not open without the Stack/Butler, repo all loaded). Changing the primary dataId column to be the simpler dicts, and a new dataId_str column that has a simplified string for the purpose of lookups. Adjusted code throughout the notebook to accommodate these changes.

Other fixes/improvements:
- Duplicate checking function now raises instead of asserting.
- New clean dataId function that takes various forms of a dataId (e.g., Butler object, tuple, dict) and uniformly returns a properly formatted dictionary.
- New dataId_to_dataIdStr() function for the new hashable dataframe column
- removed hard-coded "calexp" requirements, now either user-supplied or (default) uses the first of the desired_datasetTypes list.
- unified lookup tables (removed duplicate generation)
- other minor fixes