### PR TITLE
Change numpy NAN

### DIFF
--- a/src/kbmod/filters/sigma_g_filter.py
+++ b/src/kbmod/filters/sigma_g_filter.py
@@ -136,7 +136,7 @@ class SigmaGClipping:
         if self.clip_negative:
             # We mask out the values less than zero so they are not used in the median computation.
             masked_lh = np.copy(lh)
-            masked_lh[lh <= 0] = np.NAN
+            masked_lh[lh <= 0] = np.nan
             lower_per, median, upper_per = np.nanpercentile(
                 masked_lh, [self.low_bnd, 50, self.high_bnd], axis=1
             )
@@ -177,7 +177,7 @@ def apply_clipped_sigma_g(clipper, result_data):
         logger.info("SigmaG Clipping : skipping, nothing to filter.")
         return
 
-    lh = result_data.compute_likelihood_curves(filter_obs=True, mask_value=np.NAN)
+    lh = result_data.compute_likelihood_curves(filter_obs=True, mask_value=np.nan)
     obs_valid = clipper.compute_clipped_sigma_g_matrix(lh)
     result_data.update_obs_valid(obs_valid)
     return

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -217,7 +217,7 @@ class test_results(unittest.TestCase):
         psi_array = np.array(
             [
                 [1.0, 1.1, 1.0, 1.3],
-                [10.0, np.NAN, np.inf, 1.3],
+                [10.0, np.nan, np.inf, 1.3],
                 [1.0, 4.0, 10.0, 1.0],
             ]
         )
@@ -246,7 +246,7 @@ class test_results(unittest.TestCase):
         self.assertTrue(np.allclose(lh_mat2, expected2))
 
         # Try masking with NAN. This replaces ALL the invalid cells.
-        lh_mat3 = table.compute_likelihood_curves(filter_obs=True, mask_value=np.NAN)
+        lh_mat3 = table.compute_likelihood_curves(filter_obs=True, mask_value=np.nan)
         expected = np.array(
             [
                 [True, True, True, False],

--- a/tests/test_sigma_g_filter.py
+++ b/tests/test_sigma_g_filter.py
@@ -57,9 +57,9 @@ class test_sigma_g_math(unittest.TestCase):
         lh[3, 0] = 50.0
 
         # "Mask" a few points in the final light curve with NANs
-        lh[4, 7] = np.NAN
-        lh[4, 8] = np.NAN
-        lh[4, 11] = np.NAN
+        lh[4, 7] = np.nan
+        lh[4, 8] = np.nan
+        lh[4, 11] = np.nan
 
         expected = np.isfinite(lh) & (lh < 20.0) & (lh > 0.0)
         sigma_g = SigmaGClipping()


### PR DESCRIPTION
Numpy's `NAN` is deprecated in v2.0. This changes the instances to `nan`. It does not fix everything broken with numpy v2.0, but crosses one known item off the list.