### PR TITLE
Retaining the geocentric distances after reprojection

### DIFF
--- a/src/kbmod/reprojection.py
+++ b/src/kbmod/reprojection.py
@@ -206,6 +206,7 @@ def _reproject_work_unit(work_unit, common_wcs, frame="original"):
         per_image_wcs=per_image_wcs,
         per_image_ebd_wcs=per_image_ebd_wcs,
         per_image_indices=per_image_indices,
+        geocentric_distances=work_unit.geocentric_distances,
         reprojected=True,
     )
 
@@ -307,6 +308,7 @@ def _reproject_work_unit_in_parallel(
         per_image_wcs=work_unit._per_image_wcs,
         per_image_ebd_wcs=work_unit._per_image_ebd_wcs,
         per_image_indices=unique_obstimes_indices,
+        geocentric_distances=work_unit.geocentric_distances,
         reprojected=True,
     )
 

--- a/tests/test_reprojection.py
+++ b/tests/test_reprojection.py
@@ -23,7 +23,7 @@ class test_reprojection(unittest.TestCase):
                 assert reprojected_wunit.wcs != None
                 assert reprojected_wunit.im_stack.get_width() == 60
                 assert reprojected_wunit.im_stack.get_height() == 50
-
+                assert reprojected_wunit.geocentric_distances == self.test_wunit.geocentric_distances
                 images = reprojected_wunit.im_stack.get_images()
 
                 # will be 3 as opposed to the four in the original `WorkUnit`,


### PR DESCRIPTION
Copying the original workunit geocentric distances to the reprojected workunit.