### PR TITLE
Add information and helpers about time sorting in ImageStack

### DIFF
--- a/src/kbmod/__init__.py
+++ b/src/kbmod/__init__.py
@@ -40,6 +40,7 @@ __PY_LOGGING_CONFIG = {
         }
     },
     "loggers": {
+        "kbmod.search.image_stack": {"handlers": ["default"]},
         "kbmod.search.psi_phi_array": {"handlers": ["default"]},
         "kbmod.search.run_search": {"handlers": ["default"]},
         "kbmod.search.stamp_creator": {"handlers": ["default"]},

--- a/src/kbmod/search/image_stack.cpp
+++ b/src/kbmod/search/image_stack.cpp
@@ -1,8 +1,15 @@
 #include "image_stack.h"
 
+#include <algorithm>
+#include "logging.h"
+
 namespace search {
 
-ImageStack::ImageStack(const std::vector<LayeredImage>& imgs) { images = imgs; }
+ImageStack::ImageStack(const std::vector<LayeredImage>& imgs) {
+    logging::getLogger("kbmod.search.image_stack")
+            ->debug("Constructing ImageStack with " + std::to_string(imgs.size()) + " images.");
+    images = imgs;
+}
 
 LayeredImage& ImageStack::get_single_image(int index) {
     if (index < 0 || index > images.size()) throw std::out_of_range("ImageStack index out of bounds.");
@@ -28,6 +35,13 @@ std::vector<double> ImageStack::build_zeroed_times() const {
         }
     }
     return zeroed_times;
+}
+
+void ImageStack::sort_by_time() {
+    logging::getLogger("kbmod.search.image_stack")
+            ->debug("Sorting " + std::to_string(images.size()) + " images by time.");
+    std::sort(images.begin(), images.end(),
+              [](LayeredImage a, LayeredImage b) { return a.get_obstime() < b.get_obstime(); });
 }
 
 void ImageStack::convolve_psf() {
@@ -75,6 +89,7 @@ static void image_stack_bindings(py::module& m) {
             .def("get_obstime", &is::get_obstime, pydocs::DOC_ImageStack_get_obstime)
             .def("get_zeroed_time", &is::get_zeroed_time, pydocs::DOC_ImageStack_get_zeroed_time)
             .def("build_zeroed_times", &is::build_zeroed_times, pydocs::DOC_ImageStack_build_zeroed_times)
+            .def("sort_by_time", &is::sort_by_time, pydocs::DOC_ImageStack_sort_by_time)
             .def("img_count", &is::img_count, pydocs::DOC_ImageStack_img_count)
             .def("make_global_mask", &is::make_global_mask, pydocs::DOC_ImageStack_make_global_mask)
             .def("convolve_psf", &is::convolve_psf, pydocs::DOC_ImageStack_convolve_psf)

--- a/src/kbmod/search/image_stack.h
+++ b/src/kbmod/search/image_stack.h
@@ -24,10 +24,11 @@ public:
     std::vector<LayeredImage>& get_images() { return images; }
     LayeredImage& get_single_image(int index);
 
-    // Functions for getting times.
+    // Functions for getting or using times.
     double get_obstime(int index) const;
     double get_zeroed_time(int index) const;
     std::vector<double> build_zeroed_times() const;  // Linear cost.
+    void sort_by_time();
 
     void convolve_psf();
 

--- a/src/kbmod/search/pydocs/image_stack_docs.h
+++ b/src/kbmod/search/pydocs/image_stack_docs.h
@@ -4,6 +4,12 @@
 namespace pydocs {
 static const auto DOC_ImageStack = R"doc(
   A class for storing a list of LayeredImages at different times.
+      
+  Notes
+  -----
+  The images are not required to be in sorted time order, but the first
+  image is used for t=0.0 when computing zeroed times (which might make
+  some times negative).
   )doc";
 
 static const auto DOC_ImageStack_get_images = R"doc(
@@ -24,13 +30,19 @@ static const auto DOC_ImageStack_get_obstime = R"doc(
 
 static const auto DOC_ImageStack_get_zeroed_time = R"doc(
   Returns a single image's observation time relative to that
-  of the first image.
+  of the first image. This can return negative times if the
+  images are not sorted by time.
   )doc";
 
 static const auto DOC_ImageStack_build_zeroed_times = R"doc(
   Construct an array of time differentials between each image
-  in the stack and the first image.
+  in the stack and the first image. This can return negative times
+  if the images are not sorted by time.
   ")doc";
+
+static const auto DOC_ImageStack_sort_by_time = R"doc(
+  Sort the images in the ImageStack by their time.
+  ")doc";    
 
 static const auto DOC_ImageStack_make_global_mask = R"doc(
   Create a new global mask from a set of flags and a threshold.

--- a/tests/test_image_stack.py
+++ b/tests/test_image_stack.py
@@ -89,6 +89,21 @@ class test_ImageStack(unittest.TestCase):
             self.assertGreater(pix_val, last_val)
             last_val = pix_val
 
+    def test_sort_by_time(self):
+        local_psf = PSF(1.0)
+        images = [
+            make_fake_layered_image(10, 15, 0.0, 0.0, 3.0, local_psf),
+            make_fake_layered_image(10, 15, 0.0, 0.0, 1.0, local_psf),
+            make_fake_layered_image(10, 15, 0.0, 0.0, 4.0, local_psf),
+            make_fake_layered_image(10, 15, 0.0, 0.0, 5.0, local_psf),
+            make_fake_layered_image(10, 15, 0.0, 0.0, 2.0, local_psf),
+        ]
+        im_stack = ImageStack(images)
+        self.assertListEqual(im_stack.build_zeroed_times(), [0.0, -2.0, 1.0, 2.0, -1.0])
+
+        im_stack.sort_by_time()
+        self.assertListEqual(im_stack.build_zeroed_times(), [0.0, 1.0, 2.0, 3.0, 4.0])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR tries to clarify what zeroed time means. Specifically KBMOD needs trajectories to start at t=0 and chooses the first image for this reference time. However it does not require that the images are sorted, so negative times are fine. This PR adds some comments to this effect as well as a sorting function for `ImageStack`