### PR TITLE
Fix pontential integer overflows

### DIFF
--- a/src/kbmod/search/common.h
+++ b/src/kbmod/search/common.h
@@ -42,10 +42,10 @@ struct Trajectory {
     // Est. Flux
     float flux = 0.0;
     // Origin
-    short x = 0;
-    short y = 0;
+    int x = 0;
+    int y = 0;
     // Number of images summed
-    short obs_count;
+    int obs_count;
     // Whether the trajectory is valid. Used for on-GPU filtering.
     bool valid = true;
 
@@ -216,8 +216,8 @@ static void trajectory_bindings(py::module &m) {
                     [](py::tuple t) {  // __setstate__
                         if (t.size() != 8) throw std::runtime_error("Invalid state!");
                         tj trj = {t[0].cast<float>(), t[1].cast<float>(), t[2].cast<float>(),
-                                  t[3].cast<float>(), t[4].cast<short>(), t[5].cast<short>(),
-                                  t[6].cast<short>(), t[7].cast<bool>()};
+                                  t[3].cast<float>(), t[4].cast<int>(), t[5].cast<int>(),
+                                  t[6].cast<int>(), t[7].cast<bool>()};
                         return trj;
                     }));
 }

--- a/src/kbmod/search/common.h
+++ b/src/kbmod/search/common.h
@@ -216,8 +216,8 @@ static void trajectory_bindings(py::module &m) {
                     [](py::tuple t) {  // __setstate__
                         if (t.size() != 8) throw std::runtime_error("Invalid state!");
                         tj trj = {t[0].cast<float>(), t[1].cast<float>(), t[2].cast<float>(),
-                                  t[3].cast<float>(), t[4].cast<int>(), t[5].cast<int>(),
-                                  t[6].cast<int>(), t[7].cast<bool>()};
+                                  t[3].cast<float>(), t[4].cast<int>(),   t[5].cast<int>(),
+                                  t[6].cast<int>(),   t[7].cast<bool>()};
                         return trj;
                     }));
 }

