### PR TITLE
Standardizers/speedup butlerstd

### DIFF
--- a/src/kbmod/image_collection.py
+++ b/src/kbmod/image_collection.py
@@ -461,9 +461,15 @@ class ImageCollection:
         bbox = [json.dumps(b) for b in self.bbox]
         tmpdata["bbox"] = bbox
 
-        configs = [json.dumps(entry["std"].config.toDict()) for entry in self.standardizers]
-        # If we name this config then the unpacking operator in get_std will
-        # catch it. Otherwise, we need to explicitly handle it in read.
+        # if all configs exists in the table, skip loading standardizers
+        # (this can happen when the IC was opened from a file)
+        if "config" in self.data.columns and all(self.data["config"]):
+            configs = [json.dumps(c) for c in self.data["config"]]
+        else:
+            configs = [json.dumps(entry["std"].config.toDict()) for entry in self.standardizers]
+
+        # We name this 'config' so the unpacking operator in get_std catches it
+        # Otherwise, we would need to explicitly handle it in read.
         tmpdata["config"] = configs
 
         # some formats do not officially support comments, like CSV, others

--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -322,7 +322,7 @@ class ButlerStandardizer(Standardizer):
                 self._metadata["effTimeSkyBgScale"] = summary.effTimeSkyBgScale
                 self._metadata["effTimeZeroPointScale"] = summary.effTimeZeroPointScale
 
