### PR TITLE
Log warning if running without GPU

### DIFF
--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -220,6 +220,9 @@ class SearchRunner:
         keep : `Results`
             The results.
         """
+        if not kb.HAS_GPU:
+            logger.warning("Code was compiled without GPU.")
+
         full_timer = kb.DebugTimer("KBMOD", logger)
 
         # Apply the mask to the images.


### PR DESCRIPTION
Create a clear warning if you try to run search with the GPU turned off.