### PR TITLE
Add more output and debugging options for Results

### DIFF
--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -2,6 +2,7 @@
 and helper functions for filtering and maintaining consistency between different attributes in each row.
 """
 
+import csv
 import logging
 import numpy as np
 import os.path as ospath
@@ -602,6 +603,7 @@ class Results:
         ------
         Raises a KeyError if the column is not in the data.
         """
+        logger.info(f"Writing {colname} column data to {filename}")
         if colname not in self.table.colnames:
             raise KeyError(f"Column {colname} missing from data.")
         data = np.array(self.table[colname])
@@ -634,6 +636,21 @@ class Results:
                 f"Error loading {filename}: expected {len(self.table)} entries, but found {len(data)}."
             )
         self.table[colname] = data
+
+    def write_filtered_stats(self, filename):
+        """Write out the filtering statistics to a human readable CSV file.
+
+        Parameters
+        ----------
+        filename : `str`
+            The name of the file to write.
+        """
+        logger.info(f"Saving results filter statistics to {filename}.")
+        with open(filename, "w") as f:
+            writer = csv.writer(f)
+            writer.writerow(["unfiltered", len(self.table)])
+            for key, value in self.filtered_stats.items():
+                writer.writerow([key, value])
 
     @classmethod
     def from_trajectory_file(cls, filename, track_filtered=False):

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -279,6 +279,10 @@ class SearchRunner:
 
             config_filename = os.path.join(config["res_filepath"], f"config_{config['output_suffix']}.yml")
             config.to_file(config_filename, overwrite=True)
+
+            if "all_stamps" in keep.colnames:
+                keep.write_column("all_stamps", f"all_stamps_{config['output_suffix']}.npy")
+
         if config["result_filename"] is not None:
             if not config["save_all_stamps"]:
                 keep.write_table(config["result_filename"], cols_to_drop=["all_stamps"])

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -280,6 +280,11 @@ class SearchRunner:
             config_filename = os.path.join(config["res_filepath"], f"config_{config['output_suffix']}.yml")
             config.to_file(config_filename, overwrite=True)
 
+            stats_filename = os.path.join(
+                config["res_filepath"], f"filter_stats_{config['output_suffix']}.csv"
+            )
+            keep.write_filtered_stats(stats_filename)
+
             if "all_stamps" in keep.colnames:
                 keep.write_column("all_stamps", f"all_stamps_{config['output_suffix']}.npy")
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -110,6 +110,22 @@ class test_results(unittest.TestCase):
             self.assertEqual(trj.flux, table["flux"][i])
             self.assertEqual(trj.lh, table["likelihood"][i])
 
+    def test_remove_column(self):
+        self.input_dict["something_added"] = [i for i in range(self.num_entries)]
+        table = Results(self.input_dict)
+        self.assertTrue("something_added" in table.colnames)
+
+        # Can't drop a column that is not there.
+        with self.assertRaises(KeyError):
+            table.remove_column("missing_column")
+
+        table.remove_column("something_added")
+        self.assertFalse("something_added" in table.colnames)
+
+        # Can't drop a required column.
+        with self.assertRaises(KeyError):
+            table.remove_column("x")
+
     def test_extend(self):
         table1 = Results.from_trajectories(self.trj_list)
         for i in range(self.num_entries):


### PR DESCRIPTION
Add more outputting and debugging options, including:

1) Allow the `Results` data structure to save and load individual columns. This is used when a column may be large and the user does not want to include it in the main table. For example we often remove the "all_stamps" column when saving the data into a table. This way we can write it into its own file and later load/join it.

2) Provide a `remove_column()` function that checks for required columns.

3) Add a function to save the `filtered_stats` data in human readable form.