### PR TITLE
creates image_positions_to_original_icrs

### DIFF
--- a/src/kbmod/reprojection_utils.py
+++ b/src/kbmod/reprojection_utils.py
@@ -106,7 +106,7 @@ def invert_correct_parallax(coord, obstime, point_on_earth, geocentric_distance,
     )
 
     original_icrs = gcrs_with_dist.transform_to(ICRS())
-    return original_icrs
+    return SkyCoord(ra=original_icrs.ra, dec=original_icrs.dec, unit="deg")
 
 
 def fit_barycentric_wcs(

--- a/src/kbmod/wcs_utils.py
+++ b/src/kbmod/wcs_utils.py
@@ -478,6 +478,8 @@ def make_fake_wcs_info(center_ra, center_dec, height, width, deg_per_pixel=None)
         "CTYPE2A": "LINEAR  ",
         "CUNIT1A": "PIXEL   ",
         "CUNIT2A": "PIXEL   ",
+        "NAXIS1" : width,
+        "NAXIX2" : height,
     }
 
     if deg_per_pixel is not None:
@@ -510,7 +512,9 @@ def make_fake_wcs(center_ra, center_dec, height, width, deg_per_pixel=None):
         The resulting WCS.
     """
     wcs_dict = make_fake_wcs_info(center_ra, center_dec, height, width, deg_per_pixel)
-    return astropy.wcs.WCS(wcs_dict)
+    wcs = astropy.wcs.WCS(wcs_dict)
+    wcs.array_shape = (height, width)
+    return wcs
 
 
 def wcs_fits_equal(wcs_a, wcs_b):

--- a/src/kbmod/wcs_utils.py
+++ b/src/kbmod/wcs_utils.py
@@ -478,8 +478,8 @@ def make_fake_wcs_info(center_ra, center_dec, height, width, deg_per_pixel=None)
         "CTYPE2A": "LINEAR  ",
         "CUNIT1A": "PIXEL   ",
         "CUNIT2A": "PIXEL   ",
-        "NAXIS1" : width,
-        "NAXIX2" : height,
+        "NAXIS1": width,
+        "NAXIX2": height,
     }
 
     if deg_per_pixel is not None:

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -589,7 +589,9 @@ class WorkUnit:
 
         return dump(workunit_dict)
 
-    def image_positions_to_original_icrs(self, image_indices, positions, input_format="xy", output_format="xy", filter_in_frame=True):
+    def image_positions_to_original_icrs(
+        self, image_indices, positions, input_format="xy", output_format="xy", filter_in_frame=True
+    ):
         """Method to transform image positions in EBD reprojected images
         into coordinates in the orignal ICRS frame of reference.
 
@@ -625,17 +627,12 @@ class WorkUnit:
         if input_format not in ["xy", "radec"]:
             raise ValueError(f"input format must be 'xy' or 'radec' , '{input_format}' provided")
         if input_format == "xy":
-            if not all(
-                isinstance(i, tuple) and
-                len(i) == 2 for i in positions
-            ):
+            if not all(isinstance(i, tuple) and len(i) == 2 for i in positions):
                 raise ValueError("positions in incorrect format for input_format='xy'")
         if input_format == "radec" and not all(isinstance(i, SkyCoord) for i in positions):
             raise ValueError("positions in incorrect format for input_format='radec'")
         if len(positions) != len(image_indices):
-            raise ValueError(
-                f"wrong number of inputs, expected {len(image_indices)}, got {len(positions)}"
-            )
+            raise ValueError(f"wrong number of inputs, expected {len(image_indices)}, got {len(positions)}")
 
         if output_format not in ["xy", "radec"]:
             raise ValueError(f"output format must be 'xy' or 'radec' , '{output_format}' provided")
@@ -681,13 +678,13 @@ class WorkUnit:
                 con_image = self.constituent_images[j]
                 con_wcs = self._per_image_wcs[j]
                 height, width = con_wcs.array_shape
-                x,y = skycoord_to_pixel(coord, con_wcs)
+                x, y = skycoord_to_pixel(coord, con_wcs)
                 x, y = float(x), float(y)
                 if output_format == "xy":
-                    result_coord = (x,y)
+                    result_coord = (x, y)
                 else:
                     result_coord = coord
