### PR TITLE
Overhaul clustering

### DIFF
--- a/docs/source/user_manual/results_filtering.rst
+++ b/docs/source/user_manual/results_filtering.rst
@@ -41,24 +41,30 @@ Clustering
 
 Clustering is used to combine duplicates found during the initial search. Since each combination of starting pixels and velocity is considered separately, we might see multiple results corresponding to the same true object. For example, if we have an object starting at pixel (10, 15) we might see enough brightness in an adjacent pixel (10, 16) to register a trajectory starting in that location as well.
 
-Two `scikit-learn <https://scikit-learn.org/stable/>`_ algorithms are supported for clustering the trajectories, ``DBSCAN`` and ``OPTICS``, specified by the parameter ``cluster_function``. Either algorithm can cluster the results based on a combination of position, velocity, and angle as specified by the parameter cluster_type, which can take on the values of:
+The `scikit-learn <https://scikit-learn.org/stable/>`_ ``DBSCAN`` algorithm performs clustering the trajectories. The algorithm can cluster the results based on a combination of position, velocity, and angle as specified by the parameter cluster_type, which can take on the values of:
 
-* ``all`` - Use scaled x position, scaled y position, scale velocity, and scaled angle as coordinates for clustering.
-* ``position`` - Use only scaled x position and scaled y position as coordinates for clustering.
-* ``mid_position`` - Use the (scaled) predicted position at the middle time as coordinates for clustering.
+* ``all`` - Use scaled x position, scaled y position, scaled velocity, and scaled angle as coordinates for clustering.
+* ``position`` - Use only the trajectory's scaled (x, y) position at the first timestep for clustering.
+* ``position_unscaled`` - Use only trajctory's (x, y) position at the first timestep for clustering.
+* ``mid_position`` - Use the (scaled) predicted position at the median time as coordinates for clustering.
+* ``mid_position_unscaled`` - Use the predicted position at the median time as coordinates for clustering.
+* ``start_end_position`` - Use the (scaled) predicted positions at the start and end times as coordinates for clustering.
+* ``start_end_position_unscaled`` - Use the predicted positions at the start and end times as coordinates for clustering.
+
+Most of the clustering approaches rely on predicted positions at different times. For example midpoint-based clustering will encode each trajectory `(x0, y0, xv, yv)` as a 2-dimensional point `(x0 + tm * xv, y0 + tm + yv)` where `tm` is the median time. Thus trajectories only need to be close at time=`tm` to be merged into a single trajectory. In contrast the start and eng based clustering will encode the same trajectory as a 4-dimensional point (x0, y0, x0 + te * xv, y0 + te + yv)` where `te` is the last time. Thus the points will need to be close at both time=0.0 and time=`te` to be merged into a single result.
+
+Each of the positional based clusterings have both a scaled and unscaled version. This impacts how DBSCAN interprets distances. In the scaled version all values are divided by the width of the corresponding dimension to normalize the values. This maps points within the image to [0, 1], so an `eps` value of 0.01 might make sense. In contrast the unscaled versions do not perform normalization. The distances between two trajectories is measured in pixels. Here an `eps` value of 10 (for 10 pixels) might be better.
 
 Relevant clustering parameters include:
 
-* ``cluster_function`` - The name of the clustering algorithm used (if ``do_clustering = True``). The value must be one of ``DBSCAN`` or ``OPTICS``.
 * ``cluster_type`` - The types of predicted values to use when determining which trajectories should be clustered together, including position, velocity, and angles  (if ``do_clustering = True``). Must be one of all, position, or mid_position.
 * ``do_clustering`` - Cluster the resulting trajectories to remove duplicates.
+* ``eps`` - The distance threshold used by DBSCAN.
 
 See Also
 ________
 
 * `DBSCAN <https://scikit-learn.org/stable/modules/generated/sklearn.cluster.DBSCAN.html#sklearn.cluster.DBSCAN>`_
