### PR TITLE
Allow _to_fits to overwrite files

### DIFF
--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -461,9 +461,7 @@ class WorkUnit:
         """
         logger.info(f"Writing WorkUnit with {self.im_stack.img_count()} images to file {filename}")
         if Path(filename).is_file() and not overwrite:
-            # are you sure you did not want to raise an error here?
-            logger.error(f"Warning: WorkUnit file {filename} already exists.")
-            return
+            raise FileExistsError(f"WorkUnit file {filename} already exists.")
 
         # Set up the initial HDU list, including the primary header
         # the metadata (empty), and the configuration.
@@ -535,7 +533,7 @@ class WorkUnit:
             ebd_hdu.name = f"EBD_{i}"
             hdul.append(ebd_hdu)
 
-        hdul.writeto(filename)
+        hdul.writeto(filename, overwrite=overwrite)
 
     def to_yaml(self):
         """Serialize the WorkUnit as a YAML string.

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -233,6 +233,12 @@ class test_work_unit(unittest.TestCase):
             self.assertDictEqual(work2.config["mask_bits_dict"], {"A": 1, "B": 2})
             self.assertIsNone(work2.config["repeated_flag_keys"])
 
+            # We throw an error if we try to overwrite a file with overwrite=False
+            self.assertRaises(FileExistsError, work.to_fits, file_path)
+
+            # We succeed if overwrite=True
+            work.to_fits(file_path, overwrite=True)
+
     def test_save_and_load_fits_global_wcs(self):
         """This check only confirms that we can read and write the global WCS. The other
         values are tested in test_save_and_load_fits()."""


### PR DESCRIPTION
Closes #644 

Fix the overwrite file logic in `WorkUnit.to_fits()`.