### PR TITLE
A series of small bug fixes and improvements to the C++ code

### DIFF
--- a/src/kbmod/search/image_stack.h
+++ b/src/kbmod/search/image_stack.h
@@ -15,7 +15,6 @@
 namespace search {
 class ImageStack {
 public:
-    ImageStack();
     ImageStack(const std::vector<LayeredImage>& imgs);
 
     // Disallow copying and assignment to avoid accidental huge memory costs
@@ -27,12 +26,10 @@ public:
 
     // Simple getters.
     unsigned img_count() const { return images.size(); }
-    unsigned get_width() const { return images.size() > 0 ? images[0].get_width() : 0; }
-    unsigned get_height() const { return images.size() > 0 ? images[0].get_height() : 0; }
-    uint64_t get_npixels() const { return images.size() > 0 ? images[0].get_npixels() : 0; }
-    uint64_t get_total_pixels() const {
-        return images.size() > 0 ? images[0].get_npixels() * images.size() : 0;
-    }
+    unsigned get_width() const { return width; }
+    unsigned get_height() const { return height; }
+    uint64_t get_npixels() const { return static_cast<uint64_t>(width) * static_cast<uint64_t>(height); }
+    uint64_t get_total_pixels() const { return get_npixels() * images.size(); }
     std::vector<LayeredImage>& get_images() { return images; }
     LayeredImage& get_single_image(int index);
 
@@ -63,6 +60,8 @@ public:
     GPUArray<double>& get_gpu_time_array() { return gpu_time_array; }
 
 private:
+    unsigned int width;
+    unsigned int height;
     std::vector<LayeredImage> images;
 
     // Data pointers on the GPU.

--- a/src/kbmod/search/image_stack.h
+++ b/src/kbmod/search/image_stack.h
@@ -15,6 +15,7 @@
 namespace search {
 class ImageStack {
 public:
+    ImageStack();
     ImageStack(const std::vector<LayeredImage>& imgs);
 
     // Disallow copying and assignment to avoid accidental huge memory costs
@@ -34,6 +35,10 @@ public:
     }
     std::vector<LayeredImage>& get_images() { return images; }
     LayeredImage& get_single_image(int index);
+
+    // Functions for setting or appending a single LayeredImage.
+    void set_single_image(int index, const LayeredImage& img);
+    void append_image(const LayeredImage& img);
 
     // Functions for getting or using times.
     double get_obstime(int index) const;

--- a/src/kbmod/search/layered_image.cpp
+++ b/src/kbmod/search/layered_image.cpp
@@ -19,6 +19,49 @@ LayeredImage::LayeredImage(const RawImage& sci, const RawImage& var, const RawIm
     variance = var;
 }
 
+// Copy constructor
+LayeredImage::LayeredImage(const LayeredImage& source) {
+    width = source.width;
+    height = source.height;
+    science = source.science;
+    mask = source.mask;
+    variance = source.variance;
+    psf = source.psf;
+}
+
+// Move constructor
+LayeredImage::LayeredImage(LayeredImage&& source)
+        : width(source.width),
+          height(source.height),
+          science(std::move(source.science)),
+          mask(std::move(source.mask)),
+          variance(std::move(source.variance)),
+          psf(std::move(source.psf)) {}
+
+// Copy assignment
+LayeredImage& LayeredImage::operator=(const LayeredImage& source) {
+    width = source.width;
+    height = source.height;
+    science = source.science;
+    mask = source.mask;
+    variance = source.variance;
+    psf = source.psf;
+    return *this;
+}
+
+// Move assignment
+LayeredImage& LayeredImage::operator=(LayeredImage&& source) {
+    if (this != &source) {
+        width = source.width;
+        height = source.height;
+        science = std::move(source.science);
+        mask = std::move(source.mask);
+        variance = std::move(source.variance);
+        psf = std::move(source.psf);
+    }
+    return *this;
+}
+
 void LayeredImage::set_psf(const PSF& new_psf) { psf = new_psf; }
 
 void LayeredImage::convolve_given_psf(PSF& given_psf) {

--- a/src/kbmod/search/layered_image.h
+++ b/src/kbmod/search/layered_image.h
@@ -16,6 +16,12 @@ class LayeredImage {
 public:
     explicit LayeredImage(const RawImage& sci, const RawImage& var, const RawImage& msk, const PSF& psf);
 
+    LayeredImage(const LayeredImage& source);  // Copy constructor
+    LayeredImage(LayeredImage&& source);       // Move constructor
+
+    LayeredImage& operator=(const LayeredImage& source);  // Copy assignment
+    LayeredImage& operator=(LayeredImage&& source);       // Move assignment
+
     // Set an image specific point spread function.
     void set_psf(const PSF& psf);
     PSF& get_psf() { return psf; }

--- a/src/kbmod/search/pydocs/image_stack_docs.h
+++ b/src/kbmod/search/pydocs/image_stack_docs.h
@@ -26,27 +26,103 @@ static const auto DOC_ImageStack_img_count = R"doc(
 
 static const auto DOC_ImageStack_get_single_image = R"doc(
   Returns a single LayeredImage for a given index.
+      
+  Parameters
+  ----------
+  index : `int`
+      The index of the LayeredImage to retrieve.
+
+  Returns
+  -------
+  `LayeredImage`
+
+  Raises
+  ------
+  Raises a ``IndexError`` if the index is out of bounds.
+)doc";
+
+static const auto DOC_ImageStack_set_single_image = R"doc(
+  Sets a single LayeredImage for at a given index.
+      
+  Parameters
+  ----------
+  index : `int`
+      The index of the LayeredImage to set.
+  img : `LayeredImage`
+      The new image.
+      
+  Raises
+  ------
+  Raises a ``IndexError`` if the index is out of bounds.
+  Raises a ``RuntimeError`` if the input image is the wrong size or the data
+  is currently on GPU.
+  )doc";
+
+static const auto DOC_ImageStack_append_image = R"doc(
+  Appends a single LayeredImage to the back of the ImageStack.
+      
+  Parameters
+  ----------
+  img : `LayeredImage`
+      The new image.
+      
+  Raises
+  ------
+  Raises a ``RuntimeError`` if the input image is the wrong size or the data
+  is currently on GPU.
   )doc";
 
 static const auto DOC_ImageStack_get_obstime = R"doc(
   Returns a single image's observation time in MJD.
+
+  Parameters
+  ----------
+  index : `int`
+      The index of the LayeredImage to retrieve.
+
+  Returns
+  -------
+  time : `double`
+      The observation time.
+
+  Raises
+  ------
+  Raises a ``IndexError`` if the index is out of bounds.
   )doc";
 
 static const auto DOC_ImageStack_get_zeroed_time = R"doc(
   Returns a single image's observation time relative to that
   of the first image. This can return negative times if the
   images are not sorted by time.
+
+  Parameters
+  ----------
+  index : `int`
+      The index of the LayeredImage to retrieve.
+
+  Returns
+  -------
+  time : `double`
+      The zeroed observation time.
+
+  Raises
+  ------
+  Raises a ``IndexError`` if the index is out of bounds.
   )doc";
 
 static const auto DOC_ImageStack_build_zeroed_times = R"doc(
   Construct an array of time differentials between each image
   in the stack and the first image. This can return negative times
   if the images are not sorted by time.