-* `OPTICS <https://scikit-learn.org/stable/modules/generated/sklearn.cluster.OPTICS.html?highlight=optics#sklearn.cluster.OPTICS>`_
-
 
 Known Object Matching
 ---------------------

--- a/docs/source/user_manual/search_params.rst
+++ b/docs/source/user_manual/search_params.rst
@@ -27,17 +27,15 @@ This document serves to provide a quick overview of the existing parameters and 
 |                        |                             | remove all negative values prior to    |
 |                        |                             | computing the percentiles.             |
 +------------------------+-----------------------------+----------------------------------------+
-| ``cluster_function``   | DBSCAN                      | The name of the clustering algorithm   |
-|                        |                             | used (if ``do_clustering=True``). The  |
-|                        |                             | value must be one of ``DBSCAN`` or     |
-|                        |                             | ``OPTICS``.                            |
-+------------------------+-----------------------------+----------------------------------------+
 | ``cluster_type``       | all                         | Types of predicted values to use when  |
 |                        |                             | determining trajectories to clustered  |
 |                        |                             | together, including position, velocity,|
 |                        |                             | and angles  (if do_clustering = True). |
-|                        |                             | Must be one of ``all``, ``position``,  |
-|                        |                             | or ``mid_position``.                   |
+|                        |                             | Options include: ``all``, ``position``,|
+|                        |                             | ``position_unscaled``, ``mid_position``|
+|                        |                             | ``mid_position_unscaled``,             |
+|                        |                             | ``start_end_position``, or             |
+|                        |                             | ``start_end_position_unscaled``.       |
 +------------------------+-----------------------------+----------------------------------------+
 | ``coadds``             | []                          | A list of additional coadds to create. |
 |                        |                             | These are not used in filtering, but   |

--- a/src/kbmod/configuration.py
+++ b/src/kbmod/configuration.py
@@ -45,7 +45,6 @@ class SearchConfiguration:
             "center_thresh": 0.00,
             "chunk_size": 500000,
             "clip_negative": False,
-            "cluster_function": "DBSCAN",
             "cluster_type": "all",
             "coadds": [],
             "debug": False,

--- a/src/kbmod/filters/clustering_filters.py
+++ b/src/kbmod/filters/clustering_filters.py
@@ -11,7 +11,7 @@ class DBSCANFilter:
     """Cluster the candidates using DBSCAN and only keep a
     single representative trajectory from each cluster."""
 
-    def __init__(self, eps, *args, **kwargs):
+    def __init__(self, eps, **kwargs):
         """Create a DBSCANFilter.
 
         Parameters
@@ -31,7 +31,7 @@ class DBSCANFilter:
         str
             The filter name.
         """
-        return f"DBSCAN_{self.cluster_type}_{self.eps}"
+        return f"DBSCAN_{self.cluster_type} eps={self.eps}"
 
     def _build_clustering_data(self, result_data):
         """Build the specific data set for this clustering approach.
@@ -68,35 +68,59 @@ class DBSCANFilter:
         cluster = DBSCAN(**self.cluster_args)
         cluster.fit(np.array(data, dtype=float).T)
 
-        # Get the best index per cluster.
+        # Get the best index per cluster. If the data is sorted by LH, this should always
+        # be the first point in the cluster. But we do an argmax in case the user has
+        # manually sorted the data by something else.
         top_vals = []
         for cluster_num in np.unique(cluster.labels_):
             cluster_vals = np.where(cluster.labels_ == cluster_num)[0]
-            top_vals.append(cluster_vals[0])
+            top_ind = np.argmax(result_data["likelihood"][cluster_vals])
+            top_vals.append(cluster_vals[top_ind])
         return top_vals
 
 
-class ClusterPositionFilter(DBSCANFilter):
-    """Cluster the candidates using their scaled starting position"""
+class ClusterPredictionFilter(DBSCANFilter):
+    """Cluster the candidates using their positions at specific times."""
 
-    def __init__(self, eps, height, width, *args, **kwargs):
+    def __init__(self, eps, pred_times=[0.0], height=1.0, width=1.0, scaled=True, **kwargs):
         """Create a DBSCANFilter.
 
         Parameters
         ----------
         eps : `float`
             The clustering threshold.
