### PR TITLE
Remove printf logging

### DIFF
--- a/src/kbmod/__init__.py
+++ b/src/kbmod/__init__.py
@@ -40,11 +40,10 @@ __PY_LOGGING_CONFIG = {
         }
     },
     "loggers": {
-        "kbmod.search.trajectory_list": {
-            "handlers": [
-                "default",
-            ]
-        }
+        "kbmod.search.psi_phi_array": {"handlers": ["default"]},
+        "kbmod.search.run_search": {"handlers": ["default"]},
+        "kbmod.search.stamp_creator": {"handlers": ["default"]},
+        "kbmod.search.trajectory_list": {"handlers": ["default"]},
     },
 }
 

--- a/src/kbmod/filters/stamp_filters.py
+++ b/src/kbmod/filters/stamp_filters.py
@@ -313,7 +313,7 @@ def extract_search_parameters_from_config(config):
 
 
 # TODO remove once we full replace ResultList with Results
-def get_coadds_and_filter(result_list, im_stack, stamp_params, chunk_size=1000000, debug=False):
+def get_coadds_and_filter(result_list, im_stack, stamp_params, chunk_size=1000000):
     """Create the co-added postage stamps and filter them based on their statistical
      properties. Results with stamps that are similar to a Gaussian are kept.
 
@@ -327,8 +327,6 @@ def get_coadds_and_filter(result_list, im_stack, stamp_params, chunk_size=100000
         The filtering parameters for the stamps.
     chunk_size : `int`
         How many stamps to load and filter at a time. Used to control memory.
-    debug : `bool`
-        Output verbose debugging messages.
     """
     if type(stamp_params) is SearchConfiguration:
         stamp_params = extract_search_parameters_from_config(stamp_params)