-        if self.config.standardize_location:
+        if self.config.standardize_uri:
             self._metadata["location"] = self.butler.getURI(
                 self.ref,
                 collections=[

--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -200,17 +200,24 @@ class ButlerStandardizer(Standardizer):
 
         self._metadata["dataId"] = str(self.ref.id)
         self._metadata["visit"] = self.ref.dataId["visit"]
-        self._metadata["filter"] = self.ref.dataId["band"]
         self._metadata["detector"] = self.ref.dataId["detector"]
         self._metadata["collection"] = self.ref.run
         self._metadata["datasetType"] = self.ref.datasetType.name
 
         meta_ref = self.ref.makeComponentRef("metadata")
         meta = self.butler.get(meta_ref)
+
+        # dataId sometimes doesn't have a filter or a band? Depends on
+        # the way the initial ref is resolved? Why is middleware so
+        # complicated! This is a best-effort attempt, 90% cases?
+        self._metadata["filter"] = meta["FILTER"]
+        self._metadata["band"] = meta["FILTER"].split(" ")[0]
+
         self._metadata["OBSID"] = meta["OBSID"]
         self._metadata["DTNSANAM"] = meta["DTNSANAM"]  # c4d08927472ksska_ori
         self._metadata["AIRMASS"] = meta["AIRMASS"]
-        self._metadata["DIMM2SEE"] = meta["DIMM2SEE"]
+        d2s = 0.0 if meta["DIMM2SEE"] == "NaN" else float(meta["DIMM2SEE"])
+        self._metadata["DIMM2SEE"] = d2s
         self._metadata["GAINA"] = meta["GAINA"]
         self._metadata["GAINB"] = meta["GAINB"]
 
@@ -348,8 +355,8 @@ class ButlerStandardizer(Standardizer):
         standardizedBBox["ra_tr"] = topright.ra.deg
         standardizedBBox["dec_tr"] = topright.dec.deg
 
-        standardizedBBox["ra_br"] = botright.ra.deg
-        standardizedBBox["dec_br"] = botright.dec.deg
+        standardizedBBox["ra_br"] = botleft.ra.deg
+        standardizedBBox["dec_br"] = botleft.dec.deg
 
         standardizedBBox["ra_bl"] = botright.ra.deg
         standardizedBBox["dec_bl"] = botright.dec.deg

--- a/src/kbmod/standardizers/standardizer.py
+++ b/src/kbmod/standardizers/standardizer.py
@@ -272,7 +272,7 @@ class Standardizer(abc.ABC):
                 raise KeyError(
                     "Standardizer must be a registered standardizer name or a "
                     f"class reference. Expected {', '.join([std for std in cls.registry])} "
-                    f"got '{standardizer}' instead. "
+                    f"got '{force}' instead. "
                 ) from e
 
         # The standardizer is unknown, check which standardizers volunteers and

--- a/tests/test_butlerstd.py
+++ b/tests/test_butlerstd.py
@@ -39,17 +39,17 @@ class TestButlerStandardizer(unittest.TestCase):
         # we want is tested later.
         _ = ButlerStandardizer(uuid.uuid1(), butler=self.butler)
         _ = ButlerStandardizer(uuid.uuid1().hex, butler=self.butler)
-        _ = ButlerStandardizer(DatasetRef(2), butler=self.butler)
+        _ = ButlerStandardizer(DatasetRef(DatasetId(2)), butler=self.butler)
         _ = ButlerStandardizer(DatasetId(3), butler=self.butler)
 
-        _ = Standardizer.get(DatasetRef(5), butler=self.butler)
+        _ = Standardizer.get(DatasetRef(DatasetId(5)), butler=self.butler)
         _ = Standardizer.get(DatasetId(6), butler=self.butler)
 
         _ = Standardizer.get(DatasetId(6), butler=self.butler, force=ButlerStandardizer)
 
     def test_standardize(self):
         """Test ButlerStandardizer instantiates and standardizes as expected."""
-        std = Standardizer.get(DatasetId(7), butler=self.butler)
+        std = Standardizer.get(DatasetId(7, fill_metadata=True), butler=self.butler)
         standardized = std.standardize()
 
         fits = FitsFactory.get_fits(7, spoof_data=True)
@@ -57,21 +57,25 @@ class TestButlerStandardizer(unittest.TestCase):
         expected = {
             "mjd": Time(hdr["DATE-AVG"], format="isot").mjd,
             "filter": hdr["FILTER"],
-            "id": "7",
-            "exp_id": hdr["EXPID"],
+            "dataId": "7",
+            "visit": hdr["EXPID"],
             "location": "file://far/far/away",
         }
 
         for k, v in expected.items():
             with self.subTest("Value not standardized as expected.", key=k):
-                self.assertEqual(v, standardized["meta"][k])
+                # mjd is almost eqaul, sometimes we offset to middle of exposure
+                if k == "mjd":
+                    self.assertAlmostEqual(v, standardized["meta"][k], 2)
+                else:
+                    self.assertEqual(v, standardized["meta"][k])
 
         # The CRVAL1/2 are with respect to the origin (CRPIX), Our center_ra
         # definition uses the pixel in the center of the CCD. The permissible
         # deviation should be on the scale of half a CCD's footprint, unless
         # it's DECam then it could be as big as half an FOV of the focal plane
-        self.assertAlmostEqual(standardized["meta"]["ra"][0], fits[1].header["CRVAL1"], 1)
-        self.assertAlmostEqual(standardized["meta"]["dec"][0], fits[1].header["CRVAL2"], 1)
+        self.assertAlmostEqual(standardized["meta"]["ra"], fits[1].header["CRVAL1"], 1)
+        self.assertAlmostEqual(standardized["meta"]["dec"], fits[1].header["CRVAL2"], 1)
 
         # compare standardized images
         # fmt: off
@@ -95,8 +99,21 @@ class TestButlerStandardizer(unittest.TestCase):
 
         standardized2 = std2.standardize()
         # TODO: I got to come up with some reasonable way of comparing this
-        for k in ["location", "bbox", "mjd", "filter", "id", "exp_id", "ra", "dec"]:
-            self.assertEqual(standardized["meta"][k], standardized2["meta"][k])
+        for k in [
+            "location",
+            "bbox",
+            "mjd",
+            "filter",
+            "dataId",
+            "OBSID",
+            "ra",
+            "dec",
+            "visit",
+            "filter",
+            "detector",
+        ]:
+            with self.subTest("Failed to rounndtrip", key=k):
+                self.assertEqual(standardized["meta"][k], standardized2["meta"][k])
 
     def mock_kbmodv1like_bitmasking(self, mockedexp):
         """Assign each flag that exists to a pixel, standardize, then expect
@@ -203,10 +220,12 @@ class TestButlerStandardizer(unittest.TestCase):
         np.testing.assert_equal(fits["MASK"].data, img.get_mask().image)
 
         # Test that we correctly set metadata
-        self.assertEqual(expected_mjd, img.get_obstime())
-        self.assertEqual(expected_mjd, img.get_science().obstime)
-        self.assertEqual(expected_mjd, img.get_variance().obstime)
-        self.assertEqual(expected_mjd, img.get_mask().obstime)
+        # times can only be compred approximately, because sometimes we
+        # calculate the time in the middle of the exposure
+        self.assertAlmostEqual(expected_mjd, img.get_obstime(), 2)
+        self.assertAlmostEqual(expected_mjd, img.get_science().obstime, 2)
+        self.assertAlmostEqual(expected_mjd, img.get_variance().obstime, 2)
+        self.assertAlmostEqual(expected_mjd, img.get_mask().obstime, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_butlerstd.py
+++ b/tests/test_butlerstd.py
@@ -59,7 +59,6 @@ class TestButlerStandardizer(unittest.TestCase):
             "filter": hdr["FILTER"],
             "dataId": "7",
             "visit": hdr["EXPID"],
-            "location": "file://far/far/away",
         }
 
         for k, v in expected.items():
@@ -100,7 +99,6 @@ class TestButlerStandardizer(unittest.TestCase):
         standardized2 = std2.standardize()
         # TODO: I got to come up with some reasonable way of comparing this
         for k in [
-            "location",
             "bbox",
             "mjd",
             "filter",

--- a/tests/test_region_search.py
+++ b/tests/test_region_search.py
@@ -160,6 +160,7 @@ class TestRegionSearch(unittest.TestCase):
         Test that the instruments are retrieved correctly.
         """
         data_ids = self.rs.fetch_vdr_data()["data_id"]
+
         # Get the instruments
         first_instrument = self.rs.get_instruments(data_ids, first_instrument_only=True)
         self.assertEqual(len(first_instrument), 1)


### PR DESCRIPTION
Review after Friday Jul 12th, have to meet with Pedro to ensure we extract all the necessary metadata. 

The region_search tests pass `DatasetRef`s as `dataIds` - this is hot-patched in `MockedButler` but is something that we should probably fix before merging. 

These changes to `ButlerStandardizer` improve its performance. Standardizes `A0a`, ~400 images, in ~94 seconds or so. Metadata is extracted via objects that do not load image, but just header metadata. This could additionally be cleaned up to save even more time per dataset reference, by constructing bounding box out of the corners of the image in `summaryStats` instead of calculating them via WCS. 

These changes make the old `ButlerStandardizer` image collection unusable anymore, but given the costs to recreate those in this PR, I hope this is not a big problem. Minor changes to other functionality, more specific tests for raised errors and documentation.

Future change should probably be to just unroll the bounding box from objects into columns for ease of use.