+        pred_times : `list`
+            The times a which to prediction the positions.
+            Default = [0.0] (starting position only)
         height : `int`
             The size of the image height (in pixels) for scaling.
+            Default: 1 (no scaling)
         width : `int`
             The size of the image width (in pixels) for scaling.
+            Default: 1 (no scaling)
+        scaled : `bool`
+            Scale the positions to [0, 1] based on ``width`` and ``height``. This impacts
+            how ``eps`` is interpreted by DBSCAN. If scaling is turned on ``eps``
+            approximates the each dimension between points. If scaling is turned off ``eps``
+            is a distance in pixels.
         """
-        super().__init__(eps, *args, **kwargs)
-        if height <= 0.0 or width <= 0:
-            raise ValueError(f"Invalid scaling parameters y={height} by x={width}")
-        self.height = height
-        self.width = width
-        self.cluster_type = "position"
+        super().__init__(eps, **kwargs)
+        if scaled:
+            if height <= 0.0 or width <= 0:
+                raise ValueError(f"Invalid scaling parameters y={height} by x={width}")
+            self.height = height
+            self.width = width
+        else:
+            self.height = 1.0
+            self.width = 1.0
+
+        # Confirm we have at least one prediction time.
+        if len(pred_times) == 0:
+            raise ValueError("No prediction times given.")
+        self.times = pred_times
+
+        # Set up the clustering algorithm's name.
+        self.cluster_type = f"position (scaled={scaled}) t={self.times}"
 
     def _build_clustering_data(self, result_data):
         """Build the specific data set for this clustering approach.
@@ -112,9 +136,18 @@ class ClusterPositionFilter(DBSCANFilter):
            The N x D matrix to cluster where N is the number of results
            and D is the number of attributes.
         """
-        x_arr = np.array(result_data["x"]) / self.width
-        y_arr = np.array(result_data["y"]) / self.height
-        return np.array([x_arr, y_arr])
+        x_arr = np.array(result_data["x"])
+        y_arr = np.array(result_data["y"])
+        vx_arr = np.array(result_data["vx"])
+        vy_arr = np.array(result_data["vy"])
+
+        # Append the predicted x and y location at each time. If scaling is turned off
+        # the division by height and width will be no-ops.
+        coords = []
+        for t in self.times:
+            coords.append((x_arr + t * vx_arr) / self.width)
+            coords.append((y_arr + t * vy_arr) / self.height)
+        return np.array(coords)
 
 
 class ClusterPosAngVelFilter(DBSCANFilter):
@@ -122,7 +155,7 @@ class ClusterPosAngVelFilter(DBSCANFilter):
     angles, and trajectory velocity magnitude.
     """
 
-    def __init__(self, eps, height, width, vel_lims, ang_lims, *args, **kwargs):
+    def __init__(self, eps, height, width, vel_lims, ang_lims, **kwargs):
         """Create a DBSCANFilter.
 
         Parameters
@@ -140,7 +173,7 @@ class ClusterPosAngVelFilter(DBSCANFilter):
             The angle limits of the search such that ang_lim[1] - ang_lim[0]
             is the range of velocities searched.
         """
-        super().__init__(eps, *args, **kwargs)
+        super().__init__(eps, **kwargs)
         if height <= 0.0 or width <= 0:
             raise ValueError(f"Invalid scaling parameters y={height} by x={width}")
         if len(vel_lims) < 2:
@@ -155,7 +188,7 @@ class ClusterPosAngVelFilter(DBSCANFilter):
         self.min_v = vel_lims[0]
         self.min_a = ang_lims[0]
 
