### PR TITLE
`WorkUnit` fits sharding and lazy loading

### DIFF
--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -458,8 +458,6 @@ class WorkUnit:
         Uses the following extensions:
             0 - Primary header with overall metadata
             1 or "metadata" - The data provenance metadata
-
-
             2 or "kbmod_config" - The search parameters
             3+ - Image extensions for the science layer ("SCI_i"),
                 variance layer ("VAR_i"), mask layer ("MSK_i"), and
@@ -548,10 +546,10 @@ class WorkUnit:
 
         hdul.writeto(filename, overwrite=overwrite)
 
-    def to_fits_shard(self, filename, directory, overwrite=False):
+    def to_sharded_fits(self, filename, directory, overwrite=False):
         """Write the WorkUnit to a multiple FITS files.
         Will create:
-            - One "primary"file, containing the main WorkUnit metadata
+            - One "primary" file, containing the main WorkUnit metadata
             (see below) as well as the per_image_wcs information for
             the whole set. This will have the given filename.
             -One image fits file containing all of the image data for
@@ -581,7 +579,7 @@ class WorkUnit:
             Indicates whether to overwrite an existing file.
         """
         logger.info(
-            f"Writing WorkUnit shards with {self.im_stack.img_count()} images with main file {filename} in {directory }"
+            f"Writing WorkUnit shards with {self.im_stack.img_count()} images with main file {filename} in {directory}"
         )
         primary_file = os.path.join(directory, filename)
         if Path(primary_file).is_file() and not overwrite:
@@ -662,9 +660,9 @@ class WorkUnit:
         hdul.writeto(os.path.join(directory, filename), overwrite=overwrite)
 
     @classmethod
-    def from_fits_shard(cls, filename, directory, lazy=False):
+    def from_sharded_fits(cls, filename, directory, lazy=False):
         """Create a WorkUnit from multiple FITS files.
-        Pointed towards the result of WorkUnit.to_fits_shard.
+        Pointed towards the result of WorkUnit.to_sharded_fits.
 
         The FITS files will have the following extensions:
 
@@ -701,7 +699,6 @@ class WorkUnit:
 
         # open the main header
         with fits.open(os.path.join(directory, filename)) as primary:
-            print(primary[2].name)
             config = SearchConfiguration.from_hdu(primary["kbmod_config"])
 
             # Read in the global WCS from extension 0 if the information exists.
@@ -762,7 +759,7 @@ class WorkUnit:
                     sub_indices.append(sci_hdu.header[f"IND_{j}"])
                 per_image_indices.append(sub_indices)
 
-        file_paths = None if lazy else file_paths
+        file_paths = None if not lazy else file_paths
         result = WorkUnit(
             im_stack=im_stack,
             config=config,

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -459,7 +459,7 @@ class WorkUnit:
             0 - Primary header with overall metadata
             1 or "metadata" - The data provenance metadata
 
-            
+
             2 or "kbmod_config" - The search parameters
             3+ - Image extensions for the science layer ("SCI_i"),
                 variance layer ("VAR_i"), mask layer ("MSK_i"), and
@@ -580,7 +580,9 @@ class WorkUnit:
         overwrite : bool
             Indicates whether to overwrite an existing file.
         """
-        logger.info(f"Writing WorkUnit with {self.im_stack.img_count()} images to file {filename}")
+        logger.info(
+            f"Writing WorkUnit shards with {self.im_stack.img_count()} images with main file {filename} in {directory }"
+        )
         primary_file = os.path.join(directory, filename)
         if Path(primary_file).is_file() and not overwrite:
             raise FileExistsError(f"WorkUnit file {filename} already exists.")
@@ -610,7 +612,7 @@ class WorkUnit:
 
         config_hdu = self.config.to_hdu()
         config_hdu.name = "kbmod_config"
-        hdul.append(config_hdu) 
+        hdul.append(config_hdu)
 
         for i in range(self.im_stack.img_count()):
             layered = self.im_stack.get_single_image(i)
@@ -683,7 +685,7 @@ class WorkUnit:
             The directory where the sharded file is located.
         lazy : `bool`
             Whether or not to lazy load, i.e. whether to load
-            all of the image data into the WorkUnit or just 
+            all of the image data into the WorkUnit or just
             the metadata.
 
         Returns
@@ -691,7 +693,7 @@ class WorkUnit:
         result : `WorkUnit`
             The loaded WorkUnit.
         """
-        # logger.info(f"Loading WorkUnit from FITS file {filename}.")
+        logger.info(f"Loading WorkUnit from primary FITS file {filename} in {directory}.")
         if not Path(os.path.join(directory, filename)).is_file():
             raise ValueError(f"WorkUnit file {filename} not found.")
 

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -290,16 +290,16 @@ class test_work_unit(unittest.TestCase):
             self.assertFalse(Path(file_path).is_file())
 
             # Unable to load non-existent file.
-            self.assertRaises(ValueError, WorkUnit.from_fits_shard, "test_workunit.fits", dir_name)
+            self.assertRaises(ValueError, WorkUnit.from_sharded_fits, "test_workunit.fits", dir_name)
 
             # Write out the existing WorkUnit with a different per-image wcs for all the entries.
             # work = WorkUnit(self.im_stack, self.config, None, self.diff_wcs)
             work = WorkUnit(im_stack=self.im_stack, config=self.config, wcs=None, per_image_wcs=self.diff_wcs)
-            work.to_fits_shard("test_workunit.fits", dir_name)
+            work.to_sharded_fits("test_workunit.fits", dir_name)
             self.assertTrue(Path(file_path).is_file())
 
             # Read in the file and check that the values agree.
-            work2 = WorkUnit.from_fits_shard(filename="test_workunit.fits", directory=dir_name)
+            work2 = WorkUnit.from_sharded_fits(filename="test_workunit.fits", directory=dir_name)
             self.assertEqual(work2.im_stack.img_count(), self.num_images)
             self.assertIsNone(work2.wcs)
             self.assertFalse(work2.has_common_wcs())
@@ -319,20 +319,12 @@ class test_work_unit(unittest.TestCase):
                 var2 = li_org.get_variance()
                 msk2 = li_org.get_mask()
 
-                for y in range(self.height):
-                    for x in range(self.width):
-                        self.assertAlmostEqual(sci1.get_pixel(y, x), sci2.get_pixel(y, x))
-                        self.assertAlmostEqual(var1.get_pixel(y, x), var2.get_pixel(y, x))
-                        self.assertAlmostEqual(msk1.get_pixel(y, x), msk2.get_pixel(y, x))
+                self.assertTrue(sci1.l2_allclose(sci2, 1e-3))
 
                 # Check the PSF layer matches.
                 p1 = self.p[i]
                 p2 = li.get_psf()
-                self.assertEqual(p1.get_dim(), p2.get_dim())
-
-                for y in range(p1.get_dim()):
-                    for x in range(p1.get_dim()):
-                        self.assertAlmostEqual(p1.get_value(y, x), p2.get_value(y, x))
+                p1.is_close(p2, 1e-3)
 
                 # No per-image WCS on the odd entries
                 self.assertIsNotNone(work2.get_wcs(i))


### PR DESCRIPTION
The cleaned up version of my prototype for sharded WorkUnit file storage.

- these are the changes to just the `WorkUnit`, for reprojection we'll still need to rewrite the code to load in the data lazily per worker. However, a sharded `WorkUnit` that's eager loaded will work exactly the same as any other `WorkUnit` in memory.