### PR TITLE
Set roundtrip_coords=False to avoid extra computations

### DIFF
--- a/src/kbmod/reprojection.py
+++ b/src/kbmod/reprojection.py
@@ -53,6 +53,7 @@ def reproject_image(image, original_wcs, common_wcs):
         shape_out=common_wcs.array_shape,
         bad_value_mode="ignore",
         output_footprint=footprint,
+        roundtrip_coords=False,
     )
 
     # if we passed in a stack of ndarrays (i.e. science, varianace, mask), we only


### PR DESCRIPTION
Setting `roundtrip_coords=False`, as this seems to be extra, unnecessary work.

Initial rough testing with %%timeit in jupyter notebook:
For non-parallelized execution times:
* 108ms `roundtrip_coords=True`
* 85ms `roundtrip_coords=False`

Parallelized with 1 cpu execution times:
* 73 ms `roundtrip_coords=True`
* 66 ms `roundtrip_coords=False`