### PR TITLE
Productionize filtering and improve its debugging

### DIFF
--- a/src/kbmod/filters/clustering_filters.py
+++ b/src/kbmod/filters/clustering_filters.py
@@ -261,6 +261,7 @@ def apply_clustering(result_data, cluster_params):
 
     # Skip clustering if there is nothing to cluster.
     if len(result_data) == 0:
+        logger.info("Clustering : skipping, no results.")
         return
     logger.info(f"Clustering {len(result_data)} results using {cluster_type}")
 

--- a/src/kbmod/filters/sigma_g_filter.py
+++ b/src/kbmod/filters/sigma_g_filter.py
@@ -5,11 +5,13 @@ Sifting Through the Static: Moving Objectg Detection in Difference Images
 by Smotherman et. al. 2021
 """
 
-import multiprocessing as mp
+import logging
 import numpy as np
 from scipy.special import erfinv
 
 from kbmod.results import Results
+
+logger = logging.getLogger(__name__)
 
 
 class SigmaGClipping:
@@ -171,6 +173,10 @@ def apply_clipped_sigma_g(clipper, result_data):
     result_data : `ResultList` or `Results`
         The values from trajectories. This data gets modified directly by the filtering.
     """
+    if len(result_data) == 0:
+        logger.info("SigmaG Clipping : skipping, nothing to filter.")
+        return
+
     lh = result_data.compute_likelihood_curves(filter_obs=True, mask_value=np.NAN)
     obs_valid = clipper.compute_clipped_sigma_g_matrix(lh)
     result_data.update_obs_valid(obs_valid)

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -125,10 +125,12 @@ class SearchRunner:
 
                 # Do the sigma-G filtering and subsequent stats filtering.
                 apply_clipped_sigma_g(clipper, result_batch)
-                row_mask = result_batch["obs_count"] >= num_obs
+                obs_row_mask = result_batch["obs_count"] >= num_obs
+                result_batch.filter_rows(obs_row_mask, "obs_count")
+
                 if lh_level > 0.0:
-                    row_mask = row_mask & (result_batch["likelihood"] >= lh_level)
-                result_batch.filter_rows(row_mask)
+                    lh_row_mask = result_batch["likelihood"] >= lh_level
+                    result_batch.filter_rows(lh_row_mask, "likelihood")
 
                 # Add the results to the final set.
                 keep.extend(result_batch)

--- a/tests/test_stamp_filters.py
+++ b/tests/test_stamp_filters.py
@@ -156,7 +156,12 @@ class test_stamp_filters(unittest.TestCase):
         self.assertEqual(keep["vx"][0], trj2.vx)
         self.assertEqual(keep["vy"][0], trj2.vy)
 
-    def test_append_all_stamps_results(self):
+        # Test with empty results.
+        keep2 = Results.from_trajectories([])
+        get_coadds_and_filter_results(keep2, ds.stack, config, chunk_size=1000)
+        self.assertTrue("stamp" in keep2.colnames)
+
+    def test_append_all_stamps(self):
         image_count = 10
         fake_times = create_fake_times(image_count, 57130.2, 1, 0.01, 1)
         ds = FakeDataSet(
@@ -184,6 +189,11 @@ class test_stamp_filters(unittest.TestCase):
             self.assertEqual(stamps_array.shape[0], image_count)
             self.assertEqual(stamps_array.shape[1], 11)
             self.assertEqual(stamps_array.shape[2], 11)
+
+        # Check that everything works if the results are empty.
+        keep2 = Results.from_trajectories([])
+        append_all_stamps(keep2, ds.stack, 5)
+        self.assertTrue("all_stamps" in keep2.colnames)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR is a series of changes to filtering that is mean to clean up the code, harden it against edge cases, and improve debugging through better logging. Changes include:
- More comprehensive logging throughout the filtering process.
- Skipping filtering when there are no results (in the sigma-g filtering and stamp filtering)
- Remove deprecated `ResultList` path for `append_all_stamps()` function
- Add basic statistics tracking to `Results` filtering to help with debugging. This is used even when track filtering is turned off.
- Simplify `Results.from_trajectories()` to just use the filter method instead of doing it manually.
- Remove `Results._append_filtered()` method which was only used in one place and merge logic into `Results.filter_rows()`
- Add filtering labels in `run_search.py`'s loading step so we can track them. Also breaks filtering into its two components for finer grained tracking.
- Add more testing 