--- a/src/kbmod/search/image_stack.cpp
+++ b/src/kbmod/search/image_stack.cpp
@@ -60,7 +60,7 @@ void ImageStack::convolve_psf() {
 }
 
 RawImage ImageStack::make_global_mask(int flags, int threshold) {
-    int npixels = get_npixels();
+    uint64_t npixels = get_npixels();
 
     // Start with an empty global mask.
     RawImage global_mask = RawImage(get_width(), get_height());
@@ -72,14 +72,14 @@ RawImage ImageStack::make_global_mask(int flags, int threshold) {
         auto imgMask = images[img].get_mask().get_image().reshaped();
 
         // Count the number of times a pixel has any of the given flags
-        for (unsigned int pixel = 0; pixel < npixels; ++pixel) {
+        for (uint64_t pixel = 0; pixel < npixels; ++pixel) {
             if ((flags & static_cast<int>(imgMask[pixel])) != 0) counts[pixel]++;
         }
     }
 
     // Set all pixels below threshold to 0 and all above to 1
     auto global_m = global_mask.get_image().reshaped();
-    for (unsigned int p = 0; p < npixels; ++p) {
+    for (uint64_t p = 0; p < npixels; ++p) {
         global_m[p] = counts[p] < threshold ? 0.0 : 1.0;
     }
 
@@ -107,7 +107,8 @@ static void image_stack_bindings(py::module& m) {
             .def("convolve_psf", &is::convolve_psf, pydocs::DOC_ImageStack_convolve_psf)
             .def("get_width", &is::get_width, pydocs::DOC_ImageStack_get_width)
             .def("get_height", &is::get_height, pydocs::DOC_ImageStack_get_height)
-            .def("get_npixels", &is::get_npixels, pydocs::DOC_ImageStack_get_npixels);
+            .def("get_npixels", &is::get_npixels, pydocs::DOC_ImageStack_get_npixels)
+            .def("get_total_pixels", &is::get_total_pixels, pydocs::DOC_ImageStack_get_total_pixels);
 }
 
 #endif /* Py_PYTHON_H */

--- a/src/kbmod/search/image_stack.h
+++ b/src/kbmod/search/image_stack.h
@@ -20,7 +20,10 @@ public:
     unsigned img_count() const { return images.size(); }
     unsigned get_width() const { return images.size() > 0 ? images[0].get_width() : 0; }
     unsigned get_height() const { return images.size() > 0 ? images[0].get_height() : 0; }
-    unsigned get_npixels() const { return images.size() > 0 ? images[0].get_npixels() : 0; }
+    uint64_t get_npixels() const { return images.size() > 0 ? images[0].get_npixels() : 0; }
+    uint64_t get_total_pixels() const {
+        return images.size() > 0 ? images[0].get_npixels() * images.size() : 0;
+    }
     std::vector<LayeredImage>& get_images() { return images; }
     LayeredImage& get_single_image(int index);
 

--- a/src/kbmod/search/kernels/kernels.cu
+++ b/src/kbmod/search/kernels/kernels.cu
@@ -362,7 +362,7 @@ __global__ void deviceGetCoaddStamp(int num_images, int width, int height, float
         int img_x = current_x - params.radius + stamp_x;
         int img_y = current_y - params.radius + stamp_y;
         if ((img_x >= 0) && (img_x < width) && (img_y >= 0) && (img_y < height)) {
-            int pixel_index = width * height * t + img_y * width + img_x;
+            uint64_t pixel_index = width * height * t + img_y * width + img_x;
             if (device_pixel_valid(image_vect[pixel_index])) {
                 values[num_values] = image_vect[pixel_index];
                 ++num_values;

--- a/src/kbmod/search/layered_image.cpp
+++ b/src/kbmod/search/layered_image.cpp
@@ -169,7 +169,7 @@ RawImage LayeredImage::generate_psi_image() {
 
     // Set each of the result pixels.
     const uint64_t num_pixels = get_npixels();
-    int no_data_count = 0;
+    uint64_t no_data_count = 0;
     for (uint64_t p = 0; p < num_pixels; ++p) {
         float var_pix = var_array[p];
         if (pixel_value_valid(var_pix) && var_pix != 0.0 && pixel_value_valid(sci_array[p])) {
@@ -197,7 +197,7 @@ RawImage LayeredImage::generate_phi_image() {
 
     // Set each of the result pixels.
     const uint64_t num_pixels = get_npixels();
-    int no_data_count = 0;
+    uint64_t no_data_count = 0;
     for (uint64_t p = 0; p < num_pixels; ++p) {
         float var_pix = var_array[p];
         if (pixel_value_valid(var_pix) && var_pix != 0.0) {

--- a/src/kbmod/search/layered_image.h
+++ b/src/kbmod/search/layered_image.h
@@ -23,7 +23,7 @@ public:
     // Basic getter functions for image data.
     unsigned get_width() const { return width; }
     unsigned get_height() const { return height; }
-    unsigned get_npixels() const { return width * height; }
+    uint64_t get_npixels() const { return width * height; }
     double get_obstime() const { return science.get_obstime(); }
     void set_obstime(double obstime) { science.set_obstime(obstime); }
 

--- a/src/kbmod/search/psi_phi_array.cpp
+++ b/src/kbmod/search/psi_phi_array.cpp
@@ -251,9 +251,9 @@ void set_encode_cpu_psi_phi_array(PsiPhiArray& data, const std::vector<RawImage>
     // We use a uint64_t to prevent overflow on large image stacks
     uint64_t current_index = 0;
     int num_bytes = data.get_num_bytes();
-    for (int t = 0; t < data.get_num_times(); ++t) {
-        for (int row = 0; row < data.get_height(); ++row) {
-            for (int col = 0; col < data.get_width(); ++col) {
+    for (unsigned int t = 0; t < data.get_num_times(); ++t) {
+        for (unsigned int row = 0; row < data.get_height(); ++row) {
+            for (unsigned int col = 0; col < data.get_width(); ++col) {
                 float psi_value = psi_imgs[t].get_pixel({row, col});
                 float phi_value = phi_imgs[t].get_pixel({row, col});
 
@@ -290,9 +290,9 @@ void set_float_cpu_psi_phi_array(PsiPhiArray& data, const std::vector<RawImage>&
 
     // We use a uint64_t to prevent overflow on large image stacks
     uint64_t current_index = 0;
-    for (int t = 0; t < data.get_num_times(); ++t) {
-        for (int row = 0; row < data.get_height(); ++row) {
-            for (int col = 0; col < data.get_width(); ++col) {
+    for (unsigned int t = 0; t < data.get_num_times(); ++t) {
+        for (unsigned int row = 0; row < data.get_height(); ++row) {
+            for (unsigned int col = 0; col < data.get_width(); ++col) {
                 encoded[current_index++] = psi_imgs[t].get_pixel({row, col});
                 encoded[current_index++] = phi_imgs[t].get_pixel({row, col});
             }
@@ -370,7 +370,7 @@ void fill_psi_phi_array_from_image_stack(PsiPhiArray& result_data, ImageStack& s
                    " images, requiring " + std::to_string(total_bytes) + " bytes.");
 
     // Build the psi and phi images first.
-    for (int i = 0; i < num_images; ++i) {
+    for (unsigned int i = 0; i < num_images; ++i) {
         LayeredImage& img = stack.get_single_image(i);
         psi_images.push_back(img.generate_psi_image());
         phi_images.push_back(img.generate_phi_image());

--- a/src/kbmod/search/pydocs/image_stack_docs.h
+++ b/src/kbmod/search/pydocs/image_stack_docs.h
@@ -82,6 +82,10 @@ static const auto DOC_ImageStack_get_npixels = R"doc(
   Returns the number of pixels per image.
   )doc";
 
+static const auto DOC_ImageStack_get_total_pixels = R"doc(
+  Returns the total number of pixels in all the images.
+  )doc";
+
 }  // namespace pydocs
 
 #endif /* IMAGESTACK_DOCS */

--- a/src/kbmod/search/pydocs/stack_search_docs.h
+++ b/src/kbmod/search/pydocs/stack_search_docs.h
@@ -104,20 +104,20 @@ static const auto DOC_StackSearch_set_results_per_pixel = R"doc(
   )doc";
 
 static const auto DOC_StackSearch_get_num_images = R"doc(
-  "Returns the number of images to process.
-  ")doc";
+  Returns the number of images to process.
+  )doc";
 
 static const auto DOC_StackSearch_get_image_width = R"doc(
-  "Returns the width of the images in pixels.
-  ")doc";
+  Returns the width of the images in pixels.
+  )doc";
 
 static const auto DOC_StackSearch_get_image_height = R"doc(
-  "Returns the height of the images in pixels.
-  ")doc";
+  Returns the height of the images in pixels.
+  )doc";
 
 static const auto DOC_StackSearch_get_image_npixels = R"doc(
-  "Returns the number of pixels for each image.
-  ")doc";
+  Returns the number of pixels for each image.
+  )doc";
 
 static const auto DOC_StackSearch_get_imagestack = R"doc(
   Return the `kb.ImageStack` containing the data to search.

--- a/src/kbmod/search/raw_image.cpp
+++ b/src/kbmod/search/raw_image.cpp
@@ -57,8 +57,8 @@ RawImage& RawImage::operator=(RawImage&& source) {
 }
 
 bool RawImage::l2_allclose(const RawImage& img_b, float atol) const {
-    for (int y = 0; y < height; ++y) {
-        for (int x = 0; x < width; ++x) {
+    for (unsigned int y = 0; y < height; ++y) {
+        for (unsigned int x = 0; x < width; ++x) {
             if (!pixel_value_valid(image(y, x))) {
                 if (pixel_value_valid(img_b.image(y, x))) return false;
             } else if (!pixel_value_valid(img_b.image(y, x))) {
@@ -121,8 +121,8 @@ float RawImage::interpolate(const Point& p) const {
 }
 
 void RawImage::replace_masked_values(float value) {
-    for (int y = 0; y < height; ++y) {
-        for (int x = 0; x < width; ++x) {
+    for (unsigned int y = 0; y < height; ++y) {
+        for (unsigned int x = 0; x < width; ++x) {
             if (!pixel_value_valid(image(y, x))) {
                 image(y, x) = value;
             }
@@ -312,7 +312,7 @@ Index RawImage::find_peak(bool furthest_from_center) const {
 // value has been shifted to zero and the sum of all elements is 1.0.
 // Elements with invalid or masked data are treated as zero.
 ImageMoments RawImage::find_central_moments() const {
-    const int num_pixels = width * height;
+    const uint64_t num_pixels = width * height;
     const int c_x = width / 2;
     const int c_y = height / 2;
 
@@ -328,7 +328,7 @@ ImageMoments RawImage::find_central_moments() const {
 
     // Find the sum of the zero-shifted (valid) pixels.
     double sum = 0.0;
-    for (int p = 0; p < num_pixels; ++p) {
+    for (uint64_t p = 0; p < num_pixels; ++p) {
         sum += pixel_value_valid(pixels[p]) ? (pixels[p] - min_val) : 0.0;
     }
     if (sum == 0.0) return res;
@@ -352,7 +352,7 @@ ImageMoments RawImage::find_central_moments() const {
 }
 
 bool RawImage::center_is_local_max(double flux_thresh, bool local_max) const {
-    const int num_pixels = width * height;
+    const uint64_t num_pixels = width * height;
     int c_x = width / 2;
     int c_y = height / 2;
     int c_ind = c_y * width + c_x;
@@ -362,7 +362,7 @@ bool RawImage::center_is_local_max(double flux_thresh, bool local_max) const {
 
     // Find the sum of the zero-shifted (valid) pixels.
     double sum = 0.0;
-    for (int p = 0; p < num_pixels; ++p) {
+    for (uint64_t p = 0; p < num_pixels; ++p) {
         float pix_val = pixels[p];
         if (p != c_ind && local_max && pix_val >= center_val) {
             return false;

--- a/src/kbmod/search/raw_image.h
+++ b/src/kbmod/search/raw_image.h
@@ -38,7 +38,7 @@ public:
     // Basic getter functions for image data.
     unsigned get_width() const { return width; }
     unsigned get_height() const { return height; }
-    unsigned get_npixels() const { return width * height; }
+    uint64_t get_npixels() const { return width * height; }
     const Image& get_image() const { return image; }
     Image& get_image() { return image; }
     void set_image(Image& other) { image = other; }

--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -219,10 +219,10 @@ std::vector<Trajectory> StackSearch::search_single_batch() {
     return results.get_batch(0, max_results);
 }
 
-int StackSearch::compute_max_results() {
+uint64_t StackSearch::compute_max_results() {
     int search_width = params.x_start_max - params.x_start_min;
     int search_height = params.y_start_max - params.y_start_min;
-    int num_search_pixels = search_width * search_height;
+    uint64_t num_search_pixels = search_width * search_height;
     return num_search_pixels * params.results_per_pixel;
 }
 

--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -140,7 +140,7 @@ void StackSearch::evaluate_single_trajectory(Trajectory& trj) {
 #endif
 }
 
-Trajectory StackSearch::search_linear_trajectory(short x, short y, float vx, float vy) {
+Trajectory StackSearch::search_linear_trajectory(int x, int y, float vx, float vy) {
     Trajectory result;
     result.x = x;
     result.y = y;

--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -214,7 +214,7 @@ void StackSearch::search_batch() {
 }
 
 std::vector<Trajectory> StackSearch::search_single_batch() {
-    int max_results = compute_max_results();
+    uint64_t max_results = compute_max_results();
     search_batch();
     return results.get_batch(0, max_results);
 }
@@ -229,11 +229,11 @@ uint64_t StackSearch::compute_max_results() {
 std::vector<float> StackSearch::extract_psi_or_phi_curve(Trajectory& trj, bool extract_psi) {
     prepare_psi_phi();
 
-    const int num_times = stack.img_count();
+    const unsigned int num_times = stack.img_count();
     std::vector<float> result(num_times, 0.0);
 
-    for (int i = 0; i < num_times; ++i) {
-        float time = psi_phi_array.read_time(i);
+    for (unsigned int i = 0; i < num_times; ++i) {
+        double time = psi_phi_array.read_time(i);
 
         // Query the center of the predicted location's pixel.
         PsiPhi psi_phi_val = psi_phi_array.read_psi_phi(i, trj.get_y_index(time), trj.get_x_index(time));

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -48,7 +48,7 @@ public:
 
     // The primary search functions
     void evaluate_single_trajectory(Trajectory& trj);
-    Trajectory search_linear_trajectory(short x, short y, float vx, float vy);
+    Trajectory search_linear_trajectory(int x, int y, float vx, float vy);
     void prepare_search(std::vector<Trajectory>& search_list, int min_observations);
     std::vector<Trajectory> search_single_batch();
     void search_batch();

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -30,11 +30,11 @@ using Image = search::Image;
 class StackSearch {
 public:
     StackSearch(ImageStack& imstack);
-    int compute_max_results();
+    uint64_t compute_max_results();
     int num_images() const { return stack.img_count(); }
     int get_image_width() const { return stack.get_width(); }
     int get_image_height() const { return stack.get_height(); }
-    int get_image_npixels() const { return stack.get_npixels(); }
+    uint64_t get_image_npixels() const { return stack.get_npixels(); }
     const ImageStack& get_imagestack() const { return stack; }
 
     // Parameter setters used to control the searches.

--- a/src/kbmod/search/stamp_creator.cpp
+++ b/src/kbmod/search/stamp_creator.cpp
@@ -18,8 +18,8 @@ std::vector<RawImage> StampCreator::create_stamps(ImageStack& stack, const Traje
     bool use_all_stamps = use_index.size() == 0;
 
     std::vector<RawImage> stamps;
-    int num_times = stack.img_count();
-    for (int i = 0; i < num_times; ++i) {
+    unsigned int num_times = stack.img_count();
+    for (unsigned int i = 0; i < num_times; ++i) {
         if (use_all_stamps || use_index[i]) {
             // Calculate the trajectory position.
             double time = stack.get_zeroed_time(i);
@@ -79,10 +79,10 @@ std::vector<RawImage> StampCreator::get_coadded_stamps_cpu(ImageStack& stack,
                                                            std::vector<Trajectory>& t_array,
                                                            std::vector<std::vector<bool>>& use_index_vect,
                                                            const StampParameters& params) {
-    const int num_trajectories = t_array.size();
+    const uint64_t num_trajectories = t_array.size();
     std::vector<RawImage> results(num_trajectories);
 
-    for (int i = 0; i < num_trajectories; ++i) {
+    for (uint64_t i = 0; i < num_trajectories; ++i) {
         std::vector<RawImage> stamps =
                 StampCreator::create_stamps(stack, t_array[i], params.radius, true, use_index_vect[i]);
 
@@ -115,7 +115,7 @@ std::vector<RawImage> StampCreator::get_coadded_stamps_cpu(ImageStack& stack,
 bool StampCreator::filter_stamp(const RawImage& img, const StampParameters& params) {
     // Allocate space for the coadd information and initialize to zero.
     const int stamp_width = 2 * params.radius + 1;
-    const int stamp_ppi = stamp_width * stamp_width;
+    const uint64_t stamp_ppi = stamp_width * stamp_width;
     // this ends up being something like eigen::vector1f something, not vector
     // but it behaves in all the same ways so just let it figure it out itself
     const auto& pixels = img.get_image().reshaped();
@@ -132,7 +132,7 @@ bool StampCreator::filter_stamp(const RawImage& img, const StampParameters& para
         const auto& pixels = img.get_image().reshaped();
         float center_val = pixels[idx.j * stamp_width + idx.i];
         float pixel_sum = 0.0;
-        for (int p = 0; p < stamp_ppi; ++p) {
+        for (uint64_t p = 0; p < stamp_ppi; ++p) {
             pixel_sum += pixels[p];
         }
 
@@ -169,7 +169,7 @@ std::vector<RawImage> StampCreator::get_coadded_stamps_gpu(ImageStack& stack,
     std::vector<double> image_times = stack.build_zeroed_times();
 
     // Allocate space for the results.
-    const int num_trajectories = t_array.size();
+    const uint64_t num_trajectories = t_array.size();
     const int stamp_width = 2 * params.radius + 1;
     const int stamp_ppi = stamp_width * stamp_width;
     std::vector<float> stamp_data(stamp_ppi * num_trajectories);
@@ -200,10 +200,10 @@ std::vector<RawImage> StampCreator::get_coadded_stamps_gpu(ImageStack& stack,
     // Copy the stamps into RawImages and do the filtering.
     std::vector<RawImage> results(num_trajectories);
     std::vector<float> current_pixels(stamp_ppi, 0.0);
-    for (int t = 0; t < num_trajectories; ++t) {
+    for (uint64_t t = 0; t < num_trajectories; ++t) {
         // Copy the data into a single RawImage.
-        int offset = t * stamp_ppi;
-        for (unsigned p = 0; p < stamp_ppi; ++p) {
+        uint64_t offset = t * stamp_ppi;
+        for (uint64_t p = 0; p < stamp_ppi; ++p) {
             current_pixels[p] = stamp_data[offset + p];
         }
 

--- a/tests/test_image_stack.py
+++ b/tests/test_image_stack.py
@@ -34,6 +34,7 @@ class test_ImageStack(unittest.TestCase):
         self.assertEqual(self.im_stack.get_height(), 80)
         self.assertEqual(self.im_stack.get_width(), 60)
         self.assertEqual(self.im_stack.get_npixels(), 60 * 80)
+        self.assertEqual(self.im_stack.get_total_pixels(), 5 * 60 * 80)
 
         # Add an image of the wrong size.
         self.images.append(make_fake_layered_image(5, 5, 2.0, 4.0, 10.0, self.p[0]))


### PR DESCRIPTION
This PR includes a series of changes meant to support large image sizes:

- Change the starting coordinate in `Trajectory` from `short` to `int`.
- Change all instance of the computation and storage of the number of pixels per image to a unsigned 64.
- Allow for greater than an int’s worth of result trajectories to be sorted in a `TrajectoryList` during stamp creation.

Also a few clean ups:
- Fix some docstring formats
- Change loops over the dimensions from `int` to `unsigned int` for clarity.
- Change the time lookup in `extract_psi_or_phi_curve()` from `float` to `double` to be consistent with the precision used in the rest of the code. 