### PR TITLE
Change int to uint64 to prevent overflow

### DIFF
--- a/src/kbmod/search/psi_phi_array.cpp
+++ b/src/kbmod/search/psi_phi_array.cpp
@@ -248,7 +248,7 @@ void set_encode_cpu_psi_phi_array(PsiPhiArray& data, const std::vector<RawImage>
     float safe_max_psi = data.get_psi_max_val() - data.get_psi_scale() / 100.0;
     float safe_max_phi = data.get_phi_max_val() - data.get_phi_scale() / 100.0;
 
-    int current_index = 0;
+    uint64 current_index = 0;
     int num_bytes = data.get_num_bytes();
     for (int t = 0; t < data.get_num_times(); ++t) {
         for (int row = 0; row < data.get_height(); ++row) {
@@ -287,7 +287,7 @@ void set_float_cpu_psi_phi_array(PsiPhiArray& data, const std::vector<RawImage>&
         throw std::runtime_error("Unable to allocate space for CPU PsiPhi array.");
     }
 
-    int current_index = 0;
+    uint64_t current_index = 0;
     for (int t = 0; t < data.get_num_times(); ++t) {
         for (int row = 0; row < data.get_height(); ++row) {
             for (int col = 0; col < data.get_width(); ++col) {

--- a/src/kbmod/search/psi_phi_array.cpp
+++ b/src/kbmod/search/psi_phi_array.cpp
@@ -248,7 +248,8 @@ void set_encode_cpu_psi_phi_array(PsiPhiArray& data, const std::vector<RawImage>
     float safe_max_psi = data.get_psi_max_val() - data.get_psi_scale() / 100.0;
     float safe_max_phi = data.get_phi_max_val() - data.get_phi_scale() / 100.0;
 
-    uint64 current_index = 0;
+    // We use a uint64_t to prevent overflow on large image stacks
+    uint64_t current_index = 0;
     int num_bytes = data.get_num_bytes();
     for (int t = 0; t < data.get_num_times(); ++t) {
         for (int row = 0; row < data.get_height(); ++row) {
@@ -287,6 +288,7 @@ void set_float_cpu_psi_phi_array(PsiPhiArray& data, const std::vector<RawImage>&
         throw std::runtime_error("Unable to allocate space for CPU PsiPhi array.");
     }
 
+    // We use a uint64_t to prevent overflow on large image stacks
     uint64_t current_index = 0;
     for (int t = 0; t < data.get_num_times(); ++t) {
         for (int row = 0; row < data.get_height(); ++row) {


### PR DESCRIPTION
In a recent KBMOD run, we used an ImageStack of 198 images with pixel dimensions of 4563 x 4563.

When filling out the psi phi arrays in `src/kbmod/search/psi_phi_array.cpp`, we allocate an array of size 4122551862 (= 4563 x 4563 x 198) 

We then iterate over the indices of that array with an int which has a max value of only 2147483647 on most systems. This then resorts in an overflow and segfault.

I switched to using a `uint64_t` since it is portable across systems.