### PR TITLE
Replace asserts in C++ code with throw std::runtime_error

### DIFF
--- a/src/kbmod/search/common.h
+++ b/src/kbmod/search/common.h
@@ -7,9 +7,6 @@
 
 #include "pydocs/common_docs.h"
 
-// assert(condition, message if !condition)
-#define assertm(exp, msg) assert(((void)msg, exp))
-
 namespace search {
 #ifdef HAVE_CUDA
 constexpr bool HAVE_GPU = true;

--- a/src/kbmod/search/geom.h
+++ b/src/kbmod/search/geom.h
@@ -6,7 +6,6 @@
 #include <utility>  // pair
 #include <array>
 #include <vector>
-#include <assert.h>
 
 #include <Eigen/Core>
 
@@ -147,8 +146,8 @@ inline std::tuple<int, int, int> centered_range(int val, const int r, const int 
 inline Rectangle anchored_block(const Index& idx, const int r, const unsigned width, const unsigned height) {
     auto [top, bot, rangei] = centered_range(idx.i, r, height);
     auto [left, right, rangej] = centered_range(idx.j, r, width);
-    assertm(rangei > 0, "Selected block lies outside of the image limits.");
-    assertm(rangej > 0, "Selected block lies outside of the image limits.");
+    if (rangei <= 0) throw std::runtime_error("Selected block lies outside of the image limits.");
+    if (rangej <= 0) throw std::runtime_error("Selected block lies outside of the image limits.");
 
     int anchor_top = std::max(r - idx.i, 0);
     int anchor_left = std::max(r - idx.j, 0);

--- a/src/kbmod/search/kernels/image_kernels.cu
+++ b/src/kbmod/search/kernels/image_kernels.cu
@@ -8,7 +8,6 @@
 #ifndef IMAGE_KERNELS_CU_
 #define IMAGE_KERNELS_CU_
 
-#include <assert.h>
 #include "../common.h"
 #include "cuda_errors.h"
 #include <stdio.h>

--- a/src/kbmod/search/kernels/kernels.cu
+++ b/src/kbmod/search/kernels/kernels.cu
@@ -10,6 +10,7 @@
 #define MAX_NUM_IMAGES 140
 #define MAX_STAMP_IMAGES 200
 
+#include <assert.h>
 #include <cmath>
 #include <stdexcept>
 #include <vector>
@@ -342,7 +343,6 @@ __global__ void deviceGetCoaddStamp(int num_images, int width, int height, float
     int pixel_index = stamp_width * stamp_y + stamp_x;
 
     // Allocate space for the coadd information.
-    assertm(num_images < MAX_STAMP_IMAGES, "Number of images exceedes MAX_STAMP_IMAGES");
     float values[MAX_STAMP_IMAGES];
 
     // Loop over each image and compute the stamp.
@@ -420,6 +420,11 @@ void deviceGetCoadds(const unsigned int num_images, const unsigned int width, co
                      std::vector<float *> data_refs, std::vector<double> &image_times,
                      std::vector<Trajectory> &trajectories, StampParameters params,
                      std::vector<std::vector<bool>> &use_index_vect, float *results) {
+    if (num_images >= MAX_STAMP_IMAGES) {
+        throw std::runtime_error("Number of images=" + std::to_string(num_images) +
+                                 " exceedes MAX_STAMP_IMAGES=" + std::to_string(MAX_STAMP_IMAGES));
+    }
+
     // Compute the dimensions for the data.
     const unsigned int num_trajectories = trajectories.size();
     const unsigned int num_image_pixels = num_images * width * height;
@@ -442,8 +447,9 @@ void deviceGetCoadds(const unsigned int num_images, const unsigned int width, co
         int *start_ptr = device_use_index;
         std::vector<int> int_vect(num_images, 0);
         for (unsigned i = 0; i < num_trajectories; ++i) {
-            assertm(use_index_vect[i].size() == num_images,
-                    "Number of images and indices selected for processing do not match");
+            if (use_index_vect[i].size() != num_images) {
+                throw std::runtime_error("Number of images and indices do not match");
+            }
             for (unsigned t = 0; t < num_images; ++t) {
                 int_vect[t] = use_index_vect[i][t] ? 1 : 0;
             }

--- a/src/kbmod/search/layered_image.cpp
+++ b/src/kbmod/search/layered_image.cpp
@@ -125,7 +125,9 @@ void LayeredImage::grow_mask(int steps) {
 }
 
 void LayeredImage::subtract_template(RawImage& sub_template) {
-    assert(get_height() == sub_template.get_height() && get_width() == sub_template.get_width());
+    if (get_height() != sub_template.get_height() || get_width() != sub_template.get_width()) {
+        throw std::runtime_error("Template image size does not match LayeredImage size.");
+    }
     const int num_pixels = get_npixels();
 
     logging::getLogger("kbmod.search.layered_image")->debug("Subtracting template image.");

--- a/src/kbmod/search/layered_image.h
+++ b/src/kbmod/search/layered_image.h
@@ -5,7 +5,6 @@
 #include <iostream>
 #include <string>
 #include <random>
-#include <assert.h>
 #include <stdexcept>
 #include "raw_image.h"
 #include "common.h"

--- a/src/kbmod/search/raw_image.cpp
+++ b/src/kbmod/search/raw_image.cpp
@@ -179,8 +179,8 @@ std::array<float, 2> RawImage::compute_bounds() const {
         }
 
     // Assert that we have seen at least some valid data.
-    assert(max_val != -FLT_MAX);
-    assert(min_val != FLT_MAX);
+    if (max_val == -FLT_MAX) throw std::runtime_error("No max value found in RawImage.");
+    if (min_val == FLT_MAX) throw std::runtime_error("No min value found in RawImage.");
 
     return {min_val, max_val};
 }
@@ -379,12 +379,14 @@ bool RawImage::center_is_local_max(double flux_thresh, bool local_max) const {
 // and image stack
 RawImage create_median_image(const std::vector<RawImage>& images) {
     int num_images = images.size();
-    assert(num_images > 0);
+    if (num_images <= 0) throw std::runtime_error("Unable to create median image given 0 images.");
 
     int width = images[0].get_width();
     int height = images[0].get_height();
     for (auto& img : images) {
-        assert(img.get_width() == width and img.get_height() == height);
+        if (img.get_width() != width || img.get_height() != height) {
+            throw std::runtime_error("Can not sum images with different dimensions.");
+        }
     }
 
     Image result = Image::Zero(height, width);
@@ -425,11 +427,15 @@ RawImage create_median_image(const std::vector<RawImage>& images) {
 
 RawImage create_summed_image(const std::vector<RawImage>& images) {
     int num_images = images.size();
-    assert(num_images > 0);
+    if (num_images <= 0) throw std::runtime_error("Unable to create summed image given 0 images.");
 
     int width = images[0].get_width();
     int height = images[0].get_height();
-    for (auto& img : images) assert(img.get_width() == width and img.get_height() == height);
+    for (auto& img : images) {
+        if (img.get_width() != width || img.get_height() != height) {
+            throw std::runtime_error("Can not sum images with different dimensions.");
+        }
+    }
 
     Image result = Image::Zero(height, width);
     for (auto& img : images) {
@@ -446,13 +452,15 @@ RawImage create_summed_image(const std::vector<RawImage>& images) {
 
 RawImage create_mean_image(const std::vector<RawImage>& images) {
     int num_images = images.size();
-    assert(num_images > 0);
+    if (num_images <= 0) throw std::runtime_error("Unable to create mean image given 0 images.");
 
     int width = images[0].get_width();
     int height = images[0].get_height();
-    for (auto& img : images)
-        assertm(img.get_width() == width and img.get_height() == height,
-                "Can not sum images with different dimensions.");
+    for (auto& img : images) {
+        if (img.get_width() != width || img.get_height() != height) {
+            throw std::runtime_error("Can not sum images with different dimensions.");
+        }
+    }
 
     Image result = Image::Zero(height, width);
     for (int y = 0; y < height; ++y) {

--- a/src/kbmod/search/raw_image.h
+++ b/src/kbmod/search/raw_image.h
@@ -5,7 +5,6 @@
 #include <float.h>
 #include <iostream>
 #include <stdexcept>
-#include <assert.h>
 #include <math.h>
 
 #include <Eigen/Core>

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -9,7 +9,6 @@
 #include <sstream>  // formatting log msgs
 #include <chrono>
 #include <stdexcept>
-#include <assert.h>
 #include <float.h>
 
 #include "logging.h"

--- a/src/kbmod/search/stamp_creator.cpp
+++ b/src/kbmod/search/stamp_creator.cpp
@@ -185,8 +185,9 @@ std::vector<RawImage> StampCreator::get_coadded_stamps_gpu(ImageStack& stack,
         // should not accept images of different sizes being added to the stack
         // and then get rid of all these for loops in the code
         auto& sci = stack.get_single_image(t).get_science().get_image();
-        assertm(sci.cols() == width, "Stack image has different width than 0th image.");
-        assertm(sci.rows() == height, "Stack image has different width than 0th image.");
+        if ((sci.cols() != width) || (sci.rows() != height)) {
+            throw std::runtime_error("Stack image has different dimensions than 0th image.");
+        }
         data_refs[t] = sci.data();
     }
 

--- a/tests/test_layered_image.py
+++ b/tests/test_layered_image.py
@@ -399,6 +399,11 @@ class test_LayeredImage(unittest.TestCase):
                     val2 = sci.get_pixel(y, x)
                     self.assertAlmostEqual(val1, val2, delta=1e-5)
 
+        # Test that we fail when the template size does not match.
+        template2 = RawImage(self.image.get_width(), self.image.get_height() + 1)
+        template2.set_all(0.0)
+        self.assertRaises(RuntimeError, self.image.sub_template, template2)
+
     def test_read_write_files(self):
         with tempfile.TemporaryDirectory() as dir_name:
             im1 = make_fake_layered_image(

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -583,6 +583,12 @@ class test_RawImage(unittest.TestCase):
         self.assertEqual(median_image.height, 3)
         self.assertTrue(np.allclose(median_image.image, expected, atol=1e-6))
 
+        # Check that we throw an error for an empty array or mismatched sizes.
+        self.assertRaises(RuntimeError, create_median_image, [])
+        img1 = RawImage(np.array([1.0, 2.0, 3.0], dtype=np.single))
+        img2 = RawImage(np.array([1.0, 2.0], dtype=np.single))
+        self.assertRaises(RuntimeError, create_median_image, [img1, img2])
+
     def test_create_summed_image(self):
         arrs = np.array(
             [
@@ -611,6 +617,12 @@ class test_RawImage(unittest.TestCase):
         self.assertEqual(summed_image.width, 2)
         self.assertEqual(summed_image.height, 3)
         self.assertTrue(np.allclose(expected, summed_image.image, atol=1e-6))
+
+        # Check that we throw an error for an empty array or mismatched sizes.
+        self.assertRaises(RuntimeError, create_summed_image, [])
+        img1 = RawImage(np.array([1.0, 2.0, 3.0], dtype=np.single))
+        img2 = RawImage(np.array([1.0, 2.0], dtype=np.single))
+        self.assertRaises(RuntimeError, create_summed_image, [img1, img2])
 
     def test_create_mean_image(self):
         arrs = np.array(
@@ -643,6 +655,12 @@ class test_RawImage(unittest.TestCase):
         self.assertEqual(mean_image.width, 2)
         self.assertEqual(mean_image.height, 3)
         self.assertTrue(np.allclose(mean_image.image, expected, atol=1e-6))
+
+        # Check that we throw an error for an empty array or mismatched sizes.
+        self.assertRaises(RuntimeError, create_mean_image, [])
+        img1 = RawImage(np.array([1.0, 2.0, 3.0], dtype=np.single))
+        img2 = RawImage(np.array([1.0, 2.0], dtype=np.single))
+        self.assertRaises(RuntimeError, create_mean_image, [img1, img2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replace asserts in C++ code with throw std::runtime_error to both providing more meaningful error messages and also allow them to be caught easily in Python.