### PR TITLE
Mark copy and move constructors noexcept

### DIFF
--- a/src/kbmod/search/image_stack.cpp
+++ b/src/kbmod/search/image_stack.cpp
@@ -28,7 +28,7 @@ LayeredImage& ImageStack::get_single_image(int index) {
     return images[index];
 }
 
-void ImageStack::set_single_image(int index, const LayeredImage& img) {
+void ImageStack::set_single_image(int index, LayeredImage& img) {
     if (data_on_gpu) throw std::runtime_error("Cannot modify images while on GPU");
     if (index < 0 || index >= images.size()) throw std::out_of_range("ImageStack index out of bounds.");
     assert_sizes_equal(img.get_width(), width, "ImageStack image width");
@@ -36,7 +36,7 @@ void ImageStack::set_single_image(int index, const LayeredImage& img) {
     images[index] = img;
 }
 
-void ImageStack::append_image(const LayeredImage& img) {
+void ImageStack::append_image(LayeredImage& img) {
     if (data_on_gpu) throw std::runtime_error("Cannot modify images while on GPU");
 
     if (images.size() == 0) {

--- a/src/kbmod/search/image_stack.h
+++ b/src/kbmod/search/image_stack.h
@@ -34,8 +34,8 @@ public:
     LayeredImage& get_single_image(int index);
 
     // Functions for setting or appending a single LayeredImage.
-    void set_single_image(int index, const LayeredImage& img);
-    void append_image(const LayeredImage& img);
+    void set_single_image(int index, LayeredImage& img);
+    void append_image(LayeredImage& img);
 
     // Functions for getting or using times.
     double get_obstime(int index) const;

--- a/src/kbmod/search/layered_image.cpp
+++ b/src/kbmod/search/layered_image.cpp
@@ -20,7 +20,7 @@ LayeredImage::LayeredImage(const RawImage& sci, const RawImage& var, const RawIm
 }
 
 // Copy constructor
-LayeredImage::LayeredImage(const LayeredImage& source) {
+LayeredImage::LayeredImage(const LayeredImage& source) noexcept {
     width = source.width;
     height = source.height;
     science = source.science;
@@ -30,7 +30,7 @@ LayeredImage::LayeredImage(const LayeredImage& source) {
 }
 
 // Move constructor
-LayeredImage::LayeredImage(LayeredImage&& source)
+LayeredImage::LayeredImage(LayeredImage&& source) noexcept
         : width(source.width),
           height(source.height),
           science(std::move(source.science)),
@@ -39,7 +39,7 @@ LayeredImage::LayeredImage(LayeredImage&& source)
           psf(std::move(source.psf)) {}
 
 // Copy assignment
-LayeredImage& LayeredImage::operator=(const LayeredImage& source) {
+LayeredImage& LayeredImage::operator=(const LayeredImage& source) noexcept {
     width = source.width;
     height = source.height;
     science = source.science;
@@ -50,7 +50,7 @@ LayeredImage& LayeredImage::operator=(const LayeredImage& source) {
 }
 
 // Move assignment
-LayeredImage& LayeredImage::operator=(LayeredImage&& source) {
+LayeredImage& LayeredImage::operator=(LayeredImage&& source) noexcept {
     if (this != &source) {
         width = source.width;
         height = source.height;

--- a/src/kbmod/search/layered_image.h
+++ b/src/kbmod/search/layered_image.h
@@ -16,11 +16,11 @@ class LayeredImage {
 public:
     explicit LayeredImage(const RawImage& sci, const RawImage& var, const RawImage& msk, const PSF& psf);
 
-    LayeredImage(const LayeredImage& source);  // Copy constructor
-    LayeredImage(LayeredImage&& source);       // Move constructor
+    LayeredImage(const LayeredImage& source) noexcept;  // Copy constructor
+    LayeredImage(LayeredImage&& source) noexcept;       // Move constructor
 
-    LayeredImage& operator=(const LayeredImage& source);  // Copy assignment
-    LayeredImage& operator=(LayeredImage&& source);       // Move assignment
+    LayeredImage& operator=(const LayeredImage& source) noexcept;  // Copy assignment
+    LayeredImage& operator=(LayeredImage&& source) noexcept;       // Move assignment
 
     // Set an image specific point spread function.
     void set_psf(const PSF& psf);

--- a/src/kbmod/search/psf.cpp
+++ b/src/kbmod/search/psf.cpp
@@ -48,7 +48,7 @@ PSF::PSF(float stdev) {
 }
 
 // Copy constructor.
-PSF::PSF(const PSF& other) {
+PSF::PSF(const PSF& other) noexcept {
     kernel = other.kernel;
     dim = other.dim;
     radius = other.radius;
@@ -57,7 +57,7 @@ PSF::PSF(const PSF& other) {
 }
 
 // Copy assignment.
-PSF& PSF::operator=(const PSF& other) {
+PSF& PSF::operator=(const PSF& other) noexcept {
     kernel = other.kernel;
     dim = other.dim;
     radius = other.radius;
@@ -67,7 +67,7 @@ PSF& PSF::operator=(const PSF& other) {
 }
 
 // Move constructor.
-PSF::PSF(PSF&& other)
+PSF::PSF(PSF&& other) noexcept
         : kernel(std::move(other.kernel)),
           dim(other.dim),
           radius(other.radius),
@@ -75,7 +75,7 @@ PSF::PSF(PSF&& other)
           sum(other.sum) {}
 
 // Move assignment.
-PSF& PSF::operator=(PSF&& other) {
+PSF& PSF::operator=(PSF&& other) noexcept {
     if (this != &other) {
         kernel = std::move(other.kernel);
         dim = other.dim;

--- a/src/kbmod/search/psf.h
+++ b/src/kbmod/search/psf.h
@@ -15,8 +15,8 @@ class PSF {
 public:
     PSF();  // Create a no-op PSF.
     PSF(float stdev);
-    PSF(const PSF& other);  // Copy constructor
-    PSF(PSF&& other);       // Move constructor
+    PSF(const PSF& other) noexcept;  // Copy constructor
+    PSF(PSF&& other) noexcept;       // Move constructor
 #ifdef Py_PYTHON_H
     PSF(pybind11::array_t<float> arr);
     void set_array(pybind11::array_t<float> arr);
@@ -25,8 +25,8 @@ public:
     virtual ~PSF(){};
 
     // Assignment functions.
-    PSF& operator=(const PSF& other);  // Copy assignment
-    PSF& operator=(PSF&& other);       // Move assignment
+    PSF& operator=(const PSF& other) noexcept;  // Copy assignment
+    PSF& operator=(PSF&& other) noexcept;       // Move assignment
 
     // Getter functions (inlined)
     float get_std() const { return width; }

--- a/src/kbmod/search/raw_image.cpp
+++ b/src/kbmod/search/raw_image.cpp
@@ -22,7 +22,7 @@ RawImage::RawImage(unsigned w, unsigned h, float value, double obs_time)
 }
 
 // Copy constructor
-RawImage::RawImage(const RawImage& old) {
+RawImage::RawImage(const RawImage& old) noexcept {
     width = old.get_width();
     height = old.get_height();
     image = old.get_image();
@@ -30,14 +30,14 @@ RawImage::RawImage(const RawImage& old) {
 }
 
 // Move constructor
-RawImage::RawImage(RawImage&& source)
+RawImage::RawImage(RawImage&& source) noexcept
         : width(source.width),
           height(source.height),
           obstime(source.obstime),
           image(std::move(source.image)) {}
 
 // Copy assignment
-RawImage& RawImage::operator=(const RawImage& source) {
+RawImage& RawImage::operator=(const RawImage& source) noexcept {
     width = source.width;
     height = source.height;
     image = source.image;
@@ -46,7 +46,7 @@ RawImage& RawImage::operator=(const RawImage& source) {
 }
 
 // Move assignment
-RawImage& RawImage::operator=(RawImage&& source) {
+RawImage& RawImage::operator=(RawImage&& source) noexcept {
     if (this != &source) {
         width = source.width;
         height = source.height;
@@ -247,7 +247,7 @@ void RawImage::convolve_cpu(PSF& psf) {
 #ifdef HAVE_CUDA
 // Performs convolution between an image represented as an array of floats
 // and a PSF on a GPU device.
-extern "C" void deviceConvolve(float *source_img, float *result_img, int width, int height, PSF& psf);
+extern "C" void deviceConvolve(float* source_img, float* result_img, int width, int height, PSF& psf);
 #endif
 
 void RawImage::convolve(PSF& psf) {

--- a/src/kbmod/search/raw_image.h
+++ b/src/kbmod/search/raw_image.h
@@ -29,11 +29,11 @@ public:
     explicit RawImage(Image& img, double obs_time = -1.0);
     explicit RawImage(unsigned w, unsigned h, float value = 0.0, double obs_time = -1.0);
 
-    RawImage(const RawImage& old);  // Copy constructor
-    RawImage(RawImage&& source);    // Move constructor
+    RawImage(const RawImage& old) noexcept;  // Copy constructor
+    RawImage(RawImage&& source) noexcept;    // Move constructor
 
-    RawImage& operator=(const RawImage& source);  // Copy assignment
-    RawImage& operator=(RawImage&& source);       // Move assignment
+    RawImage& operator=(const RawImage& source) noexcept;  // Copy assignment
+    RawImage& operator=(RawImage&& source) noexcept;       // Move assignment
 
     // Basic getter functions for image data.
     unsigned get_width() const { return width; }

--- a/src/kbmod/search/trajectory_list.cpp
+++ b/src/kbmod/search/trajectory_list.cpp
@@ -107,7 +107,8 @@ void TrajectoryList::filter_by_obs_count(int min_obs_count) {
 void TrajectoryList::filter_by_valid() {
     if (data_on_gpu) throw std::runtime_error("Data on GPU");
 
-    auto new_end = std::partition(cpu_list.begin(), cpu_list.end(), [](const Trajectory& x) { return x.valid; });
+    auto new_end =
+            std::partition(cpu_list.begin(), cpu_list.end(), [](const Trajectory& x) { return x.valid; });
     uint64_t new_size = std::distance(cpu_list.begin(), new_end);
     resize(new_size);
 }


### PR DESCRIPTION
In order for C++ to use the move constructor for vector resizing it needs to be marked `noexcept`. Otherwise the vector resizing will cause a copy of the current elements.