-        self.cluster_type = "all"
+        self.cluster_type = f"cluster_all_{self.eps}"
 
     def _build_clustering_data(self, result_data):
         """Build the specific data set for this clustering approach.
@@ -179,63 +212,14 @@ class ClusterPosAngVelFilter(DBSCANFilter):
         vel_arr = np.sqrt(np.square(vx_arr) + np.square(vy_arr))
         ang_arr = np.arctan2(vy_arr, vx_arr)
 
-        # Scale the values.
+        # Scale the values. We always do this because distances and velocities
+        # are not directly comparable.
         scaled_x = x_arr / self.width
         scaled_y = y_arr / self.height
         scaled_vel = (vel_arr - self.min_v) / self.v_scale
         scaled_ang = (ang_arr - self.min_a) / self.a_scale
 
         return np.array([scaled_x, scaled_y, scaled_vel, scaled_ang])
-
-
-class ClusterMidPosFilter(ClusterPositionFilter):
-    """Cluster the candidates using their scaled positions at the median time."""
-
-    def __init__(self, eps, height, width, times, *args, **kwargs):
-        """Create a DBSCANFilter.
-
-        Parameters
-        ----------
-        eps : `float`
-            The clustering threshold.
-        height : `int`
-            The size of the image height (in pixels) for scaling.
-        width : `int`
-            The size of the image width (in pixels) for scaling.
-        times : `list` or `numpy.ndarray`
-            A list of times for the images. Can be MJD or zero indexed.
-        """
-        super().__init__(eps, height, width, *args, **kwargs)
-
-        zeroed_times = np.array(times) - times[0]
-        self.midtime = np.median(zeroed_times)
-        self.cluster_type = "midpoint"
-
-    def _build_clustering_data(self, result_data):
-        """Build the specific data set for this clustering approach.
-
-        Parameters
-        ----------
-        result_data: `Results`
-            The set of results to filter.
-
-        Returns
-        -------
-        data : `numpy.ndarray`
-           The N x D matrix to cluster where N is the number of results
-           and D is the number of attributes.
-        """
-        # Create arrays of each the trajectories information.
-        x_arr = np.array(result_data["x"])
-        y_arr = np.array(result_data["y"])
-        vx_arr = np.array(result_data["vx"])
-        vy_arr = np.array(result_data["vy"])
-
-        # Scale the values.
-        scaled_mid_x = (x_arr + self.midtime * vx_arr) / self.width
-        scaled_mid_y = (y_arr + self.midtime * vy_arr) / self.height
-
-        return np.array([scaled_mid_x, scaled_mid_y])
 
 
 def apply_clustering(result_data, cluster_params):
@@ -248,7 +232,7 @@ def apply_clustering(result_data, cluster_params):
         the filtering.
     cluster_params : dict
         Contains values concerning the image and search settings including:
-        cluster_type, eps, height, width, vel_lims, ang_lims, and mjd.
+        cluster_type, eps, height, width, scaled, vel_lims, ang_lims, and times.
 
     Raises
     ------
@@ -263,17 +247,41 @@ def apply_clustering(result_data, cluster_params):
     if len(result_data) == 0:
         logger.info("Clustering : skipping, no results.")
         return
-    logger.info(f"Clustering {len(result_data)} results using {cluster_type}")
+
+    # Get the times used for prediction clustering.
+    all_times = np.sort(cluster_params["times"])
+    zeroed_times = np.array(all_times) - all_times[0]
 
     # Do the clustering and the filtering.
-    if cluster_type == "all":
+    if cluster_type == "all" or cluster_type == "pos_vel":
         filt = ClusterPosAngVelFilter(**cluster_params)
-    elif cluster_type == "position":
-        filt = ClusterPositionFilter(**cluster_params)
+    elif cluster_type == "position" or cluster_type == "start_position":
+        cluster_params["pred_times"] = [0.0]
+        cluster_params["scaled"] = True
+        filt = ClusterPredictionFilter(**cluster_params)
+    elif cluster_type == "position_unscaled" or cluster_type == "start_position_unscaled":
+        cluster_params["pred_times"] = [0.0]
+        cluster_params["scaled"] = False
+        filt = ClusterPredictionFilter(**cluster_params)
     elif cluster_type == "mid_position":
-        filt = ClusterMidPosFilter(**cluster_params)
+        cluster_params["pred_times"] = [np.median(zeroed_times)]
+        cluster_params["scaled"] = True
+        filt = ClusterPredictionFilter(**cluster_params)
+    elif cluster_type == "mid_position_unscaled":
+        cluster_params["pred_times"] = [np.median(zeroed_times)]
+        cluster_params["scaled"] = False
+        filt = ClusterPredictionFilter(**cluster_params)
+    elif cluster_type == "start_end_position":
+        cluster_params["pred_times"] = [0.0, zeroed_times[-1]]
+        filt = ClusterPredictionFilter(**cluster_params)
+        cluster_params["scaled"] = True
+    elif cluster_type == "start_end_position_unscaled":
+        cluster_params["pred_times"] = [0.0, zeroed_times[-1]]
+        filt = ClusterPredictionFilter(**cluster_params)
+        cluster_params["scaled"] = False
     else:
         raise ValueError(f"Unknown clustering type: {cluster_type}")
+    logger.info(f"Clustering {len(result_data)} results using {filt.get_filter_name()}")
 
     # Do the actual filtering.
     indices_to_keep = filt.keep_indices(result_data)

--- a/src/kbmod/filters/clustering_filters.py
+++ b/src/kbmod/filters/clustering_filters.py
@@ -101,8 +101,8 @@ class ClusterPredictionFilter(DBSCANFilter):
         scaled : `bool`
             Scale the positions to [0, 1] based on ``width`` and ``height``. This impacts
             how ``eps`` is interpreted by DBSCAN. If scaling is turned on ``eps``
-            approximates the each dimension between points. If scaling is turned off ``eps``
-            is a distance in pixels.
+            approximates the percentage of each dimension between points. If scaling is
+            turned off ``eps`` is a distance in pixels.
         """
         super().__init__(eps, **kwargs)
         if scaled:

