### PR TITLE
Add a warning if the tests are run without a GPU

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,10 +2,15 @@ import math
 import numpy as np
 import unittest
 
-from kbmod.search import Trajectory, pixel_value_valid
+from kbmod.search import HAS_GPU, Trajectory, pixel_value_valid
 
 
 class test_common(unittest.TestCase):
+    @unittest.skipIf(HAS_GPU, "Skipping test (GPU detected)")
+    def test_warning_no_GPU(self):
+        """Throw a loud warning if you are running tests without GPU."""
+        print("\n\n*** WARNING: SKIPPING GPU TESTS ***\n\n")
+
     def test_pixel_value_valid(self):
         self.assertTrue(pixel_value_valid(1.0))
         self.assertTrue(pixel_value_valid(-1.0))


### PR DESCRIPTION
Add a more explicit warning if the tests are run with GPU-mode turned off to help with debugging environmental set up.