-                to_allow = (y >= 0. and y <= height and x >= 0 and x <= width) or (not filter_in_frame)
+                to_allow = (y >= 0.0 and y <= height and x >= 0 and x <= width) or (not filter_in_frame)
                 if to_allow:
                     pos.append((result_coord, con_image))
             if len(pos) == 0:
@@ -697,12 +694,11 @@ class WorkUnit:
                 if filter_in_frame:
                     warnings.warn(
                         f"ambiguous image origin for coordinate {i}, including all potential constituent images.",
-                        Warning
+                        Warning,
                     )
             else:
                 positions.append(pos[0])
         return positions
-
 
 
 def raw_image_to_hdu(img, wcs=None):
@@ -752,4 +748,3 @@ def hdu_to_raw_image(hdu):
         if "MJD" in hdu.header:
             img.obstime = hdu.header["MJD"]
     return img
-

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -1,6 +1,8 @@
 from astropy.io import fits
 from astropy.table import Table
 from astropy.wcs import WCS
+from astropy.coordinates import EarthLocation, SkyCoord
+from astropy.time import Time
 import numpy as np
 import os
 from pathlib import Path
@@ -11,8 +13,11 @@ import warnings
 from kbmod.configuration import SearchConfiguration
 from kbmod.fake_data.fake_data_creator import make_fake_layered_image
 import kbmod.search as kb
+from kbmod.reprojection_utils import fit_barycentric_wcs
 from kbmod.wcs_utils import make_fake_wcs, wcs_fits_equal
 from kbmod.work_unit import hdu_to_raw_image, raw_image_to_hdu, WorkUnit
+
+import numpy.testing as npt
 
 
 class test_work_unit(unittest.TestCase):
@@ -29,7 +34,7 @@ class test_work_unit(unittest.TestCase):
                 self.height,
                 2.0,  # noise_level
                 4.0,  # variance
-                2.0 * i + 1.0,  # time
+                59000. + (2.0 * i + 1.0),  # time
                 self.p[i],
             )
 
@@ -46,12 +51,12 @@ class test_work_unit(unittest.TestCase):
         self.config.set("repeated_flag_keys", None)
 
         # Create a fake WCS
-        self.wcs = make_fake_wcs(200.6145, -7.7888, 2000, 4000)
+        self.wcs = make_fake_wcs(200.6145, -7.7888, 500, 700, 0.00027)
         self.per_image_wcs = per_image_wcs = [self.wcs for i in range(self.num_images)]
 
         self.diff_wcs = []
         for i in range(self.num_images):
-            self.diff_wcs.append(make_fake_wcs(200.0 + i, -7.7888, 2000, 4000))
+            self.diff_wcs.append(make_fake_wcs(200.0 + i, -7.7888, 500, 700))
 
     def test_create(self):
         # Test the creation of a WorkUnit with no WCS. Should throw a warning.
@@ -196,7 +201,7 @@ class test_work_unit(unittest.TestCase):
                 li = work2.im_stack.get_single_image(i)
                 self.assertEqual(li.get_width(), self.width)
                 self.assertEqual(li.get_height(), self.height)
-                self.assertEqual(li.get_obstime(), 2 * i + 1)
+                self.assertEqual(li.get_obstime(), 59000. + (2 * i + 1))
 
                 # Check the three image layers match.
                 sci1 = li.get_science()
@@ -275,6 +280,196 @@ class test_work_unit(unittest.TestCase):
         self.assertDictEqual(work2.config["mask_bits_dict"], {"A": 1, "B": 2})
         self.assertIsNone(work2.config["repeated_flag_keys"])
 