-  ")doc";
+  )doc";
 
 static const auto DOC_ImageStack_sort_by_time = R"doc(
   Sort the images in the ImageStack by their time.
-  ")doc";
+
+  Raises
+  ------
+  Raises a ``RuntimeError`` if the input image is the data is currently on GPU.    
+  )doc";
 
 static const auto DOC_ImageStack_make_global_mask = R"doc(
   Create a new global mask from a set of flags and a threshold.

--- a/src/kbmod/search/pydocs/psf_docs.h
+++ b/src/kbmod/search/pydocs/psf_docs.h
@@ -84,7 +84,7 @@ static const auto DOC_PSF_is_close = R"doc(
   `bool`
       Indicates whether the two PSFs are close.
   )doc";
-    
+
 static const auto DOC_PSF_square_psf = R"doc(
   "Squares, raises to the power of two, the elements of the PSF kernel.
   ")doc";

--- a/src/kbmod/search/trajectory_list.cpp
+++ b/src/kbmod/search/trajectory_list.cpp
@@ -21,7 +21,7 @@ TrajectoryList::TrajectoryList(uint64_t max_list_size) {
     gpu_array.resize(max_size);
 }
 
-TrajectoryList::TrajectoryList(const std::vector<Trajectory> &prev_list) {
+TrajectoryList::TrajectoryList(const std::vector<Trajectory>& prev_list) {
     max_size = prev_list.size();
     cpu_list = prev_list;  // Do a full copy.
 
@@ -46,7 +46,7 @@ void TrajectoryList::resize(uint64_t new_size) {
     max_size = new_size;
 }
 
-void TrajectoryList::set_trajectories(const std::vector<Trajectory> &new_values) {
+void TrajectoryList::set_trajectories(const std::vector<Trajectory>& new_values) {
     if (data_on_gpu) throw std::runtime_error("Data on GPU");
     const uint64_t new_size = new_values.size();
 
@@ -69,13 +69,13 @@ std::vector<Trajectory> TrajectoryList::get_batch(uint64_t start, uint64_t count
 void TrajectoryList::sort_by_likelihood() {
     if (data_on_gpu) throw std::runtime_error("Data on GPU");
     __gnu_parallel::sort(cpu_list.begin(), cpu_list.end(),
-                         [](Trajectory a, Trajectory b) { return b.lh < a.lh; });
+                         [](const Trajectory& a, const Trajectory& b) { return b.lh < a.lh; });
 }
 
 void TrajectoryList::sort_by_obs_count() {
     if (data_on_gpu) throw std::runtime_error("Data on GPU");
     __gnu_parallel::sort(cpu_list.begin(), cpu_list.end(),
-                         [](Trajectory a, Trajectory b) { return b.obs_count < a.obs_count; });
+                         [](const Trajectory& a, const Trajectory& b) { return b.obs_count < a.obs_count; });
 }
 
 void TrajectoryList::filter_by_likelihood(float min_likelihood) {
@@ -140,12 +140,12 @@ void TrajectoryList::move_to_cpu() {
 // -------------------------------------------
 
 #ifdef Py_PYTHON_H
-static void trajectory_list_binding(py::module &m) {
+static void trajectory_list_binding(py::module& m) {
     using trjl = search::TrajectoryList;
 
     py::class_<trjl>(m, "TrajectoryList", pydocs::DOC_TrajectoryList)
             .def(py::init<int>())
-            .def(py::init<std::vector<Trajectory> &>())
+            .def(py::init<std::vector<Trajectory>&>())
             .def_property_readonly("on_gpu", &trjl::on_gpu, pydocs::DOC_TrajectoryList_on_gpu)
             .def("__len__", &trjl::get_size)
             .def("resize", &trjl::resize, pydocs::DOC_TrajectoryList_resize)

--- a/src/kbmod/search/trajectory_list.cpp
+++ b/src/kbmod/search/trajectory_list.cpp
@@ -107,7 +107,7 @@ void TrajectoryList::filter_by_obs_count(int min_obs_count) {
 void TrajectoryList::filter_by_valid() {
     if (data_on_gpu) throw std::runtime_error("Data on GPU");
 
-    auto new_end = std::partition(cpu_list.begin(), cpu_list.end(), [](Trajectory x) { return x.valid; });
+    auto new_end = std::partition(cpu_list.begin(), cpu_list.end(), [](const Trajectory& x) { return x.valid; });
     uint64_t new_size = std::distance(cpu_list.begin(), new_end);
     resize(new_size);
 }

--- a/src/kbmod/search/trajectory_list.h
+++ b/src/kbmod/search/trajectory_list.h
@@ -34,13 +34,13 @@ public:
     inline uint64_t get_size() const { return max_size; }
 
     inline Trajectory& get_trajectory(uint64_t index) {
-        if (index > max_size) throw std::runtime_error("Index out of bounds.");
+        if (index >= max_size) throw std::runtime_error("Index out of bounds.");
         if (data_on_gpu) throw std::runtime_error("Data on GPU");
         return cpu_list[index];
     }
 
     inline void set_trajectory(uint64_t index, const Trajectory& new_value) {
-        if (index > max_size) throw std::runtime_error("Index out of bounds.");
+        if (index >= max_size) throw std::runtime_error("Index out of bounds.");
         if (data_on_gpu) throw std::runtime_error("Data on GPU");
         cpu_list[index] = new_value;
     }

--- a/tests/test_image_stack.py
+++ b/tests/test_image_stack.py
@@ -28,6 +28,12 @@ class test_ImageStack(unittest.TestCase):
 
         self.im_stack = ImageStack(self.images)
 
+    def test_create_empty(self):
+        im_stack = ImageStack([])
+        self.assertEqual(len(im_stack), 0)
+        self.assertEqual(im_stack.get_width(), 0)
+        self.assertEqual(im_stack.get_height(), 0)
+
     def test_create(self):
         self.assertEqual(len(self.im_stack), self.num_images)
         self.assertEqual(self.num_images, self.im_stack.img_count())
@@ -49,6 +55,31 @@ class test_ImageStack(unittest.TestCase):
         # Test an out of bounds access.
         with self.assertRaises(IndexError):
             img = self.im_stack.get_single_image(self.num_images + 1)
+
+    def test_set(self):
+        new_img = make_fake_layered_image(60, 80, 2.0, 4.0, -1.0, self.p[0])
+        self.im_stack.set_single_image(2, new_img)
+        self.assertEqual(self.im_stack.get_obstime(2), -1.0)
+
+        # Test an out of bounds access.
+        with self.assertRaises(IndexError):
+            img = self.im_stack.set_single_image(self.num_images + 1, new_img)
+
+        # Test an invalid shaped image.
+        new_img2 = make_fake_layered_image(10, 80, 2.0, 4.0, -1.0, self.p[0])
+        with self.assertRaises(RuntimeError):
+            self.im_stack.set_single_image(2, new_img2)
+
+    def test_append(self):
+        new_img = make_fake_layered_image(60, 80, 2.0, 4.0, -1.0, self.p[0])
+        self.im_stack.append_image(new_img)
+        self.assertEqual(len(self.im_stack), self.num_images + 1)
+        self.assertEqual(self.im_stack.get_obstime(self.num_images), -1.0)
+
+        # Test an invalid shaped image.
+        new_img2 = make_fake_layered_image(10, 80, 2.0, 4.0, -1.0, self.p[0])
+        with self.assertRaises(RuntimeError):
+            self.im_stack.append_image(new_img2)
 
     def test_times(self):
         """Check that we can access specific times.


### PR DESCRIPTION
Fixes a series of small bugs and memory inefficiencies in `ImageStack` and `TrajectoryList` including:
- Incorrect bounds checking for `index` bounds
- Inadvertent copy during sort (by not passing references)

Adds a move constructor (and an explicit copy constructor) to `LayeredImage`

Also enhances `ImageStack` by:
- Adds the ability to set or append images (so we don't need to copy a full vector)
- Saves a local copy of width and height to simplify bounds checking code.
- Updates height and width when inserting the first image into a stack.