### PR TITLE
Provide ability to configure the trajectory generator used

### DIFF
--- a/docs/source/user_manual/search_params.rst
+++ b/docs/source/user_manual/search_params.rst
@@ -73,6 +73,10 @@ This document serves to provide a quick overview of the existing parameters and 
 |                        |                             | ``filter_type=clipped_sigmaG``         |
 |                        |                             | filtering is supported on GPU.         |
 +------------------------+-----------------------------+----------------------------------------+
+| ``generator_config``   | None                        | The configuration dictionary for the   |
+|                        |                             | trajectory generator that will create  |
+|                        |                             | the search candidates.                 |
++------------------------+-----------------------------+----------------------------------------+
 | ``im_filepath``        | None                        | The image file path from which to load |
 |                        |                             | images. This should point to a         |
 |                        |                             | directory with multiple FITS files     |

--- a/docs/source/user_manual/search_space.rst
+++ b/docs/source/user_manual/search_space.rst
@@ -27,10 +27,61 @@ KBMOD provides the ability to expand or contract the range of starting pixels us
 1. Adding a fixed sized buffer around the edge of the images. This is done using the ``x_pixel_buffer`` and ``y_pixel_buffer`` parameters to set separate buffers for the x and y dimensions. If ``x_pixel_buffer = 5`` the code will add 5 pixels to both sides of the image, using starting pixels from [-5, w + 5).
 2. Specifying absolute pixel boundaries. This is done using the ``x_pixel_bounds`` and ``y_pixel_bounds`` parameters. For example you can *reduce* the size of the search by using ``x_pixel_bounds = [10, 100]``, which will search [10, 100) regardless of the image's width. Similarly, you can increase the region of the search by setting the bounds outside the image's area.
 
-Velocity Grid
--------------
+Choosing Velocities
+-------------------
 
-Perhaps the most complex aspect of the KBMOD algorithm is how it defines the grid of search velocities. The grid is defined by two sets of parameters: a sampling of absolute velocities (``v_arr``) in pixels per day and a sampling of the velocities' angles (``ang_arr``) in radians. Each sampling consists of values defining the range and number of sampling steps. 
+Perhaps the most complex aspect of the KBMOD algorithm is how it defines the grid of search velocities. KBMOD allows you to define custom search strategies to best match the data. These include:
+* ``SingleVelocitySearch`` - A single predefined x and y velocity
+* ``VelocityGridSearch`` - An evenly spaced grid of x and y velocities
+* ``KBMODV1SearchConfig `` - An evenly spaced grid of velocity magnitudes and angles (this was the only option in v1.1 and before)
+* ``RandomVelocitySearch`` - Randomly sampled x and y velocities
+Additional search strategies can be defined by overriding the ``TrajectoryGenerator`` class in trajectory_generator.py.
+
+The search is selected and configured by a single ``generator_config`` parameter that takes a dictionary. The dictionary must contain a ``name`` entry that matches one of the options above. For example to search a single trajectory with a given ``vx = 1.0`` and ``vy = -2.0``, we would use::
+
+    generator_config = { "name": "SingleVelocitySearch", "vx": 1.0, "vy": -2.0 }
+
+If no generator_config is provided, then KBMOD uses the ``KBMODV1SearchConfig`` search strategy and pulls the configuration parameters from the top level. In this case if ``average_angle`` is not specified, it is estimated from the image's WCS.
+
+SingleVelocitySearch
+--------------------
+
+As the name implies the generator tests a single trajectory (with given vx and vy) per pixel.
+
++------------------------+---------------------------------------------------+
+| **Parameter**          | **Interpretation**                                |
++------------------------+---------------------------------------------------+
+| ``vx``                 | The velocity in pixels per day in the x-dimension |
++------------------------+---------------------------------------------------+
+| ``vy``                 | The velocity in pixels per day in the y-dimension |
++------------------------+---------------------------------------------------+
+
+VelocityGridSearch
+------------------
+
+The ``VelocityGridSearch`` strategy searches a uniform grid of x and y velocities.
+
++------------------------+-----------------------------------------------------------+
+| **Parameter**          | **Interpretation**                                        |
++------------------------+-----------------------------------------------------------+
+| ``vx_steps``           | The number of velocity steps in the x-dimension.          |
++------------------------+-----------------------------------------------------------+
+| ``min_vx``             | The minimum velocity in the x-dimension (pixels per day). |
++------------------------+-----------------------------------------------------------+
+| ``max_vx``             | The maximum velocity in the x-dimension (pixels per day). |
++------------------------+-----------------------------------------------------------+
+| ``vy_steps``           | The number of velocity steps in the y-dimension.          |
++------------------------+-----------------------------------------------------------+
+| ``min_vy``             | The minimum velocity in the y-dimension (pixels per day). |
++------------------------+-----------------------------------------------------------+
+| ``max_vy``             | The maximum velocity in the y-dimension (pixels per day). |
++------------------------+-----------------------------------------------------------+
+
+
+KBMODV1SearchConfig
+-------------------
+
+The grid is defined by two sets of parameters: a sampling of absolute velocities (``v_arr``) in pixels per day and a sampling of the velocities' angles (``ang_arr``) in radians. Each sampling consists of values defining the range and number of sampling steps. 
 
 The velocity array ``v_arr`` uses the format [minimum velocity, maximum velocity, number of steps]. The setting ``v_arr = [92.0, 526.0, 256]`` samples velocities from 92 pixels per day to 526 pixels per day with 256 equally spaced samples.
 
@@ -54,3 +105,58 @@ Given the linear sampling for both velocities and angles, the full set of candid
     }
 
 where ``angles`` contains the list of angles to test and ``velocities`` contains the list of velocities.
+
++------------------------+----------------------------------------------------------------------+
+| **Parameter**          | **Interpretation**                                                   |
++------------------------+----------------------------------------------------------------------+
+| ``ang_arr``            | A length 3 array with the minimum, maximum and number of angles      |
+|                        | to search through (in radians)                                       |
++------------------------+----------------------------------------------------------------------+
+| ``average_angle``      | Overrides the ecliptic angle calculation and instead centers the     |
+|                        | average search around average_angle   (in radians).                  |
++------------------------+----------------------------------------------------------------------+
+| ``v_arr``              | A length 3 array with the minimum, maximum and number of velocities. |
+|                        | to search through.  The minimum and maximum velocities are specified |
+|                        |          in pixels per day.                                          |
++------------------------+----------------------------------------------------------------------+
+
+KBMODV1Search
+-------------
+
+The ``KBMODV1Search`` strategy provides an alternate (more understandable) parameterization of the ``KBMODV1SearchConfig`` search above. Specifically, instead of specifying the angle offsets relative to a reference (``average_angle``) this parametrization specifies them directly in pixel space.
+
++------------------------+-----------------------------------------------------+
+| **Parameter**          | **Interpretation**                                  |
++------------------------+-----------------------------------------------------+
+| ``vel_steps``          | The number of velocity steps.                       |
++------------------------+-----------------------------------------------------+
+| ``min_vel``            | The minimum velocity magnitude (in pixels per day). |
++------------------------+-----------------------------------------------------+
+| ``max_vel``            | The maximum velocity magnitude (in pixels per day). |
++------------------------+-----------------------------------------------------+
+| ``ang_steps``          | The number of angle steps.                          |
++------------------------+-----------------------------------------------------+
+| ``min_ang``            | The minimum angle (in radians).                     |
++------------------------+-----------------------------------------------------+
+| ``max_ang``            | The maximum angle (in radians).                     |
++------------------------+-----------------------------------------------------+
+
+RandomVelocitySearch
+--------------------
+
+The ``RandomVelocitySearch`` randomly selects points within a bounding box of velocities.
+
++------------------------+--------------------------------------------------------+
+| **Parameter**          | **Interpretation**                                     |
++------------------------+--------------------------------------------------------+
+| ``min_vx``             | The minimum velocity magnitude (in pixels per day).    |
++------------------------+--------------------------------------------------------+
+| ``max_vx``             | The minimum velocity magnitude (in pixels per day).    |
++------------------------+--------------------------------------------------------+
+| ``min_vy``             | The maximum velocity magnitude (in pixels per day).    |
++------------------------+--------------------------------------------------------+
+| ``max_vy``             | The maximum velocity magnitude (in pixels per day).    |
++------------------------+--------------------------------------------------------+
+| ``max_samples``        | The maximum number of samples to generate. Used to.    |
+|                        | avoid infinite loops in KBMOD code.                    |
++------------------------+--------------------------------------------------------+

--- a/docs/source/user_manual/search_space.rst
+++ b/docs/source/user_manual/search_space.rst
@@ -33,7 +33,7 @@ Choosing Velocities
 Perhaps the most complex aspect of the KBMOD algorithm is how it defines the grid of search velocities. KBMOD allows you to define custom search strategies to best match the data. These include:
 * ``SingleVelocitySearch`` - A single predefined x and y velocity
 * ``VelocityGridSearch`` - An evenly spaced grid of x and y velocities
-* ``KBMODV1SearchConfig `` - An evenly spaced grid of velocity magnitudes and angles (this was the only option in v1.1 and before)
+* ``KBMODV1SearchConfig`` - An evenly spaced grid of velocity magnitudes and angles (this was the only option in v1.1 and before)
 * ``RandomVelocitySearch`` - Randomly sampled x and y velocities
 Additional search strategies can be defined by overriding the ``TrajectoryGenerator`` class in trajectory_generator.py.
 
@@ -117,7 +117,7 @@ where ``angles`` contains the list of angles to test and ``velocities`` contains
 +------------------------+----------------------------------------------------------------------+
 | ``v_arr``              | A length 3 array with the minimum, maximum and number of velocities. |
 |                        | to search through.  The minimum and maximum velocities are specified |
-|                        |          in pixels per day.                                          |
+|                        | in pixels per day.                                                   |
 +------------------------+----------------------------------------------------------------------+
 
 KBMODV1Search

--- a/docs/source/user_manual/search_space.rst
+++ b/docs/source/user_manual/search_space.rst
@@ -41,7 +41,7 @@ The search is selected and configured by a single ``generator_config`` parameter
 
     generator_config = { "name": "SingleVelocitySearch", "vx": 1.0, "vy": -2.0 }
 
-If no generator_config is provided, then KBMOD uses the ``KBMODV1SearchConfig`` search strategy and pulls the configuration parameters from the top level. In this case if ``average_angle`` is not specified, it is estimated from the image's WCS.
+If no generator_config is provided, then KBMOD uses the ``KBMODV1SearchConfig`` search strategy and pulls the configuration parameters from the top level. In this case (when falling back to legacy behavior), if ``average_angle`` is not specified, it is estimated from the image's WCS. If the parameters are specified via ``generator_config`` then ``average_angle`` will not automatically be estimated and must be provided as part of that config.
 
 SingleVelocitySearch
 --------------------

--- a/docs/source/user_manual/search_space.rst
+++ b/docs/source/user_manual/search_space.rst
@@ -41,7 +41,7 @@ The search is selected and configured by a single ``generator_config`` parameter
 
     generator_config = { "name": "SingleVelocitySearch", "vx": 1.0, "vy": -2.0 }
 
-If no generator_config is provided, then KBMOD uses the ``KBMODV1SearchConfig`` search strategy and pulls the configuration parameters from the top level. In this case (when falling back to legacy behavior), if ``average_angle`` is not specified, it is estimated from the image's WCS. If the parameters are specified via ``generator_config`` then ``average_angle`` will not automatically be estimated and must be provided as part of that config.
+If no generator_config is provided, then KBMOD uses the ``KBMODV1SearchConfig`` search strategy and pulls the configuration parameters from the top level.
 
 SingleVelocitySearch
 --------------------

--- a/src/kbmod/configuration.py
+++ b/src/kbmod/configuration.py
@@ -54,6 +54,7 @@ class SearchConfiguration:
             "eps": 0.03,
             "encode_num_bytes": -1,
             "flag_keys": default_flag_keys,
+            "generator_config": None,
             "gpu_filter": False,
             "ind_output_files": True,
             "im_filepath": None,
@@ -90,6 +91,9 @@ class SearchConfiguration:
             "y_pixel_bounds": None,
             "y_pixel_buffer": None,
         }
+
+    def __contains__(self, key):
+        return key in self._params
 
     def __getitem__(self, key):
         """Gets the value of a specific parameter.

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -13,7 +13,7 @@ from .filters.sigma_g_filter import apply_clipped_sigma_g, SigmaGClipping
 from .filters.stamp_filters import append_all_stamps, append_coadds, get_coadds_and_filter_results
 from .masking import apply_mask_operations
 from .results import Results
-from .trajectory_generator import KBMODV1Search
+from .trajectory_generator import create_trajectory_generator, KBMODV1SearchConfig
 from .wcs_utils import calc_ecliptic_angle
 from .work_unit import WorkUnit
 
@@ -232,15 +232,7 @@ class SearchRunner:
 
         # Perform the actual search.
         if trj_generator is None:
-            ang_limits = self.get_angle_limits(config)
-            trj_generator = KBMODV1Search(
-                int(config["v_arr"][2]),
-                config["v_arr"][0],
-                config["v_arr"][1],
-                int(config["ang_arr"][2]),
-                ang_limits[0],
-                ang_limits[1],
-            )
+            trj_generator = create_trajectory_generator(config)
         keep = self.do_gpu_search(config, stack, trj_generator)
 
         if config["do_stamp_filter"]:

--- a/src/kbmod/trajectory_generator.py
+++ b/src/kbmod/trajectory_generator.py
@@ -65,12 +65,14 @@ class TrajectoryGenerator(abc.ABC):
     2) cannot be infinite
     """
 
-    generators = {}
+    generators = {}  # A mapping of class name to class object for subclasses.
 
     def __init__(self, *args, **kwargs):
         pass
 
     def __init_subclass__(cls, **kwargs):
+        # Register all subclasses in a dictionary mapping class name to the
+        # class object, so we can programmatically create objects from the names.
         super().__init_subclass__(**kwargs)
         cls.generators[cls.__name__] = cls
 

--- a/tests/test_trajectory_generator.py
+++ b/tests/test_trajectory_generator.py
@@ -1,10 +1,13 @@
 import unittest
 
+from kbmod.configuration import SearchConfiguration
 from kbmod.trajectory_generator import (
     KBMODV1Search,
+    KBMODV1SearchConfig,
     SingleVelocitySearch,
     RandomVelocitySearch,
     VelocityGridSearch,
+    create_trajectory_generator,
 )
 
 
@@ -65,6 +68,18 @@ class test_trajectory_generator(unittest.TestCase):
         self.assertRaises(ValueError, KBMODV1Search, 3, 0.0, 3.0, 2, 0.25, -0.25)
         self.assertRaises(ValueError, KBMODV1Search, 3, 3.5, 3.0, 2, -0.25, 0.25)
 
+    def test_KBMODV1SearchConfig(self):
+        # Note that KBMOD v1's search will never include the upper bound of angle or velocity.
+        gen = KBMODV1SearchConfig([0.0, 3.0, 3], [0.25, 0.25, 2], 0.0)
+        expected_x = [0.0, 0.9689, 1.9378, 0.0, 1.0, 2.0]
+        expected_y = [0.0, -0.247, -0.4948, 0.0, 0.0, 0.0]
+
+        trjs = [trj for trj in gen]
+        self.assertEqual(len(trjs), 6)
+        for i in range(6):
+            self.assertAlmostEqual(trjs[i].vx, expected_x[i], delta=0.001)
+            self.assertAlmostEqual(trjs[i].vy, expected_y[i], delta=0.001)
+
     def test_RandomVelocitySearch(self):
         gen = RandomVelocitySearch(0.0, 2.0, -0.25, 0.25)
 
@@ -86,6 +101,54 @@ class test_trajectory_generator(unittest.TestCase):
         # Generate a twenty more candidates.
         gen2.reset_sample_count(20)
         self.assertEqual(len([trj for trj in gen2]), 20)
+
+    def test_create_trajectory_generator(self):
+        config1 = {
+            "name": "VelocityGridSearch",
+            "vx_steps": 10,
+            "min_vx": 0,
+            "max_vx": 5,
+            "vy_steps": 20,
+            "min_vy": -5,
+            "max_vy": 15,
+        }
+        gen1 = create_trajectory_generator(config1)
+        self.assertTrue(type(gen1) is VelocityGridSearch)
+        self.assertEqual(gen1.vx_steps, 10)
+        self.assertEqual(gen1.min_vx, 0)
+        self.assertEqual(gen1.max_vx, 5)
+        self.assertEqual(gen1.vy_steps, 20)
+        self.assertEqual(gen1.min_vy, -5)
+        self.assertEqual(gen1.max_vy, 15)
+
+        config2 = {"name": "SingleVelocitySearch", "vx": 1, "vy": 2}
+        gen2 = create_trajectory_generator(config2)
+        self.assertTrue(type(gen2) is SingleVelocitySearch)
+        self.assertEqual(gen2.vx, 1)
+        self.assertEqual(gen2.vy, 2)
+
+    def test_create_trajectory_generator_config(self):
+        config = SearchConfiguration()
+        config.set("ang_arr", [0.5, 0.5, 30])
+        config.set("average_angle", 0.0)
+        config.set("v_arr", [0.0, 10.0, 100])
+
+        # Without a "generator_config" option, we fall back on the legacy generator.
+        gen1 = create_trajectory_generator(config)
+        self.assertTrue(type(gen1) is KBMODV1SearchConfig)
+        self.assertEqual(gen1.vel_steps, 100)
+        self.assertEqual(gen1.min_vel, 0.0)
+        self.assertEqual(gen1.max_vel, 10.0)
+        self.assertEqual(gen1.ang_steps, 30)
+        self.assertEqual(gen1.min_ang, -0.5)
+        self.assertEqual(gen1.max_ang, 0.5)
+
+        # Add a generator configuration.
+        config.set("generator_config", {"name": "SingleVelocitySearch", "vx": 1, "vy": 2})
+        gen2 = create_trajectory_generator(config)
+        self.assertTrue(type(gen2) is SingleVelocitySearch)
+        self.assertEqual(gen2.vx, 1)
+        self.assertEqual(gen2.vy, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Provide ability to configure the trajectory generator used. The generator type and configuration parameters are read from a new configuration field `generator_config`, but the code falls back to current behavior if that is not provided (to prevent breaking any current workflows).

To make things easier also creates a mechanism for registering `TrajectoryGenerator` class names to objects, so they can be programmatically created and creates a new `KBMODV1SearchConfig` generator.

Expand the documentation to include all the new generators and their parameters.