+    def test_image_positions_to_original_icrs(self):
+        # work = WorkUnit(im_stack=self.im_stack, config=self.config, wcs=None, per_image_wcs=self.per_image_wcs)
+
+        per_image_ebd_wcs, geo_dist = fit_barycentric_wcs(
+            self.wcs,
+            self.width,
+            self.height,
+            41.,
+            Time(59000, format="mjd"),
+            EarthLocation.of_site("ctio"),
+        )
+
+        constituent_images = [
+            "one.fits",
+            "two.fits",
+            "three.fits",
+            "four.fits",
+            "five.fits",
+        ]
+        work = WorkUnit(
+            im_stack=self.im_stack, 
+            config=self.config, 
+            wcs=per_image_ebd_wcs, 
+            per_image_wcs=self.per_image_wcs,
+            per_image_ebd_wcs=[per_image_ebd_wcs] * self.num_images,
+            geocentric_distances=[geo_dist] * self.num_images,
+            heliocentric_distance=41.,
+            constituent_images = constituent_images,
+            reprojected=True,
+
+        )
+        # work.wcs = per_image_ebd_wcs
+        # work._per_image_ebd_wcs = [per_image_ebd_wcs] * self.num_images
+        # work.geocentric_distances = [geo_dist] * self.num_images
+        # work.heliocentric_distance = 41.
+        # work.constituent_images = [
+        #     "one.fits",
+        #     "two.fits",
+        #     "three.fits",
+        #     "four.fits",
+        # ]
+
+        # Incorrect format for 'xy'
+        self.assertRaises(
+            ValueError,
+            work.image_positions_to_original_icrs,
+            [0],
+            [("0", "1", "2")],
+            "xy",
+        )
+
+        # Incorrect format for 'radec'
+        self.assertRaises(
+            ValueError,
+            work.image_positions_to_original_icrs,
+            [0],
+            [(24, 601)],
+            "radec",
+        )
+
+        # Incorrect length for positions
+        self.assertRaises(
+            ValueError,
+            work.image_positions_to_original_icrs,
+            [0],
+            [(24, 601), (0, 1)],
+            "xy",
+        )
+
+        indices = [0, 1, 2, 3]
+        pixel_positions = [(350 + i, 300 + i) for i in indices]
+
+        input_radec_positions = [
+            SkyCoord(201.60941351, -8.19964405, unit="deg"),
+            SkyCoord(201.60968108, -8.19937797, unit="deg"),
+            SkyCoord(201.60994864, -8.19911188, unit="deg"),
+            SkyCoord(201.61021621, -8.19884579, unit="deg"),
+        ]
+        expected_radec_positions = [
+            SkyCoord(200.62673991, -7.79623142, unit="deg"),
+            SkyCoord(200.59733711, -7.78473232, unit="deg"),
+            SkyCoord(200.56914856, -7.77372976, unit="deg"),
+            SkyCoord(200.54220037, -7.76323338, unit="deg"),
+        ]
+
+        expected_pixel_positions = [
+            (293.91409096900713, 321.4755237663834),
+            (186.0196821526124, 364.0641470322672),
+            (82.57542144600637, 404.8067348560266),
+            (-16.322177615492762, 443.6685337511032)
+        ]
+
+        res = work.image_positions_to_original_icrs(
+            indices,
+            pixel_positions,
+            input_format="xy",
+            output_format="radec",
+            filter_in_frame=False,
+        )
+
+        for r, e in zip(res, expected_radec_positions):
+            npt.assert_almost_equal(r.separation(e).deg, 0.0, decimal=6)
+
+        res = work.image_positions_to_original_icrs(
+            indices,
+            input_radec_positions,
+            input_format="radec",
+            output_format="radec",
+            filter_in_frame=False,
+        )
+
+        for r, e in zip(res, expected_radec_positions):
+            npt.assert_almost_equal(r.separation(e).deg, 0.0, decimal=6)
+
+        res = work.image_positions_to_original_icrs(
+            indices,
+            pixel_positions,
+            input_format="xy",
+            output_format="xy",
+            filter_in_frame=False,
+        )
+
+        for r, e in zip(res, expected_pixel_positions):
+            rx,ry = r[0]
+            ex, ey = e
+            npt.assert_almost_equal(rx, ex, decimal=1)
+            npt.assert_almost_equal(ry, ey, decimal=1)
+
+        # test filtering
+        res = work.image_positions_to_original_icrs(
+            indices,
+            pixel_positions,
+            input_format="xy",
+            output_format="xy",
+            filter_in_frame=True,
+        )
+
+        assert res[3] is None
+        for r, e in zip(res, expected_pixel_positions[:3]):
+            rx,ry = r[0]
+            ex, ey = e
+            npt.assert_almost_equal(rx, ex, decimal=1)
+            npt.assert_almost_equal(ry, ey, decimal=1)
+
+        # test mosaicking conditions
+        new_wcs = make_fake_wcs(190., -7.7888, 500, 700)
+        work._per_image_wcs[-1] = new_wcs
+        work._per_image_indices[3] = [3,4]
+
+        res = work.image_positions_to_original_icrs(
+            indices,
+            pixel_positions,
+            input_format="xy",
+            output_format="xy",
+            filter_in_frame=True,
+        )
+
+        rx, ry = res[3][0]
+        assert rx > 0 and rx < 500
+        assert ry> 0 and ry < 700
+        assert res[3][1] == "five.fits"
+
+        res = work.image_positions_to_original_icrs(
+            indices,
+            pixel_positions,
+            input_format="xy",
+            output_format="radec",
+            filter_in_frame=True,
+        )
+
+        npt.assert_almost_equal(res[3][0].separation(expected_radec_positions[3]).deg, 0.0, decimal=6)
+        assert res[3][1] == "five.fits"
+
+        # work._per_image_wcs[4] = work._per_image_wcs[3]
+        # work._per_image_ebd_wcs[4] = work._per_image_ebd_wcs[3]
+
+        res = work.image_positions_to_original_icrs(
+            indices,
+            pixel_positions,
+            input_format="xy",
+            output_format="xy",
+            filter_in_frame=False,
+        )
+
+        rx, ry = res[3][0][0] 
+        ex, ey = expected_pixel_positions[3]
+        npt.assert_almost_equal(rx, ex, decimal=1)
+        npt.assert_almost_equal(ry, ey, decimal=1)
+        assert res[3][0][1] == "four.fits"
+        assert res[3][1][1] == "five.fits"
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -34,7 +34,7 @@ class test_work_unit(unittest.TestCase):
                 self.height,
                 2.0,  # noise_level
                 4.0,  # variance
