### PR TITLE
Initial demo of matching KBMOD results to known fakes

### DIFF
--- a/notebooks/kbmod_search_results_for_fakes.ipynb
+++ b/notebooks/kbmod_search_results_for_fakes.ipynb
@@ -8,7 +8,7 @@
     "  \n",
     "A basic notebook to demonstrate searching results against known fakes in the data.\n",
     "\n",
-    "Is intended to be run using shared data on baldur."
+    "Note that this notebook is intended to be run using shared data on baldur."
    ]
   },
   {
@@ -17,7 +17,7 @@
    "source": [
     "# Setup demo\n",
     "\n",
-    "Before importing, make sure you have installed kbmod using `pip install .` in the root directory.  Also be sure you are running with python3 and using the correct notebook kernel."
+    "Before importing, make sure you have installed kbmod using `pip install .` in the root `KBMOD` directory.  Also be sure you are running with python3 and using the correct notebook kernel."
    ]
   },
   {
@@ -44,6 +44,7 @@
     "# Data paths\n",
     "wu_path = '/epyc/projects/kbmod/runs/wbeebe/1000_imgs_5_16/reprojected_wu.fits' # A reflex-corrected WorkUnit\n",
     "res_path = '/epyc/projects/kbmod/runs/wbeebe/1000_imgs_5_16_slow'\n",
+    "# Path to known fakes (with reflex-corrected) coordinates on the dates used in this KBMOD search.\n",
     "fakes_path = '/epyc/projects/kbmod/runs/wbeebe/fakes_detections_20190404_20190505_simple.csv'"
    ]
   },
