### PR TITLE
Clean up a bunch of output from the tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dynamic = ["version"]
 dependencies = [
     "astropy>=5.1",
     "astroquery>=0.4.6",
+    "joblib>=1.4",
     "matplotlib>=3.5",
     "numpy>=1.18",
     "pandas>=1.5.1",

--- a/src/kbmod/data_interface.py
+++ b/src/kbmod/data_interface.py
@@ -108,9 +108,6 @@ def save_deccam_layered_image(img, filename, wcs=None, overwrite=True):
     hdul.writeto(filename, overwrite=overwrite)
 
 
-logger = kb.Logging.getLogger(__name__)
-
-
 def load_input_from_individual_files(
     im_filepath,
     time_file,

--- a/tests/test_data_interface.py
+++ b/tests/test_data_interface.py
@@ -1,4 +1,5 @@
 from astropy.wcs import WCS
+import logging
 import os
 import tempfile
 import unittest
@@ -17,6 +18,16 @@ from utils.utils_for_tests import get_absolute_data_path
 
 
 class test_data_interface(unittest.TestCase):
+    def setUp(self):
+        # Turn off WARNING-level logging for these tests since they will always
+        # generate a warning about a bad file (wrong_filename.fits) that has
+        # intentionally been inserted into the data as part of the test.
+        logging.basicConfig(level=logging.CRITICAL)
+
+    def tearDown(self):
+        # Re-enable the WARNING-level logging.
+        logging.basicConfig(level=logging.WARNING)
+
     def test_file_load_basic(self):
         stack, wcs_list, mjds = load_input_from_individual_files(
             get_absolute_data_path("fake_images"),

--- a/tests/test_regression_test.py
+++ b/tests/test_regression_test.py
@@ -3,6 +3,7 @@ This is a manually run regression test that is more comprehensive than
 the individual unittests.
 """
 
+import logging
 import math
 import os
 import sys
@@ -20,6 +21,8 @@ from kbmod.result_list import ResultList
 from kbmod.run_search import SearchRunner
 from kbmod.search import *
 from kbmod.wcs_utils import append_wcs_to_hdu_header, make_fake_wcs_info
+
+logger = logging.getLogger(__name__)
 
 
 def ave_trajectory_distance(trjA, trjB, times=[0.0]):
@@ -244,21 +247,21 @@ def save_fake_data(data_dir, stack, times, psf_vals, default_psf_val=1.0):
     # Make the subdirectory if needed.
     dir_path = Path(data_dir)
     if not dir_path.is_dir():
-        print("Directory '%s' does not exist. Creating." % data_dir)
+        logger.debug("Directory '%s' does not exist. Creating." % data_dir)
         os.mkdir(data_dir)
 
     # Make the subdirectory if needed.
     img_dir = data_dir + "/imgs"
     dir_path = Path(img_dir)
     if not dir_path.is_dir():
-        print("Directory '%s' does not exist. Creating." % img_dir)
+        logger.debug("Directory '%s' does not exist. Creating." % img_dir)
         os.mkdir(img_dir)
 
     # Save each of the image files.
     for i in range(stack.img_count()):
         img = stack.get_single_image(i)
         filename = os.path.join(img_dir, ("%06i.fits" % i))
-        print("Saving file: %s" % filename)
+        logger.debug("Saving file: %s" % filename)
 
         # If the file already exists, delete it.
         if Path(filename).exists():
@@ -272,7 +275,7 @@ def save_fake_data(data_dir, stack, times, psf_vals, default_psf_val=1.0):
 
     # Save the psf file.
     psf_file_name = data_dir + "/psf_vals.dat"
-    print("Creating psf file: %s" % psf_file_name)
+    logger.debug("Creating psf file: %s" % psf_file_name)
     with open(psf_file_name, "w") as file:
         file.write("# visit_id psf_val\n")
         for i in range(len(times)):
@@ -473,7 +476,7 @@ def run_full_test():
         save_fake_data(dir_name, stack, times, psf_vals, default_psf)
 
         # Do the search.
-        print("Running search with data in %s/" % dir_name)
+        logger.debug("Running search with data in %s/" % dir_name)
         result_filename = os.path.join(dir_name, "results.ecsv")
         perform_search(
             os.path.join(dir_name, "imgs"),
@@ -488,24 +491,24 @@ def run_full_test():
         loaded_data = ResultList.read_table(result_filename)
         for row in loaded_data.results:
             found.append(row.trajectory)
-        print("Found %i trajectories vs %i used." % (len(found), len(trjs)))
+        logger.debug("Found %i trajectories vs %i used." % (len(found), len(trjs)))
 
         # Determine which trajectories we did not recover.
         overlap = find_unique_overlap(trjs, found, 3.0, [0.0, 2.0])
         missing = find_set_difference(trjs, found, 3.0, [0.0, 2.0])
 
-        print("\nRecovered %i matching trajectories:" % len(overlap))
+        logger.debug("\nRecovered %i matching trajectories:" % len(overlap))
         for x in overlap:
-            print(x)
+            logger.debug(x)
 
         if len(missing) == 0:
-            print("*** PASSED ***")
+            logger.debug("*** PASSED ***")
             return True
         else:
-            print("\nFailed to recover %i trajectories:" % len(missing))
+            logger.debug("\nFailed to recover %i trajectories:" % len(missing))
             for x in missing:
-                print(x)
-            print("*** FAILED ***")
+                logger.debug(x)
+            logger.debug("*** FAILED ***")
             return False
 
 

--- a/tests/test_sigma_g_filter.py
+++ b/tests/test_sigma_g_filter.py
@@ -1,5 +1,6 @@
 import numpy as np
 import unittest
+import warnings
 
 from kbmod.filters.sigma_g_filter import SigmaGClipping, apply_clipped_sigma_g
 from kbmod.result_list import ResultRow, ResultList
@@ -110,9 +111,12 @@ class test_sigma_g_math(unittest.TestCase):
                 [False] * num_points,
             ]
         )
-
         sigma_g = SigmaGClipping(clip_negative=True)
-        index_valid = sigma_g.compute_clipped_sigma_g_matrix(lh)
+
+        # Surpress the warning we get from encountering a row of all NaNs.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            index_valid = sigma_g.compute_clipped_sigma_g_matrix(lh)
         self.assertTrue(np.array_equal(index_valid, expected))
 
     def test_apply_clipped_sigma_g(self):


### PR DESCRIPTION
- Switch the regression test to use debug logging.
- pin joblib >= 1.4 to remove a deprecation warning.
- Turn off warnings for the tests in `test_data_interface.py` since they use a data directory with an invalid file and will always generate a warning
- Suppress an "all NaN" warning in one of the statistics tests.