### PR TITLE
Remove copies for LayeredImage creation

### DIFF
--- a/src/kbmod/data_interface.py
+++ b/src/kbmod/data_interface.py
@@ -192,7 +192,7 @@ def load_input_from_individual_files(
     patch_visits = sorted(os.listdir(im_filepath))
 
     # Load the images themselves.
-    stack = ImageStack([])
+    stack = ImageStack()
     visit_times = []
     wcs_list = []
     for visit_file in np.sort(patch_visits):
@@ -246,9 +246,10 @@ def load_input_from_individual_files(
             logger.info(f"Pruning file {visit_file} by timestamp={time_stamp}.")
             continue
 
-        # Save image, time, and WCS information.
+        # Save image, time, and WCS information. The force move destroys img, so we should
+        # not use it after that point.
         visit_times.append(time_stamp)
-        stack.append_image(img)
+        stack.append_image(img, force_move=True)
         wcs_list.append(curr_wcs)
 
     logger.info(f"Loaded {len(stack)} images")

--- a/src/kbmod/data_interface.py
+++ b/src/kbmod/data_interface.py
@@ -82,10 +82,11 @@ def load_deccam_layered_image(filename, psf):
                     break
 
         img = LayeredImage(
-            RawImage(hdul[1].data.astype(np.float32), obstime),  # Science
-            RawImage(hdul[3].data.astype(np.float32), obstime),  # Variance
-            RawImage(hdul[2].data.astype(np.float32), obstime),  # Mask
+            hdul[1].data.astype(np.float32),  # Science
+            hdul[3].data.astype(np.float32),  # Variance
+            hdul[2].data.astype(np.float32),  # Mask
             psf,
+            obstime,
         )
 
     return img

--- a/src/kbmod/data_interface.py
+++ b/src/kbmod/data_interface.py
@@ -192,7 +192,7 @@ def load_input_from_individual_files(
     patch_visits = sorted(os.listdir(im_filepath))
 
     # Load the images themselves.
-    images = []
+    stack = ImageStack([])
     visit_times = []
     wcs_list = []
     for visit_file in np.sort(patch_visits):
@@ -248,11 +248,10 @@ def load_input_from_individual_files(
 
         # Save image, time, and WCS information.
         visit_times.append(time_stamp)
-        images.append(img)
+        stack.append_image(img)
         wcs_list.append(curr_wcs)
 
-    logger.info(f"Loaded {len(images)} images")
-    stack = ImageStack(images)
+    logger.info(f"Loaded {len(stack)} images")
 
     return (stack, wcs_list, visit_times)
 

--- a/src/kbmod/fake_data/fake_data_creator.py
+++ b/src/kbmod/fake_data/fake_data_creator.py
@@ -68,10 +68,14 @@ def make_fake_layered_image(
         seed = int.from_bytes(os.urandom(4), "big")
     rng = np.random.default_rng(seed)
 
-    sci = RawImage(rng.normal(0.0, noise_stdev, (height, width)).astype(np.float32), obstime)
-    var = RawImage(np.full((height, width), pixel_variance).astype(np.float32), obstime)
-    msk = RawImage(np.zeros((height, width)).astype(np.float32), obstime)
-    img = LayeredImage(sci, var, msk, psf)
+    # Create the LayeredImage directly from the layers.
+    img = LayeredImage(
+        rng.normal(0.0, noise_stdev, (height, width)).astype(np.float32),
+        np.full((height, width), pixel_variance).astype(np.float32),
+        np.zeros((height, width)).astype(np.float32),
+        psf,
+        obstime,
+    )
     return img
 
 

--- a/src/kbmod/fake_data/fake_data_creator.py
+++ b/src/kbmod/fake_data/fake_data_creator.py
@@ -202,8 +202,7 @@ class FakeDataSet:
         stack : `ImageStack`
         """
         p = PSF(self.psf_val)
-
-        image_list = []
+        stack = ImageStack([])
         for i in range(self.num_times):
             img = make_fake_layered_image(
                 self.width,
@@ -214,9 +213,7 @@ class FakeDataSet:
                 p,
                 i if self.use_seed else -1,
             )
-            image_list.append(img)
-
-        stack = ImageStack(image_list)
+            stack.append_image(img)
         return stack
 
     def insert_object(self, trj):

--- a/src/kbmod/fake_data/fake_data_creator.py
+++ b/src/kbmod/fake_data/fake_data_creator.py
@@ -202,7 +202,7 @@ class FakeDataSet:
         stack : `ImageStack`
         """
         p = PSF(self.psf_val)
-        stack = ImageStack([])
+        stack = ImageStack()
         for i in range(self.num_times):
             img = make_fake_layered_image(
                 self.width,
@@ -213,7 +213,7 @@ class FakeDataSet:
                 p,
                 i if self.use_seed else -1,
             )
-            stack.append_image(img)
+            stack.append_image(img, force_move=True)
         return stack
 
     def insert_object(self, trj):

--- a/src/kbmod/reprojection.py
+++ b/src/kbmod/reprojection.py
@@ -125,7 +125,7 @@ def _reproject_work_unit(work_unit, common_wcs, frame="original"):
     unique_obstimes = np.unique(obstimes)
     per_image_indices = []
 
-    stack = ImageStack([])
+    stack = ImageStack()
     for time in unique_obstimes:
         indices = list(np.where(obstimes == time)[0])
         per_image_indices.append(indices)
@@ -193,7 +193,7 @@ def _reproject_work_unit(work_unit, common_wcs, frame="original"):
             psf,
             time,
         )
-        stack.append_image(new_layered_image)
+        stack.append_image(new_layered_image, force_move=True)
 
     per_image_wcs = work_unit._per_image_wcs
     per_image_ebd_wcs = work_unit._per_image_ebd_wcs

--- a/src/kbmod/reprojection.py
+++ b/src/kbmod/reprojection.py
@@ -280,7 +280,6 @@ def _reproject_work_unit_in_parallel(
 
     # when all the multiprocessing has finished, convert the returned numpy arrays to RawImages.
     concurrent.futures.wait(future_reprojections, return_when=concurrent.futures.ALL_COMPLETED)
-    time_stamps = []
     stack = ImageStack([])
     for result in future_reprojections:
         science_add, variance_add, mask_add, time = result.result()
@@ -294,9 +293,6 @@ def _reproject_work_unit_in_parallel(
             psf,
             time,
         )
-
-        # append timestamps and layeredImages to lists
-        time_stamps.append(time)
         stack.append_image(new_layered_image, force_move=True)
 
     # sort by the time_stamp

--- a/src/kbmod/reprojection.py
+++ b/src/kbmod/reprojection.py
@@ -297,7 +297,7 @@ def _reproject_work_unit_in_parallel(
 
         # append timestamps and layeredImages to lists
         time_stamps.append(time)
-        stack.append_image(new_layered_image)
+        stack.append_image(new_layered_image, force_move=True)
 
     # sort by the time_stamp
     stack.sort_by_time()

--- a/src/kbmod/search/image_stack.h
+++ b/src/kbmod/search/image_stack.h
@@ -15,6 +15,7 @@
 namespace search {
 class ImageStack {
 public:
+    ImageStack();
     ImageStack(const std::vector<LayeredImage>& imgs);
 
     // Disallow copying and assignment to avoid accidental huge memory costs
@@ -33,9 +34,10 @@ public:
     std::vector<LayeredImage>& get_images() { return images; }
     LayeredImage& get_single_image(int index);
 
-    // Functions for setting or appending a single LayeredImage.
-    void set_single_image(int index, LayeredImage& img);
-    void append_image(LayeredImage& img);
+    // Functions for setting or appending a single LayeredImage. If force_move is true,
+    // then the code uses move semantics and destroys the input object.
+    void set_single_image(int index, LayeredImage& img, bool force_move=false);
+    void append_image(LayeredImage& img, bool force_move=false);
 
     // Functions for getting or using times.
     double get_obstime(int index) const;

--- a/src/kbmod/search/layered_image.cpp
+++ b/src/kbmod/search/layered_image.cpp
@@ -47,6 +47,7 @@ LayeredImage::LayeredImage(LayeredImage&& source) noexcept
           mask(std::move(source.mask)),
           variance(std::move(source.variance)),
           psf(std::move(source.psf)) {}
+
 // Copy assignment
 LayeredImage& LayeredImage::operator=(const LayeredImage& source) noexcept {
     width = source.width;

--- a/src/kbmod/search/layered_image.cpp
+++ b/src/kbmod/search/layered_image.cpp
@@ -19,6 +19,16 @@ LayeredImage::LayeredImage(const RawImage& sci, const RawImage& var, const RawIm
     variance = var;
 }
 
+LayeredImage::LayeredImage(Image& sci, Image& var, Image& msk, PSF& psf, double obs_time)
+        : science(sci, obs_time), variance(var, obs_time), mask(msk, obs_time), psf(psf) {
+    width = science.get_width();
+    height = science.get_height();
+    assert_sizes_equal(variance.get_width(), width, "variance layer width");
+    assert_sizes_equal(variance.get_height(), height, "variance layer height");
+    assert_sizes_equal(mask.get_width(), width, "mask layer width");
+    assert_sizes_equal(mask.get_height(), height, "mask layer height");
+}
+
 // Copy constructor
 LayeredImage::LayeredImage(const LayeredImage& source) noexcept {
     width = source.width;
@@ -37,7 +47,6 @@ LayeredImage::LayeredImage(LayeredImage&& source) noexcept
           mask(std::move(source.mask)),
           variance(std::move(source.variance)),
           psf(std::move(source.psf)) {}
-
 // Copy assignment
 LayeredImage& LayeredImage::operator=(const LayeredImage& source) noexcept {
     width = source.width;
@@ -306,6 +315,9 @@ static void layered_image_bindings(py::module& m) {
 
     py::class_<li>(m, "LayeredImage", pydocs::DOC_LayeredImage)
             .def(py::init<const ri&, const ri&, const ri&, pf&>())
+            .def(py::init<search::Image&, search::Image&, search::Image&, pf&, double>(),
+                 py::arg("sci").noconvert(true), py::arg("var").noconvert(true),
+                 py::arg("msk").noconvert(true), py::arg("psf"), py::arg("obs_time"))
             .def("contains", &li::contains, pydocs::DOC_LayeredImage_cointains)
             .def("get_science_pixel", &li::get_science_pixel, pydocs::DOC_LayeredImage_get_science_pixel)
             .def("get_variance_pixel", &li::get_variance_pixel, pydocs::DOC_LayeredImage_get_variance_pixel)

--- a/src/kbmod/search/layered_image.h
+++ b/src/kbmod/search/layered_image.h
@@ -16,6 +16,9 @@ class LayeredImage {
 public:
     explicit LayeredImage(const RawImage& sci, const RawImage& var, const RawImage& msk, const PSF& psf);
 
+    // Build a layered image from the underlying matrices, taking ownership of the image data.
+    explicit LayeredImage(Image& sci, Image& var, Image& msk, PSF& psf, double obs_time);
+
     LayeredImage(const LayeredImage& source) noexcept;  // Copy constructor
     LayeredImage(LayeredImage&& source) noexcept;       // Move constructor
 

--- a/src/kbmod/search/pydocs/image_stack_docs.h
+++ b/src/kbmod/search/pydocs/image_stack_docs.h
@@ -43,14 +43,17 @@ static const auto DOC_ImageStack_get_single_image = R"doc(
 
 static const auto DOC_ImageStack_set_single_image = R"doc(
   Sets a single LayeredImage for at a given index.
-      
+
   Parameters
   ----------
   index : `int`
       The index of the LayeredImage to set.
   img : `LayeredImage`
       The new image.
-      
+  force_move : `bool`
+      Use move semantics. The input layered image is destroyed to avoid
+      a copy of the LayeredImage.
+
   Raises
   ------
   Raises a ``IndexError`` if the index is out of bounds.
@@ -60,12 +63,15 @@ static const auto DOC_ImageStack_set_single_image = R"doc(
 
 static const auto DOC_ImageStack_append_image = R"doc(
   Appends a single LayeredImage to the back of the ImageStack.
-      
+
   Parameters
   ----------
   img : `LayeredImage`
       The new image.
-      
+  force_move : `bool`
+      Use move semantics. The input layered image is destroyed to avoid
+      a copy of the LayeredImage.
+
   Raises
   ------
   Raises a ``RuntimeError`` if the input image is the wrong size or the data

--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -355,5 +355,5 @@ class ButlerStandardizer(Standardizer):
         imgs = []
         for sci, var, mask, psf, t in zip(sciences, variances, masks, psfs, mjds):
             mask = mask.astype(np.float32)
-            imgs.append(LayeredImage(RawImage(sci, t), RawImage(var, t), RawImage(mask, t), psf))
+            imgs.append(LayeredImage(sci, var, mask, psf, t))
         return imgs

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -221,7 +221,7 @@ class WorkUnit:
         if not Path(filename).is_file():
             raise ValueError(f"WorkUnit file {filename} not found.")
 
-        im_stack = ImageStack([])
+        im_stack = ImageStack()
         with fits.open(filename) as hdul:
             num_layers = len(hdul)
             if num_layers < 5:
@@ -267,7 +267,9 @@ class WorkUnit:
                     PSF(hdul[f"PSF_{i}"].data),
                     sci_hdu.header["MJD"],
                 )
-                im_stack.append_image(img)
+
+                # force_move destroys img object, but avoids a copy.
+                im_stack.append_image(img, force_move=True)
 
                 n_indices = sci_hdu.header["NIND"]
                 sub_indices = []

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -221,7 +221,7 @@ class WorkUnit:
         if not Path(filename).is_file():
             raise ValueError(f"WorkUnit file {filename} not found.")
 
-        imgs = []
+        im_stack = ImageStack([])
         with fits.open(filename) as hdul:
             num_layers = len(hdul)
             if num_layers < 5:
@@ -257,22 +257,23 @@ class WorkUnit:
             per_image_indices = []
             # Read in all the image files.
             for i in range(num_images):
-                # Read in science, variance, and mask layers.
                 sci_hdu = hdul[f"SCI_{i}"]
-                sci = hdu_to_raw_image(sci_hdu)
-                var = hdu_to_raw_image(hdul[f"VAR_{i}"])
-                msk = hdu_to_raw_image(hdul[f"MSK_{i}"])
+
+                # Read in the layered image from different extensions.
+                img = LayeredImage(
+                    sci_hdu.data.astype(np.single),
+                    hdul[f"VAR_{i}"].data.astype(np.single),
+                    hdul[f"MSK_{i}"].data.astype(np.single),
+                    PSF(hdul[f"PSF_{i}"].data),
+                    sci_hdu.header["MJD"],
+                )
+                im_stack.append_image(img)
 
                 n_indices = sci_hdu.header["NIND"]
                 sub_indices = []
                 for j in range(n_indices):
                     sub_indices.append(sci_hdu.header[f"IND_{j}"])
                 per_image_indices.append(sub_indices)
-
-                # Read the PSF layer.
-                p = PSF(hdul[f"PSF_{i}"].data)
-
-                imgs.append(LayeredImage(sci, var, msk, p))
 
             per_image_wcs = []
             per_image_ebd_wcs = []
@@ -283,7 +284,6 @@ class WorkUnit:
                 per_image_ebd_wcs.append(extract_wcs_from_hdu_header(hdul[f"EBD_{i}"].header))
                 constituent_images.append(hdul[f"WCS_{i}"].header["ILOC"])
 
-        im_stack = ImageStack(imgs)
         result = WorkUnit(
             im_stack=im_stack,
             config=config,

--- a/tests/test_image_stack.py
+++ b/tests/test_image_stack.py
@@ -34,6 +34,11 @@ class test_ImageStack(unittest.TestCase):
         self.assertEqual(im_stack.get_width(), 0)
         self.assertEqual(im_stack.get_height(), 0)
 
+        im_stack2 = ImageStack()
+        self.assertEqual(len(im_stack2), 0)
+        self.assertEqual(im_stack2.get_width(), 0)
+        self.assertEqual(im_stack2.get_height(), 0)
+
     def test_create(self):
         self.assertEqual(len(self.im_stack), self.num_images)
         self.assertEqual(self.num_images, self.im_stack.img_count())


### PR DESCRIPTION
When given a set of `RawImage`s the `LayeredImage` constructor does a copy. This PR adds a constructor that allows `LayeredImage` to take in the underlying Eigen data array (or numpy array from Python), claim ownership of the memory, and avoid the copy.

We also use `ImageStack`'s new `append_image()` function to add images to the stack one on one instead of allocating a full list and copying them in. This slightly reduces the peak memory needed. We include a `force_move` option that allows the `ImageStack` to take ownership of the image and avoid doing a copy when it inserts it into the vector.