@@ -389,7 +387,7 @@ def get_coadds_and_filter(result_list, im_stack, stamp_params, chunk_size=100000
     logger.debug("{:.2f}s elapsed".format(time.time() - start_time))
 
 
-def get_coadds_and_filter_results(result_data, im_stack, stamp_params, chunk_size=1000000, debug=False):
+def get_coadds_and_filter_results(result_data, im_stack, stamp_params, chunk_size=1000000):
     """Create the co-added postage stamps and filter them based on their statistical
      properties. Results with stamps that are similar to a Gaussian are kept.
 
@@ -403,8 +401,6 @@ def get_coadds_and_filter_results(result_data, im_stack, stamp_params, chunk_siz
         The filtering parameters for the stamps.
     chunk_size : `int`
         How many stamps to load and filter at a time. Used to control memory.
-    debug : `bool`
-        Output verbose debugging messages.
     """
     num_results = len(result_data)
 

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -157,7 +157,6 @@ class SearchRunner:
 
         width = search.get_image_width()
         height = search.get_image_height()
-        debug = config["debug"]
 
         # Set the search bounds.
         if config["x_pixel_bounds"] and len(config["x_pixel_bounds"]) == 2:
@@ -190,10 +189,6 @@ class SearchRunner:
         # set the parameters.
         if config["encode_num_bytes"] > 0:
             search.enable_gpu_encoding(config["encode_num_bytes"])
-
-        # Enable debugging.
-        if config["debug"]:
-            search.set_debug(config["debug"])
 
         # Do the actual search.
         candidates = [trj for trj in trj_generator]
@@ -244,12 +239,7 @@ class SearchRunner:
 
         if config["do_stamp_filter"]:
             stamp_timer = kb.DebugTimer("stamp filtering", logger)
-            get_coadds_and_filter(
-                keep,
-                stack,
-                config,
-                debug=config["debug"],
-            )
+            get_coadds_and_filter(keep, stack, config)
             stamp_timer.stop()
 
         if config["do_clustering"]:

--- a/src/kbmod/search/common.h
+++ b/src/kbmod/search/common.h
@@ -118,9 +118,6 @@ struct SearchParameters {
     int y_start_min;
     int y_start_max;
 
-    // Provide debugging output.
-    bool debug;
-
     const std::string to_string() const {
         std::string output = ("Filtering Settings:\n  min_observations: " + std::to_string(min_observations) +
                               "\n  min_lh: " + std::to_string(min_lh));

--- a/src/kbmod/search/logging.h
+++ b/src/kbmod/search/logging.h
@@ -224,12 +224,13 @@ static void logging_bindings(py::module& m) {
     py::class_<Logging, std::unique_ptr<Logging, py::nodelete>>(m, "Logging")
             .def(py::init([]() { return std::unique_ptr<Logging, py::nodelete>(Logging::logging()); }))
             .def("setConfig", &Logging::setConfig)
-            .def_static("getLogger", [](py::str name) -> py::object {
-                py::module_ logging = py::module_::import("logging");
-                py::object pylogger = logging.attr("getLogger")(name);
-                Logging::logging()->register_logger(new PyLogger(pylogger));
-                return pylogger;
-            })
+            .def_static("getLogger",
+                        [](py::str name) -> py::object {
+                            py::module_ logging = py::module_::import("logging");
+                            py::object pylogger = logging.attr("getLogger")(name);
+                            Logging::logging()->register_logger(new PyLogger(pylogger));
+                            return pylogger;
+                        })
             .def_static("registerLogger", [](py::object pylogger) -> void {
                 Logging::logging()->register_logger(new PyLogger(pylogger));
             });

--- a/src/kbmod/search/psi_phi_array_ds.h
+++ b/src/kbmod/search/psi_phi_array_ds.h
@@ -112,7 +112,7 @@ public:
     void set_time_array(const std::vector<double>& times);
 
     // Functions for loading / unloading data onto GPU.
-    void move_to_gpu(bool debug = false);
+    void move_to_gpu();
     void clear_from_gpu();
 
     // Should ONLY be called by the utility functions.

--- a/src/kbmod/search/psi_phi_array_utils.h
+++ b/src/kbmod/search/psi_phi_array_utils.h
@@ -28,11 +28,9 @@ namespace search {
 std::array<float, 3> compute_scale_params_from_image_vect(const std::vector<RawImage>& imgs, int num_bytes);
 
 void fill_psi_phi_array(PsiPhiArray& result_data, int num_bytes, const std::vector<RawImage>& psi_imgs,
-                        const std::vector<RawImage>& phi_imgs, const std::vector<double> zeroed_times,
-                        bool debug = false);
+                        const std::vector<RawImage>& phi_imgs, const std::vector<double> zeroed_times);
 
-void fill_psi_phi_array_from_image_stack(PsiPhiArray& result_data, ImageStack& stack, int num_bytes,
-                                         bool debug = false);
+void fill_psi_phi_array_from_image_stack(PsiPhiArray& result_data, ImageStack& stack, int num_bytes);
 
 } /* namespace search */
 

--- a/src/kbmod/search/pydocs/stack_search_docs.h
+++ b/src/kbmod/search/pydocs/stack_search_docs.h
@@ -90,15 +90,6 @@ static const auto DOC_StackSearch_set_start_bounds_y = R"doc(
   Raises a ``RunTimeError`` if invalid bounds are provided (x_max > x_min).
   )doc";
 
-static const auto DOC_StackSearch_set_debug = R"doc(
-  Set whether to dislpay debug output.
-
-  Parameters
-  ----------
-  d : `bool`
-      Set to ``True`` to turn on debug output and ``False`` to turn it off.
-  )doc";
-
 static const auto DOC_StackSearch_get_num_images = R"doc(
   "Returns the number of images to process.
   ")doc";

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -39,7 +39,6 @@ public:
     const ImageStack& get_imagestack() const { return stack; }
 
     // Parameter setters used to control the searches.
-    void set_debug(bool d);
     void set_min_obs(int new_value);
     void set_min_lh(float new_value);
     void enable_gpu_sigmag_filter(std::vector<float> percentiles, float sigmag_coeff, float min_lh);
@@ -78,7 +77,6 @@ protected:
     // Core data and search parameters
     ImageStack stack;
     SearchParameters params;
-    bool debug_info;
 
     // Precomputed and cached search data
     bool psi_phi_generated;

--- a/src/kbmod/search/stamp_creator.cpp
+++ b/src/kbmod/search/stamp_creator.cpp
@@ -65,9 +65,12 @@ std::vector<RawImage> StampCreator::get_coadded_stamps(ImageStack& stack, std::v
                                                        const StampParameters& params, bool use_gpu) {
     if (use_gpu) {
 #ifdef HAVE_CUDA
+        logging::getLogger("kbmod.search.stamp_creator")
+            ->info("Performing co-adds on the GPU.");
         return get_coadded_stamps_gpu(stack, t_array, use_index_vect, params);
 #else
-        std::cout << "WARNING: GPU is not enabled. Performing co-adds on the CPU.";
+        logging::getLogger("kbmod.search.stamp_creator")
+            ->warning("GPU is not enabled. Performing co-adds on the CPU.");
 #endif
     }
     return get_coadded_stamps_cpu(stack, t_array, use_index_vect, params);

--- a/src/kbmod/search/trajectory_list.cpp
+++ b/src/kbmod/search/trajectory_list.cpp
@@ -1,3 +1,5 @@
+#include "logging.h"
+
 #include "trajectory_list.h"
 #include "pydocs/trajectory_list_docs.h"
 
@@ -33,6 +35,9 @@ TrajectoryList::TrajectoryList(const std::vector<Trajectory> &prev_list) {
 
 TrajectoryList::~TrajectoryList() {
     if (data_on_gpu) {
+        logging::getLogger("kbmod.search.trajectory_list")
+                ->debug("Freeing TrajectoryList on GPU: " + std::to_string(gpu_array.get_size()) +
+                        " items, " + std::to_string(gpu_array.get_memory_size()) + " bytes");
         gpu_array.free_gpu_memory();
     }
 }
@@ -118,6 +123,10 @@ void TrajectoryList::filter_by_valid() {
 void TrajectoryList::move_to_gpu() {
     if (data_on_gpu) return;  // Nothing to do.
 
+    logging::getLogger("kbmod.search.trajectory_list")
+            ->debug("Moving TrajectoryList to GPU: " + std::to_string(gpu_array.get_size()) + " items, " +
+                    std::to_string(gpu_array.get_memory_size()) + " bytes");
+
     // GPUArray handles all the validity checking, allocation, and copying.
     gpu_array.copy_vector_to_gpu(cpu_list);
     data_on_gpu = true;
@@ -125,6 +134,10 @@ void TrajectoryList::move_to_gpu() {
 
 void TrajectoryList::move_to_cpu() {
     if (!data_on_gpu) return;  // Nothing to do.
+
+    logging::getLogger("kbmod.search.trajectory_list")
+            ->debug("Freeing TrajectoryList on GPU: " + std::to_string(gpu_array.get_size()) + " items, " +
+                    std::to_string(gpu_array.get_memory_size()) + " bytes");
 
     // GPUArray handles all the validity checking and copying.
     gpu_array.copy_gpu_to_vector(cpu_list);

--- a/src/kbmod/trajectory_explorer.py
+++ b/src/kbmod/trajectory_explorer.py
@@ -18,13 +18,11 @@ class TrajectoryExplorer:
     ----------
     config : `SearchConfiguration`
         The configuration parameters.
-    debug : `bool`
-        Use verbose debug output.
     search : `kb.StackSearch`
         The search object (with cached data).
     """
 
-    def __init__(self, img_stack, config=None, debug=False):
+    def __init__(self, img_stack, config=None):
         """
         Parameters
         ----------
@@ -33,8 +31,6 @@ class TrajectoryExplorer:
         config : `SearchConfiguration`, optional
             The configuration parameters. If ``None`` uses the default
             configuration parameters.
-        debug : `bool`
-            Use verbose debug output.
         """
         self._data_initalized = False
         self.im_stack = img_stack
@@ -42,7 +38,6 @@ class TrajectoryExplorer:
             self.config = SearchConfiguration()
         else:
             self.config = config
-        self.debug = debug
 
         # Allocate and configure the StackSearch object.
         self.search = None
@@ -64,7 +59,6 @@ class TrajectoryExplorer:
 
         # Allocate the search structure.
         self.search = StackSearch(self.im_stack)
-        self.search.set_debug(self.debug)
 
         self._data_initalized = True
 

--- a/tests/test_psi_phi_array.py
+++ b/tests/test_psi_phi_array.py
@@ -140,7 +140,7 @@ class test_psi_phi_array(unittest.TestCase):
             arr = PsiPhiArray()
             self.assertFalse(arr.cpu_array_allocated)
             fill_psi_phi_array(
-                arr, num_bytes, [self.psi_1, self.psi_2], [self.phi_1, self.phi_2], self.zeroed_times, False
+                arr, num_bytes, [self.psi_1, self.psi_2], [self.phi_1, self.phi_2], self.zeroed_times
             )
 
             # Check the meta data.
@@ -206,7 +206,7 @@ class test_psi_phi_array(unittest.TestCase):
 
         # Create the PsiPhiArray from the ImageStack.
         arr = PsiPhiArray()
-        fill_psi_phi_array_from_image_stack(arr, im_stack, 4, False)
+        fill_psi_phi_array_from_image_stack(arr, im_stack, 4)
 
         # Check the meta data.
         self.assertEqual(arr.num_times, num_times)

--- a/tests/test_stamp_filters.py
+++ b/tests/test_stamp_filters.py
@@ -227,7 +227,7 @@ class test_stamp_filters(unittest.TestCase):
         config = SearchConfiguration.from_dict(config_dict)
 
         # Do the filtering.
-        get_coadds_and_filter(keep, ds.stack, config, chunk_size=1, debug=False)
+        get_coadds_and_filter(keep, ds.stack, config, chunk_size=1)
 
         # The check that the correct indices and number of stamps are saved.
         self.assertEqual(keep.num_results(), 2)
@@ -278,7 +278,7 @@ class test_stamp_filters(unittest.TestCase):
         config = SearchConfiguration.from_dict(config_dict)
 
         # Do the filtering.
-        get_coadds_and_filter_results(keep, ds.stack, config, chunk_size=2, debug=False)
+        get_coadds_and_filter_results(keep, ds.stack, config, chunk_size=2)
 
         # The check that the correct indices and number of stamps are saved.
         self.assertTrue("stamp" in keep.colnames)
@@ -330,7 +330,7 @@ class test_stamp_filters(unittest.TestCase):
         config = SearchConfiguration.from_dict(config_dict)
 
         # Do the filtering.
-        get_coadds_and_filter_results(keep, ds.stack, config, chunk_size=2, debug=False)
+        get_coadds_and_filter_results(keep, ds.stack, config, chunk_size=2)
 
         # The check that the correct indices and number of stamps are saved.
         self.assertTrue("stamp" in keep.colnames)


### PR DESCRIPTION
Now that we have a logger in C++, convert all the C++ logging to use that instead of `printf()` or `cout`. This also lets us remove the `debug` Booleans that we were passing through the code. Instead the verbosity can be controlled at the Python level.