### PR TITLE
Change time precision to double throughout code

### DIFF
--- a/src/kbmod/search/common.h
+++ b/src/kbmod/search/common.h
@@ -55,15 +55,15 @@ struct Trajectory {
 
     // Get pixel positions from a zero-shifted time. Centered indicates whether
     // the prediction starts from the center of the pixel (which it does in the search)
-    inline float get_x_pos(float time, bool centered = true) const {
+    inline float get_x_pos(double time, bool centered = true) const {
         return centered ? (x + time * vx + 0.5f) : (x + time * vx);
     }
-    inline float get_y_pos(float time, bool centered = true) const {
+    inline float get_y_pos(double time, bool centered = true) const {
         return centered ? (y + time * vy + 0.5f) : (y + time * vy);
     }
 
-    inline int get_x_index(float time) const { return (int)floor(get_x_pos(time, true)); }
-    inline int get_y_index(float time) const { return (int)floor(get_y_pos(time, true)); }
+    inline int get_x_index(double time) const { return (int)floor(get_x_pos(time, true)); }
+    inline int get_y_index(double time) const { return (int)floor(get_y_pos(time, true)); }
 
     // A helper function to test if two trajectories are close in pixel space.
     bool is_close(Trajectory &trj_b, float pos_thresh, float vel_thresh) {
@@ -76,12 +76,12 @@ struct Trajectory {
                " y: " + std::to_string(y) + " vx: " + std::to_string(vx) + " vy: " + std::to_string(vy) +
                " obs_count: " + std::to_string(obs_count) + " valid: " + std::to_string(valid);
     }
-    
+
     // This is a hack to provide a constructor with non-default arguments in Python. If we include
     // the constructor as a method in the Trajectory struct CUDA will complain when creating new objects
     // because it cannot call out to a host function.
-    static Trajectory make_trajectory(int x, int y, float vx, float vy, float flux, float lh,
-                                      int obs_count, bool valid) {
+    static Trajectory make_trajectory(int x, int y, float vx, float vy, float flux, float lh, int obs_count,
+                                      bool valid) {
         Trajectory trj;
         trj.x = x;
         trj.y = y;
@@ -192,9 +192,8 @@ static void trajectory_bindings(py::module &m) {
     using tj = Trajectory;
 
     py::class_<tj>(m, "Trajectory", pydocs::DOC_Trajectory)
-            .def(py::init(&tj::make_trajectory),
-                 py::arg("x") = 0, py::arg("y") = 0, py::arg("vx") = 0.0f, py::arg("vy") = 0.0f,
-                 py::arg("flux") = 0.0f, py::arg("lh") = 0.0f, py::arg("obs_count") = 0,
+            .def(py::init(&tj::make_trajectory), py::arg("x") = 0, py::arg("y") = 0, py::arg("vx") = 0.0f,
+                 py::arg("vy") = 0.0f, py::arg("flux") = 0.0f, py::arg("lh") = 0.0f, py::arg("obs_count") = 0,
                  py::arg("valid") = true)
             .def_readwrite("vx", &tj::vx)
             .def_readwrite("vy", &tj::vy)

--- a/src/kbmod/search/image_stack.cpp
+++ b/src/kbmod/search/image_stack.cpp
@@ -14,13 +14,13 @@ double ImageStack::get_obstime(int index) const {
     return images[index].get_obstime();
 }
 
-float ImageStack::get_zeroed_time(int index) const {
+double ImageStack::get_zeroed_time(int index) const {
     if (index < 0 || index > images.size()) throw std::out_of_range("ImageStack index out of bounds.");
     return images[index].get_obstime() - images[0].get_obstime();
 }
 
-std::vector<float> ImageStack::build_zeroed_times() const {
-    std::vector<float> zeroed_times = std::vector<float>();
+std::vector<double> ImageStack::build_zeroed_times() const {
+    std::vector<double> zeroed_times = std::vector<double>();
     if (images.size() > 0) {
         double t0 = images[0].get_obstime();
         for (auto& i : images) {

--- a/src/kbmod/search/image_stack.h
+++ b/src/kbmod/search/image_stack.h
@@ -26,8 +26,8 @@ public:
 
     // Functions for getting times.
     double get_obstime(int index) const;
-    float get_zeroed_time(int index) const;
-    std::vector<float> build_zeroed_times() const;  // Linear cost.
+    double get_zeroed_time(int index) const;
+    std::vector<double> build_zeroed_times() const;  // Linear cost.
 
     void convolve_psf();
 

--- a/src/kbmod/search/kernels/kernel_memory.cu
+++ b/src/kbmod/search/kernels/kernel_memory.cu
@@ -13,8 +13,6 @@
 
 #include "cuda_errors.h"
 
-#include "../trajectory_list.h"
-
 namespace search {
 
 // ---------------------------------------

--- a/src/kbmod/search/psi_phi_array.cpp
+++ b/src/kbmod/search/psi_phi_array.cpp
@@ -85,7 +85,7 @@ void PsiPhiArray::move_to_gpu(bool debug) {
     // Create a copy of the encoded data in GPU memory.
     if (debug) {
         printf("Allocating GPU memory for PsiPhi array using %lu bytes.\n", get_total_array_size());
-        printf("Allocating GPU memory for times array using %lu bytes.\n", get_num_times() * sizeof(float));
+        printf("Allocating GPU memory for times array using %lu bytes.\n", get_num_times() * sizeof(double));
     }
 
     // Copy the Psi/Phi data
@@ -148,7 +148,7 @@ void PsiPhiArray::set_phi_scaling(float min_val, float max_val, float scale_val)
     meta_data.phi_scale = scale_val;
 }
 
-void PsiPhiArray::set_time_array(const std::vector<float>& times) { cpu_time_array = times; }
+void PsiPhiArray::set_time_array(const std::vector<double>& times) { cpu_time_array = times; }
 
 PsiPhi PsiPhiArray::read_psi_phi(int time, int row, int col) {
     PsiPhi result = {NO_DATA, NO_DATA};
@@ -184,7 +184,7 @@ PsiPhi PsiPhiArray::read_psi_phi(int time, int row, int col) {
     return result;
 }
 
-float PsiPhiArray::read_time(int time_index) {
+double PsiPhiArray::read_time(int time_index) {
     if ((time_index < 0) || (time_index >= meta_data.num_times)) {
         throw std::runtime_error("Out of bounds read for time step.");
     }
@@ -293,7 +293,7 @@ void set_float_cpu_psi_phi_array(PsiPhiArray& data, const std::vector<RawImage>&
 }
 
 void fill_psi_phi_array(PsiPhiArray& result_data, int num_bytes, const std::vector<RawImage>& psi_imgs,
-                        const std::vector<RawImage>& phi_imgs, const std::vector<float> zeroed_times,
+                        const std::vector<RawImage>& phi_imgs, const std::vector<double> zeroed_times,
                         bool debug) {
     if (result_data.get_cpu_array_ptr() != nullptr) {
         return;
@@ -343,7 +343,7 @@ void fill_psi_phi_array(PsiPhiArray& result_data, int num_bytes, const std::vect
 
     // Copy the time array.
     if (debug) {
-        const long unsigned times_bytes = result_data.get_num_times() * sizeof(float);
+        const long unsigned times_bytes = result_data.get_num_times() * sizeof(double);
         printf("Allocating %lu bytes on the CPU for times.\n", times_bytes);
     }
     result_data.set_time_array(zeroed_times);
@@ -371,7 +371,7 @@ void fill_psi_phi_array_from_image_stack(PsiPhiArray& result_data, ImageStack& s
 
     // Convert these into an array form. Needs the full psi and phi computed first so the
     // encoding can compute the bounds of each array.
-    std::vector<float> zeroed_times = stack.build_zeroed_times();
+    std::vector<double> zeroed_times = stack.build_zeroed_times();
     fill_psi_phi_array(result_data, num_bytes, psi_images, phi_images, zeroed_times, debug);
 }
 

--- a/src/kbmod/search/psi_phi_array_ds.h
+++ b/src/kbmod/search/psi_phi_array_ds.h
@@ -103,13 +103,13 @@ public:
 
     // Primary getter functions for interaction (read the data).
     PsiPhi read_psi_phi(int time_index, int row, int col);
-    float read_time(int time_index);
+    double read_time(int time_index);
 
     // Setters for the utility functions to allocate the data.
     void set_meta_data(int new_num_bytes, int new_num_times, int new_height, int new_width);
     void set_psi_scaling(float min_val, float max_val, float scale_val);
     void set_phi_scaling(float min_val, float max_val, float scale_val);
-    void set_time_array(const std::vector<float>& times);
+    void set_time_array(const std::vector<double>& times);
 
     // Functions for loading / unloading data onto GPU.
     void move_to_gpu(bool debug = false);
@@ -120,8 +120,8 @@ public:
     inline void* get_gpu_array_ptr() { return gpu_array_ptr; }
     inline void set_cpu_array_ptr(void* new_ptr) { cpu_array_ptr = new_ptr; }
 
-    inline float* get_cpu_time_array_ptr() { return cpu_time_array.data(); }
-    inline float* get_gpu_time_array_ptr() { return gpu_time_array.get_ptr(); }
+    inline double* get_cpu_time_array_ptr() { return cpu_time_array.data(); }
+    inline double* get_gpu_time_array_ptr() { return gpu_time_array.get_ptr(); }
 
 private:
     PsiPhiArrayMeta meta_data;
@@ -130,8 +130,8 @@ private:
     // Pointers to the arrays
     void* cpu_array_ptr = nullptr;
     void* gpu_array_ptr = nullptr;
-    std::vector<float> cpu_time_array;
-    GPUArray<float> gpu_time_array;
+    std::vector<double> cpu_time_array;
+    GPUArray<double> gpu_time_array;
 };
 
 } /* namespace search */

--- a/src/kbmod/search/psi_phi_array_utils.h
+++ b/src/kbmod/search/psi_phi_array_utils.h
@@ -28,7 +28,7 @@ namespace search {
 std::array<float, 3> compute_scale_params_from_image_vect(const std::vector<RawImage>& imgs, int num_bytes);
 
 void fill_psi_phi_array(PsiPhiArray& result_data, int num_bytes, const std::vector<RawImage>& psi_imgs,
-                        const std::vector<RawImage>& phi_imgs, const std::vector<float> zeroed_times,
+                        const std::vector<RawImage>& phi_imgs, const std::vector<double> zeroed_times,
                         bool debug = false);
 
 void fill_psi_phi_array_from_image_stack(PsiPhiArray& result_data, ImageStack& stack, int num_bytes,

--- a/src/kbmod/search/stamp_creator.cpp
+++ b/src/kbmod/search/stamp_creator.cpp
@@ -3,7 +3,7 @@
 namespace search {
 #ifdef HAVE_CUDA
 void deviceGetCoadds(const unsigned int num_images, const unsigned int width, const unsigned int height,
-                     std::vector<float*> data_refs, std::vector<float>& image_times,
+                     std::vector<float*> data_refs, std::vector<double>& image_times,
                      std::vector<Trajectory>& trajectories, StampParameters params,
                      std::vector<std::vector<bool>>& use_index_vect, float* results);
 #endif
@@ -22,7 +22,7 @@ std::vector<RawImage> StampCreator::create_stamps(ImageStack& stack, const Traje
     for (int i = 0; i < num_times; ++i) {
         if (use_all_stamps || use_index[i]) {
             // Calculate the trajectory position.
-            float time = stack.get_zeroed_time(i);
+            double time = stack.get_zeroed_time(i);
             Point pos{trj.get_x_pos(time), trj.get_y_pos(time)};
             RawImage& img = stack.get_single_image(i).get_science();
             stamps.push_back(img.create_stamp(pos, radius, keep_no_data));
@@ -164,7 +164,7 @@ std::vector<RawImage> StampCreator::get_coadded_stamps_gpu(ImageStack& stack,
     const int height = stack.get_height();
 
     // Create a data stucture for the per-image data.
-    std::vector<float> image_times = stack.build_zeroed_times();
+    std::vector<double> image_times = stack.build_zeroed_times();
 
     // Allocate space for the results.
     const int num_trajectories = t_array.size();


### PR DESCRIPTION
Removes the conversion to float for the times coming out of the `ImageStack` and used on the GPU. This should not make a significant difference to GPU memory usage (there is only one time per image and a lot of pixel values per image) and will avoid any future complications with loss of precision.