### PR TITLE
Remove configuration strict checking

### DIFF
--- a/docs/source/user_manual/search_params.rst
+++ b/docs/source/user_manual/search_params.rst
@@ -122,9 +122,6 @@ This document serves to provide a quick overview of the existing parameters and 
 |                        |                             | ``[xx, yy, xy, x, y]``.                |
 |                        |                             | If ``do_stamp_filter=True``.           |
 +------------------------+-----------------------------+----------------------------------------+
-| ``num_cores``          | 1                           | The number of threads  to use for      |
-|                        |                             | parallel filtering.                    |
-+------------------------+-----------------------------+----------------------------------------+
 | ``num_obs``            | 10                          | The minimum number of non-masked       |
 |                        |                             | observations for the object to be      |
 |                        |                             | accepted.                              |

--- a/src/kbmod/configuration.py
+++ b/src/kbmod/configuration.py
@@ -69,7 +69,6 @@ class SearchConfiguration:
             "max_lh": 1000.0,
             "mjd_lims": None,
             "mom_lims": [35.5, 35.5, 2.0, 0.3, 0.3],
-            "num_cores": 1,
             "num_obs": 10,
             "output_suffix": "search",
             "peak_offset": [2.0, 2.0],
@@ -110,7 +109,7 @@ class SearchConfiguration:
             result += f"{key}: {value}\n"
         return result
 
-    def set(self, param, value, strict=True):
+    def set(self, param, value, strict=False):
         """Sets the value of a specific parameter.
 
         Parameters
@@ -134,7 +133,7 @@ class SearchConfiguration:
         else:
             self._params[param] = value
 
-    def set_multiple(self, overrides, strict=True):
+    def set_multiple(self, overrides, strict=False):
         """Sets multiple parameters from a dictionary.
 
         Parameters
@@ -164,7 +163,7 @@ class SearchConfiguration:
                 raise ValueError(f"Required configuration parameter {p} missing.")
 
     @classmethod
-    def from_dict(cls, d, strict=True):
+    def from_dict(cls, d, strict=False):
         """Sets multiple values from a dictionary.
 
         Parameters
@@ -185,7 +184,7 @@ class SearchConfiguration:
         return config
 
     @classmethod
-    def from_table(cls, t, strict=True):
+    def from_table(cls, t, strict=False):
         """Sets multiple values from an astropy Table with a single row and
         one column for each parameter.
 
@@ -211,7 +210,7 @@ class SearchConfiguration:
         return SearchConfiguration.from_dict(params)
 
     @classmethod
-    def from_yaml(cls, config, strict=True):
+    def from_yaml(cls, config, strict=False):
         """Load a configuration from a YAML file.
 
         Parameters
@@ -230,7 +229,7 @@ class SearchConfiguration:
         return SearchConfiguration.from_dict(yaml_params, strict)
 
     @classmethod
-    def from_hdu(cls, hdu, strict=True):
+    def from_hdu(cls, hdu, strict=False):
         """Load a configuration from a FITS extension file.
 
         Parameters
@@ -249,7 +248,7 @@ class SearchConfiguration:
         return SearchConfiguration.from_table(t)
 
     @classmethod
-    def from_file(cls, filename, strict=True):
+    def from_file(cls, filename, strict=False):
         with open(filename) as ff:
             return SearchConfiguration.from_yaml(ff.read(), strict)
 

--- a/src/kbmod/configuration.py
+++ b/src/kbmod/configuration.py
@@ -109,7 +109,7 @@ class SearchConfiguration:
             result += f"{key}: {value}\n"
         return result
 
-    def set(self, param, value, strict=False):
+    def set(self, param, value):
         """Sets the value of a specific parameter.
 
         Parameters
@@ -118,35 +118,18 @@ class SearchConfiguration:
             The parameter name.
         value : any
             The parameter's value.
-        strict : `bool`
-            Raise an exception on unknown parameters.
-
-        Raises
-        ------
-        Raises a ``KeyError`` if the parameter is not part on the list of known parameters
-        and ``strict`` is False.
         """
         if param not in self._params:
-            if strict:
-                raise KeyError(f"Invalid parameter: {param}")
-            logger.warning(f"Ignoring invalid parameter: {param}")
-        else:
-            self._params[param] = value
+            logger.warning(f"Setting unknown parameter: {param}")
+        self._params[param] = value
 
-    def set_multiple(self, overrides, strict=False):
+    def set_multiple(self, overrides):
         """Sets multiple parameters from a dictionary.
 
         Parameters
         ----------
         overrides : `dict`
             A dictionary of parameter->value to overwrite.
-        strict : `bool`
-            Raise an exception on unknown parameters.
-
-        Raises
-        ------
-        Raises a ``KeyError`` if any parameter is not part on the list of known parameters
-        and ``strict`` is False.
         """
         for key, value in overrides.items():
             self.set(key, value)
