### PR TITLE
Add ability to output GPU memory stats on crash

### DIFF
--- a/src/kbmod/search/kernels/kernel_memory.cu
+++ b/src/kbmod/search/kernels/kernel_memory.cu
@@ -7,9 +7,29 @@
 #ifndef KERNELS_MEMORY_CU_
 #define KERNELS_MEMORY_CU_
 
+#include <iostream>
 #include "kernel_memory.h"
 
 namespace search {
+
+// Helpful debugging stats for when something crashes in the GPU.
+void cuda_print_stats() {
+    std::cout << "\n----- CUDA Debugging Log -----\n";
+
+    int device_num, device_count;
+    cudaGetDevice(&device_num);
+    cudaGetDeviceCount(&device_count);
+    std::cout << "Device: " << device_num << " [" << device_count << " devices available]\n";
+
+    // Output information about the current memory usage.
+    size_t free_mem, total_mem;
+    cudaMemGetInfo(&free_mem, &total_mem);
+    double total_mb = ((double)total_mem) / 1048576.0;
+    double free_mb = ((double)free_mem) / 1048576.0;
+    std::cout << "Total Memory: " << total_mb << " MB\n";
+    std::cout << "Used Memory: " << (total_mb - free_mb) << " MB\n";
+    std::cout << "Free Memory: " << free_mb << " MB\n";
+}
 
 // ---------------------------------------
 // --- Basic Memory Functions ------------
@@ -19,6 +39,7 @@ extern "C" void *allocate_gpu_block(uint64_t memory_size) {
     void *gpu_ptr;
     unsigned int res = static_cast<unsigned int>(cudaMalloc((void **)&gpu_ptr, memory_size));
     if ((res != 0) || (gpu_ptr == nullptr)) {
+        cuda_print_stats();
         throw std::runtime_error("Unable to allocate GPU memory (" + std::to_string(memory_size) +
                                  " bytes). Error code = " + std::to_string(res));
     }
@@ -29,6 +50,7 @@ extern "C" void free_gpu_block(void *gpu_ptr) {
     if (gpu_ptr == nullptr) throw std::runtime_error("Trying to free nullptr.");
     unsigned int res = static_cast<unsigned int>(cudaFree(gpu_ptr));
     if (res != 0) {
+        cuda_print_stats();
         throw std::runtime_error("Unable to free GPU memory. Error code = " + std::to_string(res));
     }
 }
@@ -39,6 +61,7 @@ extern "C" void copy_block_to_gpu(void *cpu_ptr, void *gpu_ptr, uint64_t memory_
     unsigned int res =
             static_cast<unsigned int>(cudaMemcpy(gpu_ptr, cpu_ptr, memory_size, cudaMemcpyHostToDevice));
     if (res != 0) {
+        cuda_print_stats();
         throw std::runtime_error("Unable to copy data to GPU (" + std::to_string(memory_size) +
                                  " bytes). Error code = " + std::to_string(res));
     }
@@ -50,6 +73,7 @@ extern "C" void copy_block_to_cpu(void *cpu_ptr, void *gpu_ptr, uint64_t memory_
     unsigned int res =
             static_cast<unsigned int>(cudaMemcpy(cpu_ptr, gpu_ptr, memory_size, cudaMemcpyDeviceToHost));
     if (res != 0) {
+        cuda_print_stats();
         throw std::runtime_error("Unable to copy data to CPU (" + std::to_string(memory_size) +
                                  " bytes). Error code = " + std::to_string(res));
     }

--- a/src/kbmod/search/kernels/kernel_memory.h
+++ b/src/kbmod/search/kernels/kernel_memory.h
@@ -13,6 +13,8 @@
 
 namespace search {
 
+void cuda_print_stats();
+    
 // ---------------------------------------
 // --- Basic Memory Functions ------------
 // ---------------------------------------


### PR DESCRIPTION
If the program fails during a GPU memory operation (allocation, freeing, etc.), it first dumps basic memory stats to stdout to help with debugging.