-                59000. + (2.0 * i + 1.0),  # time
+                59000.0 + (2.0 * i + 1.0),  # time
                 self.p[i],
             )
 
@@ -78,14 +78,14 @@ class test_work_unit(unittest.TestCase):
             (293.91409096900713, 321.4755237663834),
             (186.0196821526124, 364.0641470322672),
             (82.57542144600637, 404.8067348560266),
-            (-16.322177615492762, 443.6685337511032)
+            (-16.322177615492762, 443.6685337511032),
         ]
 
         self.per_image_ebd_wcs, self.geo_dist = fit_barycentric_wcs(
             self.wcs,
             self.width,
             self.height,
-            41.,
+            41.0,
             Time(59000, format="mjd"),
             EarthLocation.of_site("ctio"),
         )
@@ -241,7 +241,7 @@ class test_work_unit(unittest.TestCase):
                 li = work2.im_stack.get_single_image(i)
                 self.assertEqual(li.get_width(), self.width)
                 self.assertEqual(li.get_height(), self.height)
-                self.assertEqual(li.get_obstime(), 59000. + (2 * i + 1))
+                self.assertEqual(li.get_obstime(), 59000.0 + (2 * i + 1))
 
                 # Check the three image layers match.
                 sci1 = li.get_science()
@@ -322,14 +322,14 @@ class test_work_unit(unittest.TestCase):
 
     def test_image_positions_to_original_icrs_invalid_format(self):
         work = WorkUnit(
-            im_stack=self.im_stack, 
-            config=self.config, 
-            wcs=self.per_image_ebd_wcs, 
+            im_stack=self.im_stack,
+            config=self.config,
+            wcs=self.per_image_ebd_wcs,
             per_image_wcs=self.per_image_wcs,
             per_image_ebd_wcs=[self.per_image_ebd_wcs] * self.num_images,
             geocentric_distances=[self.geo_dist] * self.num_images,
-            heliocentric_distance=41.,
-            constituent_images = self.constituent_images,
+            heliocentric_distance=41.0,
+            constituent_images=self.constituent_images,
             reprojected=True,
         )
 
@@ -359,16 +359,17 @@ class test_work_unit(unittest.TestCase):
             [(24, 601), (0, 1)],
             "xy",
         )