--- a/src/kbmod/filters/clustering_filters.py
+++ b/src/kbmod/filters/clustering_filters.py
@@ -188,7 +188,7 @@ class ClusterPosAngVelFilter(DBSCANFilter):
         self.min_v = vel_lims[0]
         self.min_a = ang_lims[0]
 
-        self.cluster_type = f"cluster_all_{self.eps}"
+        self.cluster_type = "all"
 
     def _build_clustering_data(self, result_data):
         """Build the specific data set for this clustering approach.

--- a/tests/test_clustering_filters.py
+++ b/tests/test_clustering_filters.py
@@ -51,7 +51,8 @@ class test_clustering_filters(unittest.TestCase):
         f3 = ClusterPredictionFilter(eps=0.025, pred_times=[0.0], height=1000, width=1000)
         self.assertEqual(f3.keep_indices(rs), [0])
 
-        # If we do not scale everything is marked its own cluster at low eps (0.025 pixels max distance).
+        # If we do not scale everything at the same starting point is marked its own cluster at low eps
+        # (0.025 pixels max distance).
         f4 = ClusterPredictionFilter(eps=0.025, pred_times=[0.0], height=100, width=100, scaled=False)
         self.assertEqual(f4.keep_indices(rs), [0, 3, 4, 5])
 
@@ -194,6 +195,20 @@ class test_clustering_filters(unittest.TestCase):
         cluster_params["cluster_type"] = "position"
         apply_clustering(results2, cluster_params)
         self.assertEqual(len(results2), 3)
+
+        # Try clustering with start and end positions
+        results3 = self._make_result_data(
+            [
+                [10, 11, 1, 2],
+                [10, 11, 10, 20],
+                [40, 5, -1, 2],
+                [5, 0, 1, 2],
+                [5, 1, 1, 2],
+            ]
+        )
+        cluster_params["cluster_type"] = "start_end_position"
+        apply_clustering(results3, cluster_params)
+        self.assertEqual(len(results3), 4)
 
         # Try invalid or missing cluster_type.
         cluster_params["cluster_type"] = "invalid"

--- a/tests/test_clustering_filters.py
+++ b/tests/test_clustering_filters.py
@@ -27,6 +27,7 @@ class test_clustering_filters(unittest.TestCase):
         return Results.from_trajectories(trj_list)
 
     def test_dbscan_position_results(self):
+        """Test clustering based on the initial position of the trajectory."""
         rs = self._make_result_data(
             [
                 [10, 11, 1, 2],
@@ -37,25 +38,34 @@ class test_clustering_filters(unittest.TestCase):
                 [10, 12, 5, 5],
             ]
         )
-        self.assertTrue(type(rs) is Results)
 
         # Standard-ish params collapses to 2 clusters.
-        f1 = ClusterPositionFilter(eps=0.025, height=100, width=100)
+        f1 = ClusterPredictionFilter(eps=0.025, pred_times=[0.0], height=100, width=100)
         self.assertEqual(f1.keep_indices(rs), [0, 3])
 
         # Small eps is 4 clusters.
-        f2 = ClusterPositionFilter(eps=0.000015, height=100, width=100)
+        f2 = ClusterPredictionFilter(eps=0.000015, pred_times=[0.0], height=100, width=100)
         self.assertEqual(f2.keep_indices(rs), [0, 3, 4, 5])
 
         # Large scale means 1 cluster
-        f3 = ClusterPositionFilter(eps=0.025, height=1000, width=1000)
+        f3 = ClusterPredictionFilter(eps=0.025, pred_times=[0.0], height=1000, width=1000)
         self.assertEqual(f3.keep_indices(rs), [0])
 
+        # If we do not scale everything is marked its own cluster at low eps (0.025 pixels max distance).
+        f4 = ClusterPredictionFilter(eps=0.025, pred_times=[0.0], height=100, width=100, scaled=False)
+        self.assertEqual(f4.keep_indices(rs), [0, 3, 4, 5])
+
+        # We regain the clustering power with a higher eps (3 pixels max distance).
+        f5 = ClusterPredictionFilter(eps=3.0, pred_times=[0.0], height=100, width=100, scaled=False)
+        self.assertEqual(f5.keep_indices(rs), [0, 3])
+
         # Catch invalid parameters
-        self.assertRaises(ValueError, ClusterPositionFilter, eps=0.025, height=100, width=0)
-        self.assertRaises(ValueError, ClusterPositionFilter, eps=0.025, height=0, width=100)
+        self.assertRaises(ValueError, ClusterPredictionFilter, eps=0.025, width=0)
+        self.assertRaises(ValueError, ClusterPredictionFilter, eps=0.025, height=0)
+        self.assertRaises(ValueError, ClusterPredictionFilter, eps=0.025, pred_times=[])
 
     def test_dbscan_all_results(self):
+        """Test clustering based on the median position of the trajectory."""
         rs = self._make_result_data(
             [
                 [10, 11, 1, 2],
@@ -66,7 +76,6 @@ class test_clustering_filters(unittest.TestCase):
                 [10, 12, 4.1, 8],
             ]
         )
-        self.assertTrue(type(rs) is Results)
 
         # Start with 5 clusters
         f1 = ClusterPosAngVelFilter(eps=0.025, height=100, width=100, vel_lims=[0, 100], ang_lims=[0, 1.5])
@@ -112,25 +121,49 @@ class test_clustering_filters(unittest.TestCase):
                 [5, 10, 1, 2],
             ]
         )
-        self.assertTrue(type(rs) is Results)
 
-        f1 = ClusterMidPosFilter(eps=0.1, height=20, width=20, times=self.times)
+        # Use the median time.
+        f1 = ClusterPredictionFilter(eps=0.1, pred_times=[0.95], height=20, width=20)
         self.assertEqual(f1.keep_indices(rs), [0, 1, 3, 6])
 
         # Use different times.
-        f2 = ClusterMidPosFilter(eps=0.1, height=20, width=20, times=[0, 10, 20])
+        f2 = ClusterPredictionFilter(eps=0.1, pred_times=[10.0], height=20, width=20)
         self.assertEqual(f2.keep_indices(rs), [0, 1, 3, 4, 5, 6])
 
-        # Use different times.
-        f3 = ClusterMidPosFilter(eps=0.1, height=20, width=20, times=[0, 0.001, 0.002])
+        # Use different times again.
+        f3 = ClusterPredictionFilter(eps=0.1, pred_times=[0.001], height=20, width=20)
         self.assertEqual(f3.keep_indices(rs), [0, 3, 5])
+
+        # Try without scaling
+        f4 = ClusterPredictionFilter(eps=0.1, pred_times=[10.95], height=20, width=20, scaled=False)
+        self.assertEqual(f4.keep_indices(rs), [0, 1, 2, 3, 4, 5, 6])
+
+    def test_dbscan_start_end_pos(self):
+        rs = self._make_result_data(
+            [
+                [10, 11, 1, 2],
+                [10, 11, 2, 5],
+                [10, 11, 1.01, 1.99],
+                [10, 11, 0.99, 2.01],
+                [21, 23, 1, 2],
+                [21, 23, -10, -10],
+                [21, 23, -10, -10.01],
+                [21, 23, -10.01, -10],
+                [5, 10, 1, 2.1],
+                [5, 10, 1, 2],
+                [5, 10, 1, 1.9],
+            ]
+        )
+
+        f1 = ClusterPredictionFilter(eps=3.0, pred_times=[10, 11.9], scaled=False)
+        self.assertEqual(f1.keep_indices(rs), [0, 1, 4, 5, 8])
 
     def test_clustering_results(self):
         cluster_params = {
             "ang_lims": [0.0, 1.5],
             "cluster_type": "all",
             "eps": 0.03,
-            "mjd": self.times,
+            "times": self.times,
             "width": 100,
             "height": 100,
             "vel_lims": [5.0, 40.0],
@@ -145,7 +178,6 @@ class test_clustering_filters(unittest.TestCase):
                 [5, 1, 1, 2],
             ]
         )
-        self.assertTrue(type(results) is Results)
         apply_clustering(results, cluster_params)
         self.assertEqual(len(results), 4)
 
@@ -159,7 +191,6 @@ class test_clustering_filters(unittest.TestCase):
                 [5, 1, 1, 2],
             ]
         )
-        self.assertTrue(type(results2) is Results)
         cluster_params["cluster_type"] = "position"
         apply_clustering(results2, cluster_params)
         self.assertEqual(len(results2), 3)


### PR DESCRIPTION
Adds a few new options to KBMOD clustering and significantly updates the documentation. New options include:
- The ability *not* to scale the position clusterings (these are encoded as `_unscaled` clustering types)
- The ability to cluster on a combination of start and end positions

As a general cleanup, the various positional algorithms were combined into a single predicted position clustering algorithm that takes different times. For example the `ClusterPositionFilter` was replaced by using `ClusterPredictionFilter` with time=0 and `ClusterMidPosFilter` by `ClusterPredictionFilter` with the median time. This allows for a single (better tested) class and the easier ability to add new functions (like turning off scaling).

Performed a few additional small clean ups:
- More informative names for the clustering algorithm strings (for logging).
- The best point (according to LH) is chosen from each cluster. This was already happening because results were sorted by LH first, but this makes it explicit in case the ordering of results is changed somewhere else.

Closes #539 