@@ -163,28 +146,21 @@ class SearchConfiguration:
                 raise ValueError(f"Required configuration parameter {p} missing.")
 
     @classmethod
-    def from_dict(cls, d, strict=False):
+    def from_dict(cls, d):
         """Sets multiple values from a dictionary.
 
         Parameters
         ----------
         d : `dict`
             A dictionary mapping parameter name to valie.
-        strict : `bool`
-            Raise an exception on unknown parameters.
-
-        Raises
-        ------
-        Raises a ``KeyError`` if the parameter is not part on the list of known parameters
-        and ``strict`` is False.
         """
         config = SearchConfiguration()
         for key, value in d.items():
-            config.set(key, value, strict)
+            config.set(key, value)
         return config
 
     @classmethod
-    def from_table(cls, t, strict=False):
+    def from_table(cls, t):
         """Sets multiple values from an astropy Table with a single row and
         one column for each parameter.
 
@@ -210,47 +186,33 @@ class SearchConfiguration:
         return SearchConfiguration.from_dict(params)
 
     @classmethod
-    def from_yaml(cls, config, strict=False):
+    def from_yaml(cls, config):
         """Load a configuration from a YAML file.
 
         Parameters
         ----------
         config : `str` or `_io.TextIOWrapper`
             The serialized YAML data.
-        strict : `bool`
-            Raise an exception on unknown parameters.
-
-        Raises
-        ------
-        Raises a ``KeyError`` if the parameter is not part on the list of known parameters
-        and ``strict`` is False.
         """
         yaml_params = safe_load(config)
-        return SearchConfiguration.from_dict(yaml_params, strict)
+        return SearchConfiguration.from_dict(yaml_params)
 
     @classmethod
-    def from_hdu(cls, hdu, strict=False):
+    def from_hdu(cls, hdu):
         """Load a configuration from a FITS extension file.
 
         Parameters
         ----------
         hdu : `astropy.io.fits.BinTableHDU`
             The HDU from which to parse the configuration information.
-        strict : `bool`
-            Raise an exception on unknown parameters.
-
-        Raises
-        ------
-        Raises a ``KeyError`` if the parameter is not part on the list of known parameters
-        and ``strict`` is False.
         """
         t = Table(hdu.data)
         return SearchConfiguration.from_table(t)
 
     @classmethod
-    def from_file(cls, filename, strict=False):
+    def from_file(cls, filename):
         with open(filename) as ff:
-            return SearchConfiguration.from_yaml(ff.read(), strict)
+            return SearchConfiguration.from_yaml(ff.read())
 
     def to_hdu(self):
         """Create a fits HDU with all the configuration parameters.

--- a/src/kbmod/data_interface.py
+++ b/src/kbmod/data_interface.py
@@ -281,12 +281,12 @@ def load_input_from_file(filename, overrides=None):
     if path_suffix == ".yml" or path_suffix == ".yaml":
         # Try loading as a WorkUnit first.
         with open(filename) as ff:
-            work = WorkUnit.from_yaml(ff.read(), strict=False)
+            work = WorkUnit.from_yaml(ff.read())
 
         # If that load did not work, try loading the file as a configuration
         # and then using that to load the data files.
         if work is None:
-            config = SearchConfiguration.from_file(filename, strict=False)
+            config = SearchConfiguration.from_file(filename)
             if overrides is not None:
                 config.set_multiple(overrides)
             if config["im_filepath"] is not None:

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -74,9 +74,6 @@ class SearchRunner:
         chunk_size = config["chunk_size"]
         if chunk_size <= 0:
             raise ValueError(f"Invalid chunk size {chunk_size}")
-        num_cores = config["num_cores"]
-        if num_cores <= 0:
-            raise ValueError(f"Invalid number of cores {num_cores}")
 
         # Set up the list of results.
         img_stack = search.get_imagestack()

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -30,9 +30,6 @@ class test_configuration(unittest.TestCase):
         self.assertEqual(config["im_filepath"], "Here")
         self.assertEqual(config["encode_num_bytes"], 2)
 
-        # The set should fail when using unknown parameters and strict checking.
-        self.assertRaises(KeyError, config.set, "My_new_param", 100, strict=True)
-
     def set_multiple(self):
         config = SearchConfiguration()
         self.assertIsNone(config["im_filepath"])


### PR DESCRIPTION
Strict checking was meant to confirm that users didn't accidentally mistype a parameter name. But it keeps us from easily removing parameters while maintaining backwards compatibility with old configs. Change this to log a warning when an unrecognized parameter is added.

Also removes the deprecated `num_cores` parameter.