### PR TITLE
Update the kernel memory functions to allow large images

### DIFF
--- a/src/kbmod/search/gpu_array.h
+++ b/src/kbmod/search/gpu_array.h
@@ -26,8 +26,7 @@ template <typename T>
 class GPUArray {
 public:
     // Use lazy allocation for uninitialized arrays.
-    explicit GPUArray(int num_items, bool allocate_now = false) : gpu_ptr(nullptr) {
-        if (num_items < 0) throw std::runtime_error("Invalid array size");
+    explicit GPUArray(uint64_t num_items, bool allocate_now = false) : gpu_ptr(nullptr) {
         size = num_items;
         memory_size = size * sizeof(T);
 
@@ -57,16 +56,14 @@ public:
 
     // --- Basic Getters --------------------
     inline bool on_gpu() const { return gpu_ptr != nullptr; }
-    inline unsigned int get_size() const { return size; }
-    inline unsigned long get_memory_size() const { return memory_size; }
+    inline uint64_t get_size() const { return size; }
+    inline uint64_t get_memory_size() const { return memory_size; }
     inline T* get_ptr() { return gpu_ptr; }
 
     // Resizing an array with allocated GPU memory must use the destructive flag
     // in which case it frees the memory.
-    void resize(int new_size, bool destructive = false) {
+    void resize(uint64_t new_size, bool destructive = false) {
         if (new_size == size) return;  // Nothing to do.
-
-        if (new_size < 0) throw std::runtime_error("Invalid array size");
         if (gpu_ptr != nullptr) {
             if (!destructive) throw std::runtime_error("Unable to resize array on GPU");
             free_gpu_memory();
@@ -112,8 +109,8 @@ public:
     }
 
 private:
-    unsigned int size;
-    unsigned long memory_size;
+    uint64_t size;
+    uint64_t memory_size;
     T* gpu_ptr;
 };
 

--- a/src/kbmod/search/kernels/kernel_memory.cu
+++ b/src/kbmod/search/kernels/kernel_memory.cu
@@ -15,7 +15,7 @@ namespace search {
 // --- Basic Memory Functions ------------
 // ---------------------------------------
 
-extern "C" void *allocate_gpu_block(unsigned long memory_size) {
+extern "C" void *allocate_gpu_block(uint64_t memory_size) {
     void *gpu_ptr;
     unsigned int res = static_cast<unsigned int>(cudaMalloc((void **)&gpu_ptr, memory_size));
     if ((res != 0) || (gpu_ptr == nullptr)) {
@@ -33,20 +33,22 @@ extern "C" void free_gpu_block(void *gpu_ptr) {
     }
 }
 
-extern "C" void copy_block_to_gpu(void *cpu_ptr, void *gpu_ptr, unsigned long memory_size) {
+extern "C" void copy_block_to_gpu(void *cpu_ptr, void *gpu_ptr, uint64_t memory_size) {
     if (cpu_ptr == nullptr) throw std::runtime_error("Invalid CPU pointer");
     if (gpu_ptr == nullptr) throw std::runtime_error("Invalid GPU pointer");
-    unsigned int res = static_cast<unsigned int>(cudaMemcpy(gpu_ptr, cpu_ptr, memory_size, cudaMemcpyHostToDevice));
+    unsigned int res =
+            static_cast<unsigned int>(cudaMemcpy(gpu_ptr, cpu_ptr, memory_size, cudaMemcpyHostToDevice));
     if (res != 0) {
         throw std::runtime_error("Unable to copy data to GPU (" + std::to_string(memory_size) +
                                  " bytes). Error code = " + std::to_string(res));
     }
 }
 
-extern "C" void copy_block_to_cpu(void *cpu_ptr, void *gpu_ptr, unsigned long memory_size) {
+extern "C" void copy_block_to_cpu(void *cpu_ptr, void *gpu_ptr, uint64_t memory_size) {
     if (cpu_ptr == nullptr) throw std::runtime_error("Invalid CPU pointer");
     if (gpu_ptr == nullptr) throw std::runtime_error("Invalid GPU pointer");
-    unsigned int res = static_cast<unsigned int>(cudaMemcpy(cpu_ptr, gpu_ptr, memory_size, cudaMemcpyDeviceToHost));
+    unsigned int res =
+            static_cast<unsigned int>(cudaMemcpy(cpu_ptr, gpu_ptr, memory_size, cudaMemcpyDeviceToHost));
     if (res != 0) {
         throw std::runtime_error("Unable to copy data to CPU (" + std::to_string(memory_size) +
                                  " bytes). Error code = " + std::to_string(res));

--- a/src/kbmod/search/kernels/kernel_memory.h
+++ b/src/kbmod/search/kernels/kernel_memory.h
@@ -17,13 +17,13 @@ namespace search {
 // --- Basic Memory Functions ------------
 // ---------------------------------------
 
-extern "C" void* allocate_gpu_block(unsigned long memory_size);
+extern "C" void* allocate_gpu_block(uint64_t memory_size);
 
 extern "C" void free_gpu_block(void* gpu_ptr);
 
-extern "C" void copy_block_to_gpu(void* cpu_ptr, void* gpu_ptr, unsigned long memory_size);
+extern "C" void copy_block_to_gpu(void* cpu_ptr, void* gpu_ptr, uint64_t memory_size);
 
-extern "C" void copy_block_to_cpu(void* cpu_ptr, void* gpu_ptr, unsigned long memory_size);
+extern "C" void copy_block_to_cpu(void* cpu_ptr, void* gpu_ptr, uint64_t memory_size);
 
 } /* namespace search */
 

--- a/src/kbmod/search/psf.cpp
+++ b/src/kbmod/search/psf.cpp
@@ -111,7 +111,7 @@ bool PSF::is_close(const PSF& img_b, float atol) const {
     }
     return true;
 }
-    
+
 std::string PSF::print() {
     std::stringstream ss;
     ss.setf(std::ios::fixed, std::ios::floatfield);

--- a/src/kbmod/search/psf.h
+++ b/src/kbmod/search/psf.h
@@ -42,9 +42,9 @@ public:
 
     // Comparison function (for testing).
     bool is_close(const PSF& img_b, float atol) const;
-    
+
     std::string print();
-    std::string stats_string() const;    
+    std::string stats_string() const;
 
 private:
     // Validates the PSF array and computes the sum.

--- a/src/kbmod/search/psi_phi_array.cpp
+++ b/src/kbmod/search/psi_phi_array.cpp
@@ -167,7 +167,7 @@ PsiPhi PsiPhiArray::read_psi_phi(int time, int row, int col) {
     }
 
     // Compute the in-list index from the row, column, and time.
-    int start_index = 2 * (meta_data.pixels_per_image * time + row * meta_data.width + col);
+    uint64_t start_index = 2 * (meta_data.pixels_per_image * time + row * meta_data.width + col);
 
     if (meta_data.num_bytes == 4) {
         // Short circuit the typical case of float encoding.
@@ -221,7 +221,7 @@ std::array<float, 3> compute_scale_params_from_image_vect(const std::vector<RawI
         float width = (max_val - min_val);
         if (width < 1e-6) width = 1e-6;  // Avoid a zero width.
 
-        long int num_values = (1 << (8 * num_bytes)) - 1;
+        uint64_t num_values = (1 << (8 * num_bytes)) - 1;
         scale = width / (double)num_values;
     }
 
@@ -248,7 +248,8 @@ void set_encode_cpu_psi_phi_array(PsiPhiArray& data, const std::vector<RawImage>
     float safe_max_psi = data.get_psi_max_val() - data.get_psi_scale() / 100.0;
     float safe_max_phi = data.get_phi_max_val() - data.get_phi_scale() / 100.0;
 
-    int current_index = 0;
+    // We use a uint64_t to prevent overflow on large image stacks
+    uint64_t current_index = 0;
     int num_bytes = data.get_num_bytes();
     for (int t = 0; t < data.get_num_times(); ++t) {
         for (int row = 0; row < data.get_height(); ++row) {
@@ -287,7 +288,8 @@ void set_float_cpu_psi_phi_array(PsiPhiArray& data, const std::vector<RawImage>&
         throw std::runtime_error("Unable to allocate space for CPU PsiPhi array.");
     }
 
-    int current_index = 0;
+    // We use a uint64_t to prevent overflow on large image stacks
+    uint64_t current_index = 0;
     for (int t = 0; t < data.get_num_times(); ++t) {
         for (int row = 0; row < data.get_height(); ++row) {
             for (int col = 0; col < data.get_width(); ++col) {
@@ -348,7 +350,7 @@ void fill_psi_phi_array(PsiPhiArray& result_data, int num_bytes, const std::vect
     }
 
     // Copy the time array.
-    const long unsigned times_bytes = result_data.get_num_times() * sizeof(double);
+    const uint64_t times_bytes = result_data.get_num_times() * sizeof(double);
     logging::getLogger("kbmod.search.psi_phi_array")
             ->debug("Allocating times on CPU: " + std::to_string(times_bytes) + " bytes.");
     result_data.set_time_array(zeroed_times);
@@ -361,7 +363,7 @@ void fill_psi_phi_array_from_image_stack(PsiPhiArray& result_data, ImageStack& s
     std::vector<RawImage> phi_images;
     const int num_images = stack.img_count();
 
-    unsigned long total_bytes = 2 * stack.get_height() * stack.get_width() * num_images * sizeof(float);
+    uint64_t total_bytes = 2 * stack.get_height() * stack.get_width() * num_images * sizeof(float);
     logging::getLogger("kbmod.search.psi_phi_array")
             ->info("Building " + std::to_string(num_images * 2) + " temporary " +
                    std::to_string(stack.get_height()) + " by " + std::to_string(stack.get_width()) +

--- a/src/kbmod/search/psi_phi_array_ds.h
+++ b/src/kbmod/search/psi_phi_array_ds.h
@@ -51,10 +51,10 @@ struct PsiPhiArrayMeta {
     int num_times = 0;
     int width = 0;
     int height = 0;
-    long unsigned pixels_per_image = 0;
-    long unsigned num_entries = 0;
+    uint64_t pixels_per_image = 0;
+    uint64_t num_entries = 0;
     int block_size = 0;  // Actual memory used per entry.
-    long unsigned total_array_size = 0;
+    uint64_t total_array_size = 0;
 
     // Compression and scaling parameters of on GPU array.
     int num_bytes = 4;  // 1 (unit8), 2 (unit16), or 4 (float)
@@ -86,9 +86,9 @@ public:
     inline int get_num_times() { return meta_data.num_times; }
     inline int get_width() { return meta_data.width; }
     inline int get_height() { return meta_data.height; }
-    inline long unsigned get_pixels_per_image() { return meta_data.pixels_per_image; }
-    inline long unsigned get_num_entries() { return meta_data.num_entries; }
-    inline long unsigned get_total_array_size() { return meta_data.total_array_size; }
+    inline uint64_t get_pixels_per_image() { return meta_data.pixels_per_image; }
+    inline uint64_t get_num_entries() { return meta_data.num_entries; }
+    inline uint64_t get_total_array_size() { return meta_data.total_array_size; }
     inline int get_block_size() { return meta_data.block_size; }
 
     inline float get_psi_min_val() { return meta_data.psi_min_val; }

--- a/src/kbmod/search/trajectory_list.cpp
+++ b/src/kbmod/search/trajectory_list.cpp
@@ -12,10 +12,7 @@ namespace search {
 // --- Implementation of core data structure functions ---
 // -------------------------------------------------------
 
-TrajectoryList::TrajectoryList(int max_list_size) {
-    if (max_list_size < 0) {
-        throw std::runtime_error("Invalid TrajectoryList size.");
-    }
+TrajectoryList::TrajectoryList(uint64_t max_list_size) {
     max_size = max_list_size;
 
     // Start with the data on CPU.
@@ -42,11 +39,8 @@ TrajectoryList::~TrajectoryList() {
     }
 }
 
-void TrajectoryList::resize(int new_size) {
+void TrajectoryList::resize(uint64_t new_size) {
     if (data_on_gpu) throw std::runtime_error("Data on GPU");
-    if (new_size < 0) {
-        throw std::runtime_error("Invalid TrajectoryList size.");
-    }
 
     cpu_list.resize(new_size);
     gpu_array.resize(new_size);
@@ -55,18 +49,17 @@ void TrajectoryList::resize(int new_size) {
 
 void TrajectoryList::set_trajectories(const std::vector<Trajectory> &new_values) {
     if (data_on_gpu) throw std::runtime_error("Data on GPU");
-    const int new_size = new_values.size();
+    const uint64_t new_size = new_values.size();
 
     resize(new_size);
-    for (int i = 0; i < new_size; ++i) {
+    for (uint64_t i = 0; i < new_size; ++i) {
         cpu_list[i] = new_values[i];
     }
 }
 
-std::vector<Trajectory> TrajectoryList::get_batch(int start, int count) {
+std::vector<Trajectory> TrajectoryList::get_batch(uint64_t start, uint64_t count) {
     if (data_on_gpu) throw std::runtime_error("Data on GPU");
-    if (start < 0) throw std::runtime_error("start must be 0 or greater");
-    if (count <= 0) throw std::runtime_error("count must be greater than 0");
+    if (count == 0) throw std::runtime_error("count must be greater than 0");
 
     if (start + count >= max_size) {
         count = max_size - start;
@@ -90,7 +83,7 @@ void TrajectoryList::filter_by_likelihood(float min_likelihood) {
     sort_by_likelihood();
 
     // Find the first index that does not meet the threshold.
-    int index = 0;
+    uint64_t index = 0;
     while ((index < max_size) && (cpu_list[index].lh >= min_likelihood)) {
         ++index;
     }
@@ -103,7 +96,7 @@ void TrajectoryList::filter_by_obs_count(int min_obs_count) {
     sort_by_obs_count();
 
     // Find the first index that does not meet the threshold.
-    int index = 0;
+    uint64_t index = 0;
     while ((index < max_size) && (cpu_list[index].obs_count >= min_obs_count)) {
         ++index;
     }
@@ -116,7 +109,7 @@ void TrajectoryList::filter_by_valid() {
     if (data_on_gpu) throw std::runtime_error("Data on GPU");
 
     auto new_end = std::partition(cpu_list.begin(), cpu_list.end(), [](Trajectory x) { return x.valid; });
-    int new_size = std::distance(cpu_list.begin(), new_end);
+    uint64_t new_size = std::distance(cpu_list.begin(), new_end);
     resize(new_size);
 }
 

--- a/src/kbmod/search/trajectory_list.h
+++ b/src/kbmod/search/trajectory_list.h
@@ -20,7 +20,7 @@ namespace search {
 
 class TrajectoryList {
 public:
-    explicit TrajectoryList(int max_list_size);
+    explicit TrajectoryList(uint64_t max_list_size);
     explicit TrajectoryList(const std::vector<Trajectory>& prev_list);
     virtual ~TrajectoryList();
 
@@ -31,16 +31,16 @@ public:
     TrajectoryList& operator=(const TrajectoryList&) = delete;
 
     // --- Getter functions ----------------
-    inline int get_size() const { return max_size; }
+    inline uint64_t get_size() const { return max_size; }
 
-    inline Trajectory& get_trajectory(int index) {
-        if (index < 0 || index > max_size) throw std::runtime_error("Index out of bounds.");
+    inline Trajectory& get_trajectory(uint64_t index) {
+        if (index > max_size) throw std::runtime_error("Index out of bounds.");
         if (data_on_gpu) throw std::runtime_error("Data on GPU");
         return cpu_list[index];
     }
 
-    inline void set_trajectory(int index, const Trajectory& new_value) {
-        if (index < 0 || index > max_size) throw std::runtime_error("Index out of bounds.");
+    inline void set_trajectory(uint64_t index, const Trajectory& new_value) {
+        if (index > max_size) throw std::runtime_error("Index out of bounds.");
         if (data_on_gpu) throw std::runtime_error("Data on GPU");
         cpu_list[index] = new_value;
     }
@@ -53,10 +53,10 @@ public:
     }
 
     // Forcibly resize. May add blank data.
-    void resize(int new_size);
+    void resize(uint64_t new_size);
 
     // Get a batch of results.
-    std::vector<Trajectory> get_batch(int start, int count);
+    std::vector<Trajectory> get_batch(uint64_t start, uint64_t count);
 
     // Processing functions for sorting or filtering.
     void sort_by_likelihood();
@@ -74,7 +74,7 @@ public:
     inline Trajectory* get_gpu_list_ptr() { return gpu_array.get_ptr(); }
 
 private:
-    int max_size;
+    uint64_t max_size;
     bool data_on_gpu;
 
     std::vector<Trajectory> cpu_list;

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -127,7 +127,6 @@ class test_search(unittest.TestCase):
         self.assertEqual(results[1].x, 3)
 
         # Check invalid settings
-        self.assertRaises(RuntimeError, self.search.get_results, -1, 5)
         self.assertRaises(RuntimeError, self.search.get_results, 0, 0)
 
     def test_load_and_filter_results_lh(self):

--- a/tests/test_trajectory_list.py
+++ b/tests/test_trajectory_list.py
@@ -18,9 +18,6 @@ class test_trajectory_list(unittest.TestCase):
             self.assertIsNotNone(self.trj_list.get_trajectory(i))
         self.assertEqual(len(self.trj_list.get_list()), self.max_size)
 
-        # Cannot create a zero or negative length list.
-        self.assertRaises(RuntimeError, TrajectoryList, -1)
-
         # Create from a list
         trj_list2 = TrajectoryList([Trajectory(x=2 * i) for i in range(8)])
         self.assertEqual(trj_list2.get_size(), 8)
@@ -55,11 +52,9 @@ class test_trajectory_list(unittest.TestCase):
 
         # Cannot get or set out of bounds.
         self.assertRaises(RuntimeError, self.trj_list.get_trajectory, self.max_size + 1)
-        self.assertRaises(RuntimeError, self.trj_list.get_trajectory, -1)
 
         new_trj = Trajectory(x=10)
         self.assertRaises(RuntimeError, self.trj_list.set_trajectory, self.max_size + 1, new_trj)
-        self.assertRaises(RuntimeError, self.trj_list.set_trajectory, -1, new_trj)
 
     def test_get_batch(self):
         for i in range(self.max_size):
@@ -72,10 +67,6 @@ class test_trajectory_list(unittest.TestCase):
         # We can run off the end.
         subset = self.trj_list.get_batch(3, 100)
         self.assertEqual(len(subset), 7)
-
-        # We cannot use an invalid starting index or batch size
-        self.assertRaises(RuntimeError, self.trj_list.get_batch, -1, 3)
-        self.assertRaises(RuntimeError, self.trj_list.get_batch, 3, -1)
 
     def test_sort(self):
         lh = [100.0, 110.0, 90.0, 120.0, 125.0]


### PR DESCRIPTION
Change the kernel memory functions to allow arrays with a large amount of data (needing indices of int64). Change `unsigned long` to `uint64_t` for consistency throughout the code.

Also adds a divide by zero check in the core search code.