+
     def test_image_positions_to_original_icrs_basic_inputs(self):
         work = WorkUnit(
-            im_stack=self.im_stack, 
-            config=self.config, 
-            wcs=self.per_image_ebd_wcs, 
+            im_stack=self.im_stack,
+            config=self.config,
+            wcs=self.per_image_ebd_wcs,
             per_image_wcs=self.per_image_wcs,
             per_image_ebd_wcs=[self.per_image_ebd_wcs] * self.num_images,
             geocentric_distances=[self.geo_dist] * self.num_images,
-            heliocentric_distance=41.,
-            constituent_images = self.constituent_images,
+            heliocentric_distance=41.0,
+            constituent_images=self.constituent_images,
             reprojected=True,
         )
 
@@ -403,21 +404,21 @@ class test_work_unit(unittest.TestCase):
         )
 
         for r, e in zip(res, self.expected_pixel_positions):
-            rx,ry = r[0]
+            rx, ry = r[0]
             ex, ey = e
             npt.assert_almost_equal(rx, ex, decimal=1)
             npt.assert_almost_equal(ry, ey, decimal=1)
 
     def test_image_positions_to_original_icrs_filtering(self):
         work = WorkUnit(
-            im_stack=self.im_stack, 
-            config=self.config, 
-            wcs=self.per_image_ebd_wcs, 
+            im_stack=self.im_stack,
+            config=self.config,
+            wcs=self.per_image_ebd_wcs,
             per_image_wcs=self.per_image_wcs,
             per_image_ebd_wcs=[self.per_image_ebd_wcs] * self.num_images,
             geocentric_distances=[self.geo_dist] * self.num_images,
-            heliocentric_distance=41.,
-            constituent_images = self.constituent_images,
+            heliocentric_distance=41.0,
+            constituent_images=self.constituent_images,
             reprojected=True,
         )
 
@@ -431,27 +432,27 @@ class test_work_unit(unittest.TestCase):
 
         assert res[3] is None
         for r, e in zip(res, self.expected_pixel_positions[:3]):
-            rx,ry = r[0]
+            rx, ry = r[0]
             ex, ey = e
             npt.assert_almost_equal(rx, ex, decimal=1)
             npt.assert_almost_equal(ry, ey, decimal=1)
 
     def test_image_positions_to_original_icrs_mosaicking(self):
         work = WorkUnit(
-            im_stack=self.im_stack, 
-            config=self.config, 
-            wcs=self.per_image_ebd_wcs, 
+            im_stack=self.im_stack,
+            config=self.config,
+            wcs=self.per_image_ebd_wcs,
             per_image_wcs=self.per_image_wcs,
             per_image_ebd_wcs=[self.per_image_ebd_wcs] * self.num_images,
             geocentric_distances=[self.geo_dist] * self.num_images,
-            heliocentric_distance=41.,
-            constituent_images = self.constituent_images,
+            heliocentric_distance=41.0,
+            constituent_images=self.constituent_images,
             reprojected=True,
         )
 
-        new_wcs = make_fake_wcs(190., -7.7888, 500, 700)
+        new_wcs = make_fake_wcs(190.0, -7.7888, 500, 700)
         work._per_image_wcs[-1] = new_wcs
-        work._per_image_indices[3] = [3,4]
+        work._per_image_indices[3] = [3, 4]
 
         res = work.image_positions_to_original_icrs(
             self.indices,
@@ -463,7 +464,7 @@ class test_work_unit(unittest.TestCase):
 
         rx, ry = res[3][0]
         assert rx > 0 and rx < 500
-        assert ry> 0 and ry < 700
+        assert ry > 0 and ry < 700
         assert res[3][1] == "five.fits"
 
         res = work.image_positions_to_original_icrs(
@@ -488,12 +489,13 @@ class test_work_unit(unittest.TestCase):
             filter_in_frame=False,
         )
 
-        rx, ry = res[3][0][0] 
+        rx, ry = res[3][0][0]
         ex, ey = self.expected_pixel_positions[3]
         npt.assert_almost_equal(rx, ex, decimal=1)
         npt.assert_almost_equal(ry, ey, decimal=1)
         assert res[3][0][1] == "four.fits"
         assert res[3][1][1] == "five.fits"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
closes #575 

creates a function in `WorkUnit` that allows a user to transform coordinates in EBD space back into the "original" ICRS frame. Supports pixel positions and radec positions for input and output.

