### PR TITLE
Basic fixes to logging

### DIFF
--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -174,7 +174,7 @@ class SearchRunner:
 
         # If we are using gpu_filtering, enable it and set the parameters.
         if config["gpu_filter"]:
-            logger.debug("Using in-line GPU sigmaG filtering methods", flush=True)
+            logger.debug("Using in-line GPU sigmaG filtering methods")
             coeff = SigmaGClipping.find_sigma_g_coeff(
                 config["sigmaG_lims"][0],
                 config["sigmaG_lims"][1],

--- a/src/kbmod/search/debug_timer.cpp
+++ b/src/kbmod/search/debug_timer.cpp
@@ -36,7 +36,7 @@ void DebugTimer::stop() {
     t_end_ = std::chrono::system_clock::now();
     running_ = false;
     auto t_delta = std::chrono::duration_cast<std::chrono::milliseconds>(t_end_ - t_start_);
-    logger_->debug("Finished " + message_ + " in " + std::to_string(t_delta.count() / 1000.0) + "seconds.");
+    logger_->debug("Finished " + message_ + " in " + std::to_string(t_delta.count() / 1000.0) + " seconds.");
 }
 
 double DebugTimer::read() {
@@ -49,7 +49,7 @@ double DebugTimer::read() {
     }
 
     double result = t_delta.count() / 1000.0;
-    logger_->debug("Step " + message_ + " is at " + std::to_string(result) + "seconds.");
+    logger_->debug("Step " + message_ + " is at " + std::to_string(result) + " seconds.");
     return result;
 }
 

--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -9,12 +9,6 @@ extern "C" void evaluateTrajectory(PsiPhiArrayMeta psi_phi_meta, void* psi_phi_v
                                    SearchParameters params, Trajectory* candidate);
 #endif
 
-// This logger is often used in this module so we might as well declare it
-// global, but this would generally be a one-liner like:
-// logging::getLogger("kbmod.search.run_search") -> level(msg)
-// I'd imaging...
-auto rs_logger = logging::getLogger("kbmod.search.run_search");
-
 StackSearch::StackSearch(ImageStack& imstack) : stack(imstack), results(0), gpu_search_list(0) {
     psi_phi_generated = false;
 
@@ -36,6 +30,9 @@ StackSearch::StackSearch(ImageStack& imstack) : stack(imstack), results(0), gpu_
     params.x_start_max = stack.get_width();
     params.y_start_min = 0;
     params.y_start_max = stack.get_height();
+
+    // Get the logger for this module.
+    rs_logger = logging::getLogger("kbmod.search.run_search");
 }
 
 // --------------------------------------------

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -87,6 +87,9 @@ protected:
 
     // Trajectories that are being searched.
     TrajectoryList gpu_search_list;
+
+    // Logger for this object. Retrieved once this is used frequently.
+    logging::Logger* rs_logger;
 };
 
 } /* namespace search */


### PR DESCRIPTION
A series of really small fixes to logging, including:
- Remove a `flush` that was accidentally left over from the days of `print` logging.
- Add a space in the `DebugTimer`'s output for readability.
- Make `StackSearch`'s `rs_timer` a object attribute instead of a global variable. For some reason the global variable is not picking up the config correctly. This fixes that problem and removes a global variable.