### PR TITLE
Pin the numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "astroquery>=0.4.6",
     "joblib>=1.4",
     "matplotlib>=3.5",
-    "numpy>=1.18",
+    "numpy<2.0",
     "pandas>=1.5.1",
     "reproject",
     "scipy>=1.9.2",


### PR DESCRIPTION
Numpy 2.0 is breaking KBMOD. Pin the version <2.0 until we can fix the breakages.