### PR TITLE
add filter bypass option to correct_parallax

### DIFF
--- a/tests/test_reprojection_utils.py
+++ b/tests/test_reprojection_utils.py
@@ -41,6 +41,8 @@ class test_reprojection_utils(unittest.TestCase):
         self.sc1 = SkyCoord(ra=self.icrs_ra1, dec=self.icrs_dec1, unit="deg")
         self.sc2 = SkyCoord(ra=self.icrs_ra2, dec=self.icrs_dec2, unit="deg")
 
+        self.equinox_geo_dist = 50.00135417530472
+
         with solar_system_ephemeris.set("de432s"):
             self.eq_loc = EarthLocation.of_site("ctio")
 
@@ -70,6 +72,23 @@ class test_reprojection_utils(unittest.TestCase):
 
         assert type(corrected_coord1) is SkyCoord
         assert type(corrected_coord2) is SkyCoord
+
+    def test_parallax_given_geo(self):
+        corrected_coord, geo_dist = correct_parallax(
+            coord=self.sc1,
+            obstime=self.icrs_time1,
+            point_on_earth=self.eq_loc,
+            heliocentric_distance=50.0,
+            geocentric_distance=self.equinox_geo_dist,
+        )
+
+        expected_ra = 90.0
+        expected_dec = 23.43952556
+
+        npt.assert_almost_equal(corrected_coord.ra.value, expected_ra)
+        npt.assert_almost_equal(corrected_coord.dec.value, expected_dec)
+
+        assert geo_dist == self.equinox_geo_dist
 
     def test_invert_correct_parallax(self):
         corrected_coord1, geo_dist1 = correct_parallax(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -950,6 +950,7 @@ class test_search(unittest.TestCase):
     def result_hash(res):
         return hash((res.x, res.y, res.vx, res.vy, res.lh, res.obs_count))
 
+    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
     def test_search_batch(self):
         width = 50
         height = 50


### PR DESCRIPTION
resolves #614 

- adds the `geocentric_distance` parameter to `kbmod.reprojection_utils.correct_parallax`, which when set will use the provided value instead of getting the geocentric distance from the minimizer.
- also makes the `loc` casting a little cleaner for both `correct_parallax` and `invert_correct_parallax`
- also adds a test skip for a test that has a GPU call.