### PR TITLE
Replace ResultList with Results in TrajectoryExplorer

### DIFF
--- a/notebooks/TrajectoryExplorer.ipynb
+++ b/notebooks/TrajectoryExplorer.ipynb
@@ -223,7 +223,7 @@
    "source": [
     "## Filtering\n",
     "\n",
-    "A key component of KBMOD is the clipped Sigma-G filtering. `TrajectoryExplorer` does not do any filtering be default so that users can see all the information for the given trajectory. However, it provides the ability to apply the filtering manually. The mask of time step validity is stored in the column `obs_valid`."
+    "A key component of KBMOD is the clipped Sigma-G filtering. `TrajectoryExplorer` does not do any filtering by default so that users can see all the information for the given trajectory. However, it provides the ability to apply the filtering manually. The mask of time step validity is stored in the column `obs_valid`."
    ]
   },
   {

--- a/notebooks/TrajectoryExplorer.ipynb
+++ b/notebooks/TrajectoryExplorer.ipynb
@@ -16,7 +16,8 @@
     "import math\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "from kbmod.trajectory_explorer import TrajectoryExplorer"
+    "from kbmod.trajectory_explorer import TrajectoryExplorer\n",
+    "from kbmod.search import Trajectory"
    ]
   },
   {
@@ -38,7 +39,6 @@
    "outputs": [],
    "source": [
     "from kbmod.fake_data.fake_data_creator import create_fake_times, FakeDataSet\n",
-    "from kbmod.trajectory_utils import make_trajectory\n",
     "\n",
     "# Create a list of fake times from MJD=57130.2 onward\n",
     "num_images = 12\n",
@@ -54,7 +54,7 @@
     ")\n",
     "\n",
     "# Create a bright fake object starting at pixel x=50, y=60 and moving with velocity vx=5.0, vy=-2.0.\n",
-    "fake_trj = make_trajectory(50, 60, 5.0, -2.0, flux=100.0)\n",
+    "fake_trj = Trajectory(50, 60, 5.0, -2.0, flux=100.0)\n",
     "fake_ds.insert_object(fake_trj)\n",
     "\n",
     "# Display the image from the first time step.\n",
@@ -97,7 +97,7 @@
    "source": [
     "## Using TrajectoryExplorer\n",
     "\n",
-    "`TrajectoryExplorer` is constructed from the `ImageStack` and an optional configuration. Once it is instantiated, we can use the `evaluate_linear_trajectory` function to query specific trajectories. The function returns a `ResultRow` with a variety of information. The most important is a `Trajectory` object that stores the raw statistics coming from the GPU search."
+    "`TrajectoryExplorer` is constructed from the `ImageStack` and an optional configuration. Once it is instantiated, we can use the `evaluate_linear_trajectory` function to query specific trajectories. The function returns a `Results` object with a single row and a variety of columns, including the raw statistics from the GPU search."
    ]
   },
   {
@@ -109,7 +109,28 @@
     "explorer = TrajectoryExplorer(fake_ds.stack)\n",
     "\n",
     "result = explorer.evaluate_linear_trajectory(50, 60, 5.0, -2.0)\n",
-    "print(result.trajectory)"
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can access individual statistics about the results by using the column name and row index of 0."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "best_row = result[0]\n",
+    "\n",
+    "print(\n",
+    "    f\"The trajectory starts at ({best_row['x']}, {best_row['y']}) and moves as ({best_row['vx']}, {best_row['vy']})\"\n",
+    ")\n",
+    "print(f\"It has {best_row['obs_count']} observations and a likelihood of {best_row['likelihood']}.\")"
    ]
   },
   {
@@ -125,15 +146,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, axs = plt.subplots(3, 1)\n",
-    "axs[0].plot(fake_times, result.psi_curve)\n",
+    "fig, axs = plt.subplots(2, 1)\n",
+    "axs[0].plot(fake_times, best_row[\"psi_curve\"])\n",
     "axs[0].set_title(\"Psi\")\n",
     "\n",
-    "axs[1].plot(fake_times, result.phi_curve)\n",
-    "axs[1].set_title(\"Psi\")\n",
-    "\n",
-    "axs[2].plot(fake_times, result.likelihood_curve)\n",
-    "axs[2].set_title(\"Likelihood\")"
+    "axs[1].plot(fake_times, best_row[\"phi_curve\"])\n",
+    "axs[1].set_title(\"Psi\")"
    ]
   },
   {
@@ -157,7 +175,7 @@
     "    for j in range(w):\n",
     "        ind = w * i + j\n",
     "        if ind < num_images:\n",
-    "            axs[i, j].imshow(result.all_stamps[ind], cmap=\"gray\")"
+    "            axs[i, j].imshow(result[\"all_stamps\"][0][ind], cmap=\"gray\")"
    ]
   },
   {
@@ -196,7 +214,7 @@
     "print(f\"Object starts at ({ra0}, {dec0}) with velocity ({v_ra}, {v_dec}).\")\n",
     "\n",
     "result = explorer.evaluate_angle_trajectory(ra0, dec0, v_ra, v_dec, my_wcs)\n",
-    "print(result.trajectory)"
+    "print(result)"
    ]
   },
   {
@@ -205,7 +223,7 @@
    "source": [
     "## Filtering\n",
     "\n",
-    "A key component of KBMOD is the clipped Sigma-G filtering. `TrajectoryExplorer` does not do any filtering be default so that users can see all the information for the given trajectory. However, it provides the ability to apply the filtering manually. The unfiltered time stamps are stored in `valid_indices`."
+    "A key component of KBMOD is the clipped Sigma-G filtering. `TrajectoryExplorer` does not do any filtering be default so that users can see all the information for the given trajectory. However, it provides the ability to apply the filtering manually. The mask of time step validity is stored in the column `obs_valid`."
    ]
   },
   {
@@ -215,7 +233,9 @@
    "outputs": [],
    "source": [
     "explorer.apply_sigma_g(result)\n",
-    "print(f\"Valid time steps={result.valid_indices}\")"
+    "\n",
+    "for i in range(len(fake_times)):\n",
+    "    print(f\"Time {i} is valid = {result['obs_valid'][0][i]}.\")"
    ]
   },
   {

--- a/src/kbmod/trajectory_explorer.py
+++ b/src/kbmod/trajectory_explorer.py
@@ -1,9 +1,9 @@
 import numpy as np
 
 from kbmod.configuration import SearchConfiguration
-from kbmod.filters.sigma_g_filter import apply_single_clipped_sigma_g, SigmaGClipping
+from kbmod.filters.sigma_g_filter import apply_clipped_sigma_g, SigmaGClipping
 from kbmod.masking import apply_mask_operations
-from kbmod.result_list import ResultRow
+from kbmod.results import Results
 from kbmod.search import StackSearch, StampCreator, Logging
 from kbmod.trajectory_utils import make_trajectory_from_ra_dec
 
@@ -79,23 +79,24 @@ class TrajectoryExplorer:
 
         Returns
         -------
-        result : `ResultRow`
-            The result data with all fields filled out.
+        result : `Results`
+            The results table with a single row and all the columns filled out.
         """
         self.initialize_data()
 
         # Evaluate the trajectory.
         trj = self.search.search_linear_trajectory(x, y, vx, vy)
-        result = ResultRow(trj, self.im_stack.img_count())
+        result = Results.from_trajectories([trj])
 
         # Get the psi and phi curves and do the sigma_g filtering.
-        psi_curve = np.array(self.search.get_psi_curves(trj))
-        phi_curve = np.array(self.search.get_phi_curves(trj))
-        result.set_psi_phi(psi_curve, phi_curve)
+        psi_curve = np.array([self.search.get_psi_curves(trj)])
+        phi_curve = np.array([self.search.get_phi_curves(trj)])
+        obs_valid = np.full(psi_curve.shape, True)
+        result.add_psi_phi_data(psi_curve, phi_curve, obs_valid)
 
         # Get the individual stamps.
-        stamps = StampCreator.get_stamps(self.im_stack, result.trajectory, self.config["stamp_radius"])
-        result.all_stamps = np.array([stamp.image for stamp in stamps])
+        stamps = StampCreator.get_stamps(self.im_stack, trj, self.config["stamp_radius"])
+        result.table["all_stamps"] = np.array([[stamp.image for stamp in stamps]])
 
         return result
 
@@ -118,8 +119,8 @@ class TrajectoryExplorer:
 
         Returns
         -------
-        result : `ResultRow`
-            The result data with all fields filled out.
+        result : `Results`
+            The results table with a single row and all the columns filled out.
         """
         trj = make_trajectory_from_ra_dec(ra, dec, v_ra, v_dec, wcs)
         return self.evaluate_linear_trajectory(trj.x, trj.y, trj.vx, trj.vy)
@@ -129,8 +130,8 @@ class TrajectoryExplorer:
 
         Parameters
         ----------
-        result : `ResultRow`
-            The row to test for filtering.
+        result : `Results`
+            A table of results to test.
         """
         clipper = SigmaGClipping(
             self.config["sigmaG_lims"][0],
@@ -138,4 +139,4 @@ class TrajectoryExplorer:
             2,
             self.config["clip_negative"],
         )
-        apply_single_clipped_sigma_g(clipper, result)
+        apply_clipped_sigma_g(clipper, result)

--- a/tests/test_trajectory_explorer.py
+++ b/tests/test_trajectory_explorer.py
@@ -48,28 +48,26 @@ class test_trajectory_explorer(unittest.TestCase):
         result = self.explorer.evaluate_linear_trajectory(self.x0, self.y0, self.vx, self.vy)
 
         # We found the trajectory we were loooking for.
-        self.assertIsNotNone(result.trajectory)
-        self.assertEqual(result.trajectory.x, self.x0)
-        self.assertEqual(result.trajectory.y, self.y0)
-        self.assertEqual(result.trajectory.vx, self.vx)
-        self.assertEqual(result.trajectory.vy, self.vy)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result["x"][0], self.x0)
+        self.assertEqual(result["y"][0], self.y0)
+        self.assertEqual(result["vx"][0], self.vx)
+        self.assertEqual(result["vy"][0], self.vy)
 
         # The statistics seem reasonable.
-        self.assertGreater(result.trajectory.lh, 50.0)
-        self.assertGreater(result.trajectory.flux, 50.0)
-        self.assertGreater(result.trajectory.obs_count, 10)
+        self.assertGreater(result["likelihood"][0], 50.0)
+        self.assertGreater(result["flux"][0], 50.0)
+        self.assertGreater(result["obs_count"][0], 10)
 
         # We compute the rest of the data we need.
-        self.assertEqual(result.num_times, 20)
-        self.assertEqual(len(result.valid_indices), 20)
-        self.assertEqual(len(result.psi_curve), 20)
-        self.assertEqual(len(result.phi_curve), 20)
-        self.assertEqual(len(result.all_stamps), 20)
+        self.assertEqual(len(result["obs_valid"][0]), 20)
+        self.assertEqual(len(result["psi_curve"][0]), 20)
+        self.assertEqual(len(result["phi_curve"][0]), 20)
+        self.assertEqual(len(result["all_stamps"][0]), 20)
 
         # At least one index 10 should be filtered by sigma G filtering.
         self.explorer.apply_sigma_g(result)
-        self.assertLess(len(result.valid_indices), 20)
-        self.assertFalse(10 in result.valid_indices)
+        self.assertFalse(result["obs_valid"][0][10])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As a step to replacing `ResultList` with `Results` throughout KBMOD, make the switch in the standalone `TrajectoryExplorer` class and its demo notebook.

This was originally part of #563, but is being broken off to make that PR smaller.