### PR TITLE
Create more verbose kernel errors

### DIFF
--- a/src/kbmod/search/kernels/kernel_memory.cu
+++ b/src/kbmod/search/kernels/kernel_memory.cu
@@ -7,12 +7,7 @@
 #ifndef KERNELS_MEMORY_CU_
 #define KERNELS_MEMORY_CU_
 
-#include <float.h>
-#include <string.h>
-#include <stdexcept>
-#include <vector>
-
-#include "cuda_errors.h"
+#include "kernel_memory.h"
 
 namespace search {
 
@@ -22,31 +17,40 @@ namespace search {
 
 extern "C" void *allocate_gpu_block(unsigned long memory_size) {
     void *gpu_ptr;
-    cudaError_t res = cudaMalloc((void **)&gpu_ptr, memory_size);
-    if (res != 0) throw std::runtime_error("Unable to allocate GPU memory. Error = " + std::to_string(res));
+    unsigned int res = static_cast<unsigned int>(cudaMalloc((void **)&gpu_ptr, memory_size));
+    if ((res != 0) || (gpu_ptr == nullptr)) {
+        throw std::runtime_error("Unable to allocate GPU memory (" + std::to_string(memory_size) +
+                                 " bytes). Error code = " + std::to_string(res));
+    }
     return gpu_ptr;
 }
 
 extern "C" void free_gpu_block(void *gpu_ptr) {
     if (gpu_ptr == nullptr) throw std::runtime_error("Trying to free nullptr.");
-    cudaError_t res = cudaFree(gpu_ptr);
-    if (res != 0) throw std::runtime_error("Unable to free GPU memory. Error = " + std::to_string(res));
+    unsigned int res = static_cast<unsigned int>(cudaFree(gpu_ptr));
+    if (res != 0) {
+        throw std::runtime_error("Unable to free GPU memory. Error code = " + std::to_string(res));
+    }
 }
 
 extern "C" void copy_block_to_gpu(void *cpu_ptr, void *gpu_ptr, unsigned long memory_size) {
     if (cpu_ptr == nullptr) throw std::runtime_error("Invalid CPU pointer");
     if (gpu_ptr == nullptr) throw std::runtime_error("Invalid GPU pointer");
-
-    cudaError_t res = cudaMemcpy(gpu_ptr, cpu_ptr, memory_size, cudaMemcpyHostToDevice);
-    if (res != 0) throw std::runtime_error("Unable to copy data to GPU. Error = " + std::to_string(res));
+    unsigned int res = static_cast<unsigned int>(cudaMemcpy(gpu_ptr, cpu_ptr, memory_size, cudaMemcpyHostToDevice));
+    if (res != 0) {
+        throw std::runtime_error("Unable to copy data to GPU (" + std::to_string(memory_size) +
+                                 " bytes). Error code = " + std::to_string(res));
+    }
 }
 
 extern "C" void copy_block_to_cpu(void *cpu_ptr, void *gpu_ptr, unsigned long memory_size) {
     if (cpu_ptr == nullptr) throw std::runtime_error("Invalid CPU pointer");
     if (gpu_ptr == nullptr) throw std::runtime_error("Invalid GPU pointer");
-
-    cudaError_t res = cudaMemcpy(cpu_ptr, gpu_ptr, memory_size, cudaMemcpyDeviceToHost);
-    if (res != 0) throw std::runtime_error("Unable to copy data to CPU. Error = " + std::to_string(res));
+    unsigned int res = static_cast<unsigned int>(cudaMemcpy(cpu_ptr, gpu_ptr, memory_size, cudaMemcpyDeviceToHost));
+    if (res != 0) {
+        throw std::runtime_error("Unable to copy data to CPU (" + std::to_string(memory_size) +
+                                 " bytes). Error code = " + std::to_string(res));
+    }
 }
 
 } /* namespace search */

--- a/src/kbmod/search/kernels/kernel_memory.cu
+++ b/src/kbmod/search/kernels/kernel_memory.cu
@@ -7,8 +7,9 @@
 #ifndef KERNELS_MEMORY_CU_
 #define KERNELS_MEMORY_CU_
 
-#include <stdexcept>
 #include <float.h>
+#include <string.h>
+#include <stdexcept>
 #include <vector>
 
 #include "cuda_errors.h"
@@ -21,28 +22,31 @@ namespace search {
 
 extern "C" void *allocate_gpu_block(unsigned long memory_size) {
     void *gpu_ptr;
-    checkCudaErrors(cudaMalloc((void **)&gpu_ptr, memory_size));
-    if (gpu_ptr == nullptr) throw std::runtime_error("Unable to allocate GPU memory.");
+    cudaError_t res = cudaMalloc((void **)&gpu_ptr, memory_size);
+    if (res != 0) throw std::runtime_error("Unable to allocate GPU memory. Error = " + std::to_string(res));
     return gpu_ptr;
 }
 
 extern "C" void free_gpu_block(void *gpu_ptr) {
     if (gpu_ptr == nullptr) throw std::runtime_error("Trying to free nullptr.");
-    checkCudaErrors(cudaFree(gpu_ptr));
+    cudaError_t res = cudaFree(gpu_ptr);
+    if (res != 0) throw std::runtime_error("Unable to free GPU memory. Error = " + std::to_string(res));
 }
 
 extern "C" void copy_block_to_gpu(void *cpu_ptr, void *gpu_ptr, unsigned long memory_size) {
     if (cpu_ptr == nullptr) throw std::runtime_error("Invalid CPU pointer");
     if (gpu_ptr == nullptr) throw std::runtime_error("Invalid GPU pointer");
 
-    checkCudaErrors(cudaMemcpy(gpu_ptr, cpu_ptr, memory_size, cudaMemcpyHostToDevice));
+    cudaError_t res = cudaMemcpy(gpu_ptr, cpu_ptr, memory_size, cudaMemcpyHostToDevice);
+    if (res != 0) throw std::runtime_error("Unable to copy data to GPU. Error = " + std::to_string(res));
 }
 
 extern "C" void copy_block_to_cpu(void *cpu_ptr, void *gpu_ptr, unsigned long memory_size) {
     if (cpu_ptr == nullptr) throw std::runtime_error("Invalid CPU pointer");
     if (gpu_ptr == nullptr) throw std::runtime_error("Invalid GPU pointer");
 
-    checkCudaErrors(cudaMemcpy(cpu_ptr, gpu_ptr, memory_size, cudaMemcpyDeviceToHost));
+    cudaError_t res = cudaMemcpy(cpu_ptr, gpu_ptr, memory_size, cudaMemcpyDeviceToHost);
+    if (res != 0) throw std::runtime_error("Unable to copy data to CPU. Error = " + std::to_string(res));
 }
 
 } /* namespace search */

--- a/src/kbmod/search/kernels/kernel_memory.h
+++ b/src/kbmod/search/kernels/kernel_memory.h
@@ -1,11 +1,15 @@
 /*
  * kernel_memory.h
  *
- * Helper functions for transfering KBMOD data to/from GPU.
+ * Helper functions for transfering KBMOD data to/from GPU. The functions throw
+ * std::runtime_error that can be propagated back to python via pybind11.
  */
 
 #ifndef KERNELS_MEMORY_H_
 #define KERNELS_MEMORY_H_
+
+#include <string.h>
+#include <stdexcept>
 
 namespace search {
 

--- a/src/kbmod/search/kernels/kernels.cu
+++ b/src/kbmod/search/kernels/kernels.cu
@@ -17,11 +17,11 @@
 #include <float.h>
 
 #include "../common.h"
-#include "cuda_errors.h"
 #include "../gpu_array.h"
 #include "../psi_phi_array_ds.h"
 #include "../trajectory_list.h"
 
+#include "cuda_errors.h"
 #include "kernel_memory.h"
 
 namespace search {


### PR DESCRIPTION
The cuda errors are not being propagated back to python correctly. For memory management failures, directly format an error string and throw a std::runtime_error.