### PR TITLE
change ImageStack.get_obstime to return a double instead of a float

### DIFF
--- a/src/kbmod/search/image_stack.cpp
+++ b/src/kbmod/search/image_stack.cpp
@@ -9,7 +9,7 @@ LayeredImage& ImageStack::get_single_image(int index) {
     return images[index];
 }
 
-float ImageStack::get_obstime(int index) const {
+double ImageStack::get_obstime(int index) const {
     if (index < 0 || index > images.size()) throw std::out_of_range("ImageStack index out of bounds.");
     return images[index].get_obstime();
 }

--- a/src/kbmod/search/image_stack.h
+++ b/src/kbmod/search/image_stack.h
@@ -25,7 +25,7 @@ public:
     LayeredImage& get_single_image(int index);
 
     // Functions for getting times.
-    float get_obstime(int index) const;
+    double get_obstime(int index) const;
     float get_zeroed_time(int index) const;
     std::vector<float> build_zeroed_times() const;  // Linear cost.
 


### PR DESCRIPTION
resolves #568 

- Makes `ImageStack.get_obstime` return a double instead of a float, which is more consistent with how it's stored in `LayeredImage` and `RawImage`, and maintains our the floating point precision.

question for @jeremykubica : from poking around in the code, it seems like we only ever load the zeroed times onto the GPU ([here](https://github.com/dirac-institute/kbmod/blob/main/src/kbmod/search/psi_phi_array.cpp#L345-L349), which will just to be cast to a float in `ImageStack.get_zeroed_time` now) and `get_obstime` is mainly for surfacing the obstime to the python layer, so I think just removing the cast to a float shouldn't affect the memory profile of anything on GPU, but if there's anything other places you can think of that would need to be changed please lmk!!

## manually testing
the original MJDs from my `ImageCollection`:
```
&lt;Column name='mjd' dtype='float64' length=9&gt;

58685.48486111111
58685.97231481481
59450.86976851852
59450.87011574074
59450.87019675926
59450.872662037036
59450.875023148146
59450.87509259259
59451.35030092593
```
what they were after float casting:
```
[58685.484375,
 58685.97265625,
 59450.87109375,
 59450.87109375,
 59450.87109375,
 59450.87109375,
 59450.875,
 59450.875,
 59451.3515625]
```
what they are now after removing the casting:
```
[58685.48486111111,
 58685.97231481481,
 59450.86976851852,
 59450.87011574074,
 59450.87019675926,
 59450.872662037036,
 59450.875023148146,
 59450.87509259259,
 59451.35030092593]
```

:bowtie: 