@@ -106,9 +107,9 @@
    "source": [
     "# Search for results that are near known fakes\n",
     "\n",
-    "astropy allows us to easily search for nearest neighbors between two sets of coordinates represented by SkyCoord objects.\n",
+    "astropy allows us to take two catalogus of coordinates (represented by `SkyCoord` objects) and easily search for nearest neighbors between them. \n",
     "\n",
-    "First as a simple approximation, let's translate the initial (x, y) of each of our results into an (ra, dec)."
+    "First, as a simple approximation let's translate the initial (x, y) of each of our results into an (ra, dec). Note that we are using a reflex-corrected WCS from our `WorkUnit` so the (ra, dec) will be in reflex-corrected space."
    ]
   },
   {
@@ -128,7 +129,7 @@
    "source": [
     "Now we can translate our (ra, dec) pairs into single `SkyCoord` objects.\n",
     "\n",
-    "Then we can use astopy's `search_around_sky` to search for results which are near our fakes, with a max separation limit of 1 arcsecond"
+    "Then we can use astopy's `search_around_sky` to find which KBMOD results are near our known fakes, with a max separation limit of 1 arcsecond"
    ]
   },
   {
@@ -150,7 +151,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`idx1` Maps fakes to their nearest neighbors in the results. Each value is an index to a potential result in our results table."
+    "`idx1` Maps fakes to their nearest neighbors in the results. Each value is an index to a potential finding within our results table."
    ]
   },
   {
@@ -177,7 +178,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's examine the first result we believe might be a fake first"
+    "Let's first examine the first result which we believe might be a fake."
    ]
   },
   {
@@ -203,9 +204,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`idx2` shows a mapping of which fakes might be potential results. Here its values are indices within our fakes table.\n",
+    "`idx2` shows the inverse mapping of which fakes might be potential results. Here its values are indices within our fakes table.\n",
     "\n",
-    "So taking the first potential match we examined above, we can use the corresponding index (in this case 0) to inspect our fake within our fakes table.\n"
+    "So taking the first potential match we examined above, we can use the corresponding index (in this case 0) to inspect within our fakes table.\n"
    ]
   },
   {
@@ -221,7 +222,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And as a sanity check we can also inspect the distance"
+    "And as a sanity check we can also inspect the distance between the result and fake in reflex-corrected space."
    ]
   },
   {

--- a/notebooks/kbmod_search_results_for_fakes.ipynb
+++ b/notebooks/kbmod_search_results_for_fakes.ipynb
@@ -1,0 +1,284 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# KBMOD Search Results for Fakes\n",
+    "  \n",
+    "A basic notebook to demonstrate searching results against known fakes in the data.\n",
+    "\n",
+    "Is intended to be run using shared data on baldur."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Setup demo\n",
+    "\n",
+    "Before importing, make sure you have installed kbmod using `pip install .` in the root directory.  Also be sure you are running with python3 and using the correct notebook kernel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import os\n",
+    "\n",
+    "from kbmod.analysis.plotting import *\n",
+    "from kbmod.data_interface import load_deccam_layered_image\n",
+    "from kbmod.search import ImageStack, PSF, StampCreator, Trajectory\n",
+    "from kbmod.results import Results\n",
+    "from kbmod.work_unit import WorkUnit\n",
+    "\n",
+    "from astropy.coordinates import SkyCoord, search_around_sky\n",
+    "import astropy.units as u\n",
+    "from astropy.table import Table\n",
+    "\n",
+    "# Data paths\n",
+    "wu_path = '/epyc/projects/kbmod/runs/wbeebe/1000_imgs_5_16/reprojected_wu.fits' # A reflex-corrected WorkUnit\n",
+    "res_path = '/epyc/projects/kbmod/runs/wbeebe/1000_imgs_5_16_slow'\n",
+    "fakes_path = '/epyc/projects/kbmod/runs/wbeebe/fakes_detections_20190404_20190505_simple.csv'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Reload a Saved KBMOD WorkUnit\n",
+    "Note that this WorkUnit was reflex-corrected with a guess distance of 40 AU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wu = WorkUnit.from_fits(wu_path) \n",
+    "stack = wu.im_stack"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load the KBMOD Results and Known Fakes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = Results.read_table(os.path.join(res_path, \"results.ecsv\"))\n",
+    "print(f\"Loaded {len(results)} results.\")\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And now load our known fakes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fakes = Table.read(fakes_path, format='csv')\n",
+    "fakes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Search for results that are near known fakes\n",
+    "\n",
+    "astropy allows us to easily search for nearest neighbors between two sets of coordinates represented by SkyCoord objects.\n",
+    "\n",
+    "First as a simple approximation, let's translate the initial (x, y) of each of our results into an (ra, dec)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_ra_dec = [wu.wcs.pixel_to_world(r[\"x\"], r[\"y\"]) for r in results]\n",
+    "results.table[\"ra_dec\"] = results_ra_dec\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can translate our (ra, dec) pairs into single `SkyCoord` objects.\n",
+    "\n",
+    "Then we can use astopy's `search_around_sky` to search for results which are near our fakes, with a max separation limit of 1 arcsecond"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result_coords = SkyCoord(ra=[coord.ra for coord in results_ra_dec], dec=[coord.dec for coord in results_ra_dec])\n",
+    "\n",
+    "# Since our WorkUnit was reflex-corrected with a guess distance of 40 AU,\n",
+    "# we use the corresponding reflex-correced (ra, dec) for our fakes.\n",
+    "fake_coords = SkyCoord(ra=fakes[\"RA_40\"]*u.degree, dec=fakes[\"Dec_40\"]*u.degree)\n",
+    "\n",
+    "idx1, idx2, sep2dAngle, dist3d = search_around_sky(result_coords, fake_coords, 1*u.arcsecond)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`idx1` Maps fakes to their nearest neighbors in the results. Each value is an index to a potential result in our results table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(len(idx1))\n",
+    "idx1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "potential_fake_results = np.unique(idx1)\n",
+    "potential_fake_results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's examine the first result we believe might be a fake first"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results[potential_fake_results[0]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# helper function to plot a row of the results table\n",
+    "plot_result_row(results[potential_fake_results[0]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`idx2` shows a mapping of which fakes might be potential results. Here its values are indices within our fakes table.\n",
+    "\n",
+    "So taking the first potential match we examined above, we can use the corresponding index (in this case 0) to inspect our fake within our fakes table.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fakes[idx2[0]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And as a sanity check we can also inspect the distance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dist3d[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Plot the Coadds of all Suspected Fakes within Our Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot the coadds of all potential fakes\n",
+    "for idx in potential_fake_results:\n",
+    "    # helper function to plot a row of the results table\n",
+    "    plot_result_row(results[idx])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Wilson’s KBMOD Analysis",
+   "language": "python",
+   "name": "wbeebe_kbmod_analysis"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/kbmod_search_results_for_fakes.ipynb
+++ b/notebooks/kbmod_search_results_for_fakes.ipynb
@@ -118,9 +118,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results_ra_dec = [wu.wcs.pixel_to_world(r[\"x\"], r[\"y\"]) for r in results]\n",
-    "results.table[\"ra_dec\"] = results_ra_dec\n",
-    "results"
+    "results.table[\"ra_dec\"] = wu.wcs.pixel_to_world(results[\"x\"], results[\"y\"])\n",
+    "results[\"ra_dec\"]"
    ]
   },
   {
@@ -138,15 +137,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result_coords = SkyCoord(\n",
-    "    ra=[coord.ra for coord in results_ra_dec], dec=[coord.dec for coord in results_ra_dec]\n",
-    ")\n",
-    "\n",
     "# Since our WorkUnit was reflex-corrected with a guess distance of 40 AU,\n",
     "# we use the corresponding reflex-correced (ra, dec) for our fakes.\n",
     "fake_coords = SkyCoord(ra=fakes[\"RA_40\"] * u.degree, dec=fakes[\"Dec_40\"] * u.degree)\n",
     "\n",
-    "idx1, idx2, sep2dAngle, dist3d = search_around_sky(result_coords, fake_coords, 1 * u.arcsecond)"
+    "idx1, idx2, sep2dAngle, dist3d = search_around_sky(results[\"ra_dec\"], fake_coords, 1 * u.arcsecond)"
    ]
   },
   {

--- a/notebooks/kbmod_search_results_for_fakes.ipynb
+++ b/notebooks/kbmod_search_results_for_fakes.ipynb
@@ -42,10 +42,10 @@
     "from astropy.table import Table\n",
     "\n",
     "# Data paths\n",
-    "wu_path = '/epyc/projects/kbmod/runs/wbeebe/1000_imgs_5_16/reprojected_wu.fits' # A reflex-corrected WorkUnit\n",
-    "res_path = '/epyc/projects/kbmod/runs/wbeebe/1000_imgs_5_16_slow'\n",
+    "wu_path = \"/epyc/projects/kbmod/runs/wbeebe/1000_imgs_5_16/reprojected_wu.fits\"  # A reflex-corrected WorkUnit\n",
+    "res_path = \"/epyc/projects/kbmod/runs/wbeebe/1000_imgs_5_16_slow\"\n",
     "# Path to known fakes (with reflex-corrected) coordinates on the dates used in this KBMOD search.\n",
-    "fakes_path = '/epyc/projects/kbmod/runs/wbeebe/fakes_detections_20190404_20190505_simple.csv'"
+    "fakes_path = \"/epyc/projects/kbmod/runs/wbeebe/fakes_detections_20190404_20190505_simple.csv\""
    ]
   },
   {
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wu = WorkUnit.from_fits(wu_path) \n",
+    "wu = WorkUnit.from_fits(wu_path)\n",
     "stack = wu.im_stack"
    ]
   },
@@ -97,7 +97,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fakes = Table.read(fakes_path, format='csv')\n",
+    "fakes = Table.read(fakes_path, format=\"csv\")\n",
     "fakes"
    ]
   },
@@ -138,13 +138,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result_coords = SkyCoord(ra=[coord.ra for coord in results_ra_dec], dec=[coord.dec for coord in results_ra_dec])\n",
+    "result_coords = SkyCoord(\n",
+    "    ra=[coord.ra for coord in results_ra_dec], dec=[coord.dec for coord in results_ra_dec]\n",
+    ")\n",
     "\n",
     "# Since our WorkUnit was reflex-corrected with a guess distance of 40 AU,\n",
     "# we use the corresponding reflex-correced (ra, dec) for our fakes.\n",
-    "fake_coords = SkyCoord(ra=fakes[\"RA_40\"]*u.degree, dec=fakes[\"Dec_40\"]*u.degree)\n",
+    "fake_coords = SkyCoord(ra=fakes[\"RA_40\"] * u.degree, dec=fakes[\"Dec_40\"] * u.degree)\n",
     "\n",
-    "idx1, idx2, sep2dAngle, dist3d = search_around_sky(result_coords, fake_coords, 1*u.arcsecond)"
+    "idx1, idx2, sep2dAngle, dist3d = search_around_sky(result_coords, fake_coords, 1 * u.arcsecond)"
    ]
   },
   {


### PR DESCRIPTION
A simple demo notebook that reloads saved KBMOD results (both a results table and a reflex-corrected `WorkUnit`) and searches for results that are near a catalogue of known fakes (which have been similarly reflex-corrected).

In the future, we may want to standardize how we consume and represent catalogues of fakes, but this seemed helpful to share in its current state.