### PR TITLE
Add more debugging info for KBMOD

### DIFF
--- a/src/kbmod/__init__.py
+++ b/src/kbmod/__init__.py
@@ -41,6 +41,7 @@ __PY_LOGGING_CONFIG = {
     },
     "loggers": {
         "kbmod.search.image_stack": {"handlers": ["default"]},
+        "kbmod.search.layered_image": {"handlers": ["default"]},
         "kbmod.search.psi_phi_array": {"handlers": ["default"]},
         "kbmod.search.run_search": {"handlers": ["default"]},
         "kbmod.search.stamp_creator": {"handlers": ["default"]},

--- a/src/kbmod/search/layered_image.cpp
+++ b/src/kbmod/search/layered_image.cpp
@@ -93,7 +93,7 @@ void LayeredImage::union_threshold_masking(float thresh) {
 void LayeredImage::grow_mask(int steps) {
     ImageI bitmask = ImageI::Constant(height, width, -1);
     bitmask = (mask.get_image().array() > 0).select(0, bitmask);
-    
+
     for (int itr = 1; itr <= steps; ++itr) {
         for (int j = 0; j < height; ++j) {
             for (int i = 0; i < width; ++i) {

--- a/src/kbmod/search/layered_image.cpp
+++ b/src/kbmod/search/layered_image.cpp
@@ -93,7 +93,7 @@ void LayeredImage::union_threshold_masking(float thresh) {
 void LayeredImage::grow_mask(int steps) {
     ImageI bitmask = ImageI::Constant(height, width, -1);
     bitmask = (mask.get_image().array() > 0).select(0, bitmask);
-
+    
     for (int itr = 1; itr <= steps; ++itr) {
         for (int j = 0; j < height; ++j) {
             for (int i = 0; i < width; ++i) {
@@ -197,6 +197,40 @@ RawImage LayeredImage::generate_phi_image() {
     return result;
 }
 
+double LayeredImage::compute_fraction_masked() const {
+    double masked_count = 0.0;
+
+    for (int j = 0; j < height; ++j) {
+        for (int i = 0; i < width; ++i) {
+            if (!science_pixel_has_data({j, i})) masked_count += 1.0;
+        }
+    }
+    return masked_count / (double)(height * width);
+}
+
+void LayeredImage::log_stats(std::string level) const {
+    logging::Logger* logger = logging::getLogger("kbmod.search.layered_image");
+
+    logger->log(level, "Image Size = (" + std::to_string(height) + ", " + std::to_string(width) + ")");
+    logger->log(level, "Obs Time = " + std::to_string(get_obstime()));
+
+    // Output the stats for the science and variance layers.
+    std::array<float, 2> sci_bnds = science.compute_bounds();
+    std::array<double, 2> sci_stats = science.compute_mean_std();
+    logger->log(level, "Science: bounds = [" + std::to_string(sci_bnds[0]) + ", " +
+                               std::to_string(sci_bnds[1]) + "], mean = " + std::to_string(sci_stats[0]) +
+                               ", std = " + std::to_string(sci_stats[1]));
+
+    std::array<float, 2> var_bnds = variance.compute_bounds();
+    std::array<double, 2> var_stats = variance.compute_mean_std();
+    logger->log(level, "Variance: bounds = [" + std::to_string(var_bnds[0]) + ", " +
+                               std::to_string(var_bnds[1]) + "], mean = " + std::to_string(var_stats[0]) +
+                               ", std = " + std::to_string(var_stats[1]));
+
+    // Compute the fraction of science pixels that are masked.
+    logger->log(level, "Fraction masked = " + std::to_string(compute_fraction_masked()));
+}
+
 #ifdef Py_PYTHON_H
 static void layered_image_bindings(py::module& m) {
     using li = search::LayeredImage;
@@ -208,6 +242,8 @@ static void layered_image_bindings(py::module& m) {
             .def("contains", &li::contains, pydocs::DOC_LayeredImage_cointains)
             .def("get_science_pixel", &li::get_science_pixel, pydocs::DOC_LayeredImage_get_science_pixel)
             .def("get_variance_pixel", &li::get_variance_pixel, pydocs::DOC_LayeredImage_get_variance_pixel)
+            .def("science_pixel_has_data", &li::science_pixel_has_data,
+                 pydocs::DOC_LayeredImage_science_pixel_has_data)
             .def("contains",
                  [](li& cls, int i, int j) {
                      return cls.contains({i, j});
@@ -219,6 +255,10 @@ static void layered_image_bindings(py::module& m) {
             .def("get_variance_pixel",
                  [](li& cls, int i, int j) {
                      return cls.get_variance_pixel({i, j});
+                 })
+            .def("science_pixel_has_data",
+                 [](li& cls, int i, int j) {
+                     return cls.science_pixel_has_data({i, j});
                  })
             .def("set_psf", &li::set_psf, pydocs::DOC_LayeredImage_set_psf)
             .def("get_psf", &li::get_psf, py::return_value_policy::reference_internal,
@@ -251,6 +291,9 @@ static void layered_image_bindings(py::module& m) {
             .def("get_npixels", &li::get_npixels, pydocs::DOC_LayeredImage_get_npixels)
             .def("get_obstime", &li::get_obstime, pydocs::DOC_LayeredImage_get_obstime)
             .def("set_obstime", &li::set_obstime, pydocs::DOC_LayeredImage_set_obstime)
+            .def("compute_fraction_masked", &li::compute_fraction_masked,
+                 pydocs::DOC_LayeredImage_compute_fraction_masked)
+            .def("log_stats", &li::log_stats, py::arg("level") = "DEBUG", pydocs::DOC_LayeredImage_log_stats)
             .def("generate_psi_image", &li::generate_psi_image, pydocs::DOC_LayeredImage_generate_psi_image)
             .def("generate_phi_image", &li::generate_phi_image, pydocs::DOC_LayeredImage_generate_phi_image);
 }

--- a/src/kbmod/search/layered_image.h
+++ b/src/kbmod/search/layered_image.h
@@ -10,6 +10,7 @@
 #include "raw_image.h"
 #include "common.h"
 #include "pydocs/layered_image_docs.h"
+#include "logging.h"
 
 namespace search {
 class LayeredImage {
@@ -44,6 +45,11 @@ public:
         return mask.get_pixel(idx) == 0 ? variance.get_pixel(idx) : NO_DATA;
     }
 
+    inline bool science_pixel_has_data(const Index& idx) const {
+        // The get_pixel() functions perform the bounds checking and will return NO_DATA for out of bounds.
+        return mask.get_pixel(idx) == 0 ? science.pixel_has_data(idx) : false;
+    }
+
     inline bool contains(const Index& idx) const {
         return idx.i >= 0 && idx.i < height && idx.j >= 0 && idx.j < width;
     }
@@ -73,6 +79,10 @@ public:
     // Generate psi and phi images from the science and variance layers.
     RawImage generate_psi_image();
     RawImage generate_phi_image();
+
+    // Debugging and statistics functions.
+    double compute_fraction_masked() const;
+    void log_stats(std::string level = "DEBUG") const;
 
 private:
     void check_dims(RawImage& im);

--- a/src/kbmod/search/pydocs/image_stack_docs.h
+++ b/src/kbmod/search/pydocs/image_stack_docs.h
@@ -42,7 +42,7 @@ static const auto DOC_ImageStack_build_zeroed_times = R"doc(
 
 static const auto DOC_ImageStack_sort_by_time = R"doc(
   Sort the images in the ImageStack by their time.
-  ")doc";    
+  ")doc";
 
 static const auto DOC_ImageStack_make_global_mask = R"doc(
   Create a new global mask from a set of flags and a threshold.

--- a/src/kbmod/search/pydocs/layered_image_docs.h
+++ b/src/kbmod/search/pydocs/layered_image_docs.h
@@ -207,6 +207,23 @@ static const auto DOC_LayeredImage_get_variance_pixel = R"doc(
       Pixel value.
   )doc";
 
+static const auto DOC_LayeredImage_science_pixel_has_data = R"doc(
+  Checks whether the science pixel has valid data by checking both
+  the value in the science and mask layers.
+
+  Parameters
+  ----------
+  i : `int`
+      Row index.
+  j : `int`
+      Col index.
+
+  Returns
+  -------
+  value : `bool`
+      Whether the science pixel has data.
+  )doc";
+
 static const auto DOC_LayeredImage_generate_psi_image = R"doc(
   Generates the full psi image where the value of each pixel p in the
   resulting image is science[p] / variance[p]. To handle masked bits
@@ -232,6 +249,27 @@ static const auto DOC_LayeredImage_generate_phi_image = R"doc(
   result : `kbmod.RawImage`
       A ``RawImage`` of the same dimensions as the ``LayeredImage``.
   )doc";
+
+static const auto DOC_LayeredImage_compute_fraction_masked = R"doc(
+  Computes the fraction of pixels in the layered image that are masked.
+  This can be used for debugging purposes.
+
+  Returns
+  -------
+  value : `double`
+      The fraction of pixels in the science image that are masked.
+  )doc";
+
+static const auto DOC_LayeredImage_log_stats = R"doc(
+  Compute a range of statistics about the layered image and logs them.
+
+  Parameters
+  ----------
+  level : `str`
+      The logging level. Must be one of DEBUG, INFO, WARNING, ERROR, or CRITICAL.
+      Default: DEBUG
+  )doc";
+
 }  // namespace pydocs
 
 #endif /* LAYEREDIMAGE_DOCS  */

--- a/src/kbmod/search/pydocs/raw_image_docs.h
+++ b/src/kbmod/search/pydocs/raw_image_docs.h
@@ -205,6 +205,15 @@ static const auto DOC_RawImage_compute_bounds = R"doc(
       A ``(min, max)`` tuple.
   )doc";
 
+static const auto DOC_RawImage_compute_mean_std = R"doc(
+  Returns mean and standard deviation of the pixel values, ignoring the masked pixels.
+
+  Returns
+  -------
+  bounds : `tuple`
+      A ``(mean, std)`` tuple.
+  )doc";
+
 static const auto DOC_RawImage_find_peak = R"doc(
   Returns the pixel coordinates of the maximum value.
 

--- a/src/kbmod/search/pydocs/trajectory_list_docs.h
+++ b/src/kbmod/search/pydocs/trajectory_list_docs.h
@@ -64,8 +64,7 @@ static const auto DOC_TrajectoryList_set_trajectories = R"doc(
   Raises a ``RuntimeError`` if the index is invalid or the data currently resides
   on the GPU.
   )doc";
- 
-      
+
 static const auto DOC_TrajectoryList_get_list = R"doc(
   Return the full list of trajectories. The data must reside on the CPU.
 

--- a/src/kbmod/search/raw_image.cpp
+++ b/src/kbmod/search/raw_image.cpp
@@ -185,6 +185,26 @@ std::array<float, 2> RawImage::compute_bounds() const {
     return {min_val, max_val};
 }
 
+std::array<double, 2> RawImage::compute_mean_std() const {
+    double sum = 0.0;
+    double sum_sq = 0.0;
+    double count = 0.0;
+
+    for (auto elem : image.reshaped())
+        if (pixel_value_valid(elem)) {
+            sum += elem;
+            sum_sq += elem * elem;
+            count += 1.0;
+        }
+
+    // Avoid divide by zero.
+    if (count == 0) return {0, 0};
+
+    double mean = sum / count;
+    double std = sqrt(sum_sq / count - mean * mean);
+    return {mean, std};
+}
+
 void RawImage::convolve_cpu(PSF& psf) {
     Image result = Image::Zero(height, width);
 
@@ -513,6 +533,7 @@ static void raw_image_bindings(py::module& m) {
             .def("replace_masked_values", &rie::replace_masked_values, py::arg("value") = 0.0f,
                  pydocs::DOC_RawImage_replace_masked_values)
             .def("compute_bounds", &rie::compute_bounds, pydocs::DOC_RawImage_compute_bounds)
+            .def("compute_mean_std", &rie::compute_mean_std, pydocs::DOC_RawImage_compute_mean_std)
             .def("find_peak", &rie::find_peak, pydocs::DOC_RawImage_find_peak)
             .def("find_central_moments", &rie::find_central_moments,
                  pydocs::DOC_RawImage_find_central_moments)

--- a/src/kbmod/search/raw_image.h
+++ b/src/kbmod/search/raw_image.h
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <assert.h>
+#include <math.h>
 
 #include <Eigen/Core>
 
@@ -99,6 +100,9 @@ public:
 
     // Compute the min and max bounds of values in the image.
     std::array<float, 2> compute_bounds() const;
+
+    // Compute the mean and standard deviation of the valid pixel values.
+    std::array<double, 2> compute_mean_std() const;
 
     // Convolve the image with a point spread function.
     void convolve(PSF psf);

--- a/src/kbmod/search/stamp_creator.cpp
+++ b/src/kbmod/search/stamp_creator.cpp
@@ -65,12 +65,11 @@ std::vector<RawImage> StampCreator::get_coadded_stamps(ImageStack& stack, std::v
                                                        const StampParameters& params, bool use_gpu) {
     if (use_gpu) {
 #ifdef HAVE_CUDA
-        logging::getLogger("kbmod.search.stamp_creator")
-            ->info("Performing co-adds on the GPU.");
+        logging::getLogger("kbmod.search.stamp_creator")->info("Performing co-adds on the GPU.");
         return get_coadded_stamps_gpu(stack, t_array, use_index_vect, params);
 #else
         logging::getLogger("kbmod.search.stamp_creator")
-            ->warning("GPU is not enabled. Performing co-adds on the CPU.");
+                ->warning("GPU is not enabled. Performing co-adds on the CPU.");
 #endif
     }
     return get_coadded_stamps_cpu(stack, t_array, use_index_vect, params);

--- a/tests/test_layered_image.py
+++ b/tests/test_layered_image.py
@@ -14,11 +14,13 @@ from kbmod.search import *
 class test_LayeredImage(unittest.TestCase):
     def setUp(self):
         self.p = PSF(1.0)
+        self.width = 60
+        self.height = 80
 
         # Create a fake layered image to use.
         self.image = make_fake_layered_image(
-            60,  # dim_x = 60 pixels,
-            80,  # dim_y = 80 pixels,
+            self.width,
+            self.height,
             2.0,  # noise_level
             4.0,  # variance
             10.0,  # time = 10.0
@@ -172,10 +174,27 @@ class test_LayeredImage(unittest.TestCase):
 
     def test_mask_pixel(self):
         self.image.mask_pixel(10, 15)
+        self.image.mask_pixel(22, 23)
         for y in range(self.image.get_height()):
             for x in range(self.image.get_width()):
                 pix_val = self.image.get_science_pixel(y, x)
-                self.assertEqual(pixel_value_valid(pix_val), x != 15 or y != 10)
+                expected = not ((x == 15 and y == 10) or (x == 23 and y == 22))
+                self.assertEqual(pixel_value_valid(pix_val), expected)
+                self.assertEqual(self.image.science_pixel_has_data(y, x), expected)
+
+    def test_compute_fraction_masked(self):
+        total_pixels = self.width * self.height
+
+        # Mask 50 pixels
+        for y in range(0, 10):
+            for x in range(0, 5):
+                self.image.mask_pixel(y, x)
+        self.assertAlmostEqual(self.image.compute_fraction_masked(), 50.0 / total_pixels)
+
+        # Mask another 25 pixels.
+        for x in range(3, 28):
+            self.image.mask_pixel(12, x)
+        self.assertAlmostEqual(self.image.compute_fraction_masked(), 75.0 / total_pixels)
 
     def test_binarize_mask(self):
         # Mask out a range of pixels.

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -183,7 +183,7 @@ class test_RawImage(unittest.TestCase):
         img.set_all(15.0)
         self.assertTrue((img.image == 15).all())
 
-    def test_get_bounds(self):
+    def test_compute_bounds(self):
         """Test RawImage masked min/max bounds."""
         img = RawImage(self.masked_array)
         lower, upper = img.compute_bounds()
@@ -196,6 +196,13 @@ class test_RawImage(unittest.TestCase):
         lower, upper = img.compute_bounds()
         self.assertAlmostEqual(lower, 0.1, delta=1e-6)
         self.assertAlmostEqual(upper, 100.0, delta=1e-6)
+
+    def test_compute_mean_std(self):
+        """Test RawImage masked min/max bounds."""
+        img = RawImage(self.masked_array)
+        mean, std = img.compute_mean_std()
+        self.assertAlmostEqual(mean, np.nanmean(img.image.flatten()), delta=1e-6)
+        self.assertAlmostEqual(std, np.nanstd(img.image.flatten()), delta=1e-6)
 
     def test_replace_masked_values(self):
         img2 = RawImage(np.copy(self.masked_array))


### PR DESCRIPTION
Adds some functions for getting statistics about the input data that I found myself computing by hand in notebooks, including:
- The mean and standard deviation of values in an image
- The fraction of pixels that are masked within an image
As well as a function to dump this information (and more) to a logger.

This will probably only be used during manual debugging.