### PR TITLE
Speedups and memory savings for ImageCollection and Standardizers

### DIFF
--- a/src/kbmod/image_collection.py
+++ b/src/kbmod/image_collection.py
@@ -8,8 +8,9 @@ import logging
 import os
 import glob
 import json
+import warnings
 
-from astropy.table import Table
+from astropy.table import Table, Column, vstack
 from astropy.wcs import WCS
 from astropy.utils import isiterable
 
@@ -87,8 +88,9 @@ class ImageCollection:
         columns, or has null-values in the required columns.
     """
 
-    required_metadata = ["location", "mjd", "ra", "dec"]
-    _supporting_metadata = ["std_name", "std_idx", "ext_idx", "wcs", "bbox", "config"]
+    # Both are required, but supporting metadata is mostly handled internally
+    required_metadata = ["mjd", "ra", "dec", "wcs"]
+    _supporting_metadata = ["std_name", "std_idx", "ext_idx", "config"]
 
     ########################
     # CONSTRUCTORS
@@ -131,43 +133,40 @@ class ImageCollection:
                 return False, "missing required metadata values."
 
         # check that standardizer to row lookup exists
-        missing_keys = [key for key in ["std_idx", "ext_idx"] if key not in cols]
+        missing_keys = [key for key in self._supporting_metadata if key not in cols]
         if missing_keys:
             return False, (f"missing required standardizer-row lookup indices: {missing_keys}")
 
         return True, ""
 
-    def __init__(self, metadata, standardizers=None):
+    def __init__(self, metadata, standardizers=None, enable_lazy_loading=True):
         valid, explanation = self._validate(metadata)
         if valid:
             metadata.sort("mjd")
-            self.data = metadata
         else:
             raise ValueError(f"Metadata is {explanation}")
 
         # If standardizers are already instantiated, keep them. This keeps any
         # resources they are holding onto alive, and enables in-memory stds.
         # These are impossible to instantiate, but since they are already
-        # in-memory we don't need to and lazy-loading will skip attempts to.
-        # Unrelated, if it doesn't exist, add "std_name" column to metadata and
-        # update the n_stds entry. This is shared by all from* constructors, so
-        # it's just practical to do here.
-        # Else if standardizers are not given, assume they round-trip from rows
-        # and build an empty private list of stds for lazy eval. The length of
-        # the list is determined from table metadata or guessed from the number
-        # of unique targets. Table metadata is updated if necessary.
+        # in-memory we don't need to; and lazy-loading will skip attempts to.
+        # If standardizers are not instantiated, figure out how many we have
+        # from the metadata. If metadata doesn't say, guess how many there are.
+        # If lazy loading is not enabled, assume they round-trip from row data.
+        self._standardizers = None
         if standardizers is not None:
             self._standardizers = np.array(standardizers)
-            if "std_name" not in metadata.columns:
-                self.data["std_name"] = self._standardizer_names
-                self.data.meta["n_stds"] = len(standardizers)
+            metadata.meta["n_std"] = len(standardizers)
         else:
             n_stds = metadata.meta.get("n_stds", None)
             if n_stds is None:
-                n_stds = len(np.unique(metadata["location"]))
+                n_stds = metadata["std_idx"].max()
                 self.data.meta["n_stds"] = n_stds
-            self._standardizers = np.full((n_stds,), None)
 
+            if enable_lazy_loading:
+                self._standardizers = np.full((n_stds,), None)
+
+        self.data = metadata
         self._userColumns = [col for col in self.data.columns if col not in self._supporting_metadata]
 
     @classmethod
@@ -186,9 +185,6 @@ class ImageCollection:
             Image Collection
         """
         metadata = Table.read(*args, format=format, units=units, descriptions=descriptions, **kwargs)
-        metadata["wcs"] = [WCS(w) if w is not None else None for w in metadata["wcs"]]
-        metadata["bbox"] = [json.loads(b) for b in metadata["bbox"]]
-        metadata["config"] = [json.loads(c) for c in metadata["config"]]
         meta = json.loads(
             metadata.meta["comments"][0],
         )
@@ -219,14 +215,15 @@ class ImageCollection:
         logger.info(f"Creating ImageCollection from {len(standardizers)} standardizers.")
 
         unravelledStdMetadata = []
-        for i, stdFits in enumerate(standardizers):
+        for i, std in enumerate(standardizers):
             # needs a "validate standardized" method here or in standardizers
-            stdMeta = stdFits.standardizeMetadata()
+            stdMeta = std.standardizeMetadata()
 
             # unravel all standardized keys whose values are iterables unless
             # they are a string. "Unraveling" means that each processable item
-            # of standardizer gets its own row. Each non-iterable standardized
+            # of standardizer gets its own row and each non-iterable standardized
             # item is copied into that row. F.e. "a.fits" with 3 images becomes
+            # has the same location which is then duplicated across rows:
             # location    std_vals
             #  a.fits     ...1
             #  a.fits     ...2
@@ -234,7 +231,7 @@ class ImageCollection:
             unravelColumns = [
                 key for key, val in stdMeta.items() if isiterable(val) and not isinstance(val, str)
             ]
-            for j, ext in enumerate(stdFits.processable):
+            for j, ext in enumerate(std.processable):
                 row = {}
                 for key in stdMeta.keys():
                     if key in unravelColumns:
@@ -243,11 +240,25 @@ class ImageCollection:
                         row[key] = stdMeta[key]
                     row["std_idx"] = i
                     row["ext_idx"] = j
-                    row["std_name"] = stdFits.name
+                    row["std_name"] = std.name
+
+                # config and WCS are serialized in a more complicated way
+                # than most literal values. Both are stringified dicts, but
+                # WCS must construct its metadata as a header object before it
+                # can be serialized. Its important to save every character here
+                row["config"] = json.dumps(std.config.toDict(), separators=(",", ":"))
+
+                header = std.wcs[j].to_header(relax=True)
+                h, w = std.wcs[j].pixel_shape
+                header["NAXIS1"] = h
+                header["NAXIS2"] = w
+                header_dict = {k: v for k, v in header.items()}
+                row["wcs"] = json.dumps(header_dict, separators=(",", ":"))
                 unravelledStdMetadata.append(row)
 
         # We could even track things like `whoami`, `uname`, `time` etc.
-        meta = meta if meta is not None else {"n_stds": len(standardizers)}
+        meta = meta if meta is not None else {}
+        meta["n_stds"] = len(standardizers)
         metadata = Table(rows=unravelledStdMetadata, meta=meta)
         return cls(metadata=metadata, standardizers=standardizers)
 
@@ -362,11 +373,39 @@ class ImageCollection:
 
     @property
     def wcs(self):
-        return self.data["wcs"].data
+        for i in range(len(self.data)):
+            # the warnings that some keywords might be ignored are expected
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                yield WCS(json.loads(self.data["wcs"][i]), relax=True)
+
+    def get_wcs(self, idxs):
+        # select column before indices, because a copy of the data
+        # will be made, same for bbox. It pays off not to copy the
+        # whole row nearly every-time
+        selected = self.data["wcs"][idxs]
+        # the warnings that some keywords might be ignored are expected
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            if isinstance(selected, Column):
+                return [WCS(json.loads(row), relax=True) for row in selected]
+            return WCS(json.loads(selected), relax=True)
 
     @property
     def bbox(self):
-        return self.data["bbox"].data
+        # what we return here depends on what region search needs
+        # best probably to return a BBox dataclass that has some useful
+        # functionality for region search or something, maybe bbox
+        # even needs a timestamp or something...
+        cols = ["ra", "dec", "ra_tl", "dec_tl", "ra_tr", "dec_tr", "ra_bl", "dec_bl", "ra_br", "dec_br"]
+        for i in range(len(self.data)):
+            yield self.data[cols][i]
+
+    def get_bbox(self, idxs):
+        # again, we can return an BBox collection object with additional methods
+        cols = ["ra", "dec", "ra_tl", "dec_tl", "ra_tr", "dec_tr", "ra_bl", "dec_bl", "ra_br", "dec_br"]
+        selected = self.data[cols][idxs]
+        return selected
 
     @property
     def columns(self):
@@ -374,7 +413,7 @@ class ImageCollection:
         return self.data[self._userColumns].columns
 
     @property
-    def standardizers(self, **kwargs):
+    def standardizers(self):
         """Standardizer generator."""
         for i in range(len(self.data)):
             yield self.get_standardizer(i)
@@ -402,12 +441,35 @@ class ImageCollection:
         """
         row = self.data[index]
         std_idx = row["std_idx"]
-        if self._standardizers[std_idx] is None:
+
+        def load_std():
+            # we want the row, because rows have to contain all values required
+            # to init a standardizer, but std config is written in that row as
+            # just a string and we want a dict. Pluck it out, make a dict.
             std_cls = Standardizer.registry[row["std_name"]]
-            self._standardizers[std_idx] = std_cls(**kwargs, **row)
+            no_conf_cols = list(self.data.columns.keys())
+            no_conf_cols.remove("config")
+            config = json.loads(row["config"])
+            return std_cls(**kwargs, **row[no_conf_cols], config=config)
+
+        # I don't think a 65k long standardizer list will work. But if a list
+        # of _standardizers exists, then we can do to lazy loading, since the
+        # implication is, it isn't too long. Keep in mind some standardizers
+        # keep their resources alive, including images - which can be memory
+        # intensive.
+        if self._standardizers is None:
+            # no lazy loading
+            std = load_std()
+        elif self._standardizers[index] is None:
+            # lazy load and store
+            std = load_std()
+            self._standardizers[std_idx] = std
+        else:
+            # already loaded
+            std = self._standardizers[std_idx]
 
         # maybe a clever dataclass to shortcut the idx lookups on the user end?
-        return {"std": self._standardizers[std_idx], "ext": self.data[index]["ext_idx"]}
+        return {"std": std, "ext": self.data[index]["ext_idx"]}
 
     def get_standardizers(self, idxs, **kwargs):
         """Get the standardizers used to extract metadata of the selected
@@ -446,31 +508,6 @@ class ImageCollection:
         """
         logger.info(f"Writing ImageCollection to {args[0]}")
         tmpdata = self.data.copy()
-
-        # a long history: https://github.com/astropy/astropy/issues/4669
-        # short of which is that WCS will not roundtrip itself the way we want
-        wcs_strs = []
-        for wcs in self.wcs:
-            header = wcs.to_header(relax=True)
-            h, w = wcs.pixel_shape
-            header["NAXIS1"] = (h, "height of the original image axis")
-            header["NAXIS2"] = (w, "width of the original image axis")
-            wcs_strs.append(header.tostring())
-        tmpdata["wcs"] = wcs_strs
-
-        bbox = [json.dumps(b) for b in self.bbox]
-        tmpdata["bbox"] = bbox
-
-        # if all configs exists in the table, skip loading standardizers
-        # (this can happen when the IC was opened from a file)
-        if "config" in self.data.columns and all(self.data["config"]):
-            configs = [json.dumps(c) for c in self.data["config"]]
-        else:
-            configs = [json.dumps(entry["std"].config.toDict()) for entry in self.standardizers]
-
-        # We name this 'config' so the unpacking operator in get_std catches it
-        # Otherwise, we would need to explicitly handle it in read.
-        tmpdata["config"] = configs
 
         # some formats do not officially support comments, like CSV, others
         # have no problems with comments, some provide a workaround like

--- a/src/kbmod/standardizers/standardizer.py
+++ b/src/kbmod/standardizers/standardizer.py
@@ -609,3 +609,53 @@ class Standardizer(abc.ABC):
         std["psf"] = self.standardizePSF()
 
         return std
+
+    def _computeBBox(self, wcs, dimX, dimY):
+        """Given an WCS and the dimensions of an image calculates the values of
+        world coordinates at image corner and image center.
+
+        Parameters
+        ----------
+        wcs : `object`
+        The header, Astropy HDU and its derivatives.
+        dimX : `int`
+        Image dimension in x-axis.
+        dimY : `int`
+        Image dimension in y-axis.
+
+        Returns
+        -------
+        standardizedBBox : `dict`
+        Calculated coorinate values, a dict with, ``wcs_center_[ra, dec]``
+        and ``wcs_corner_[ra, dec]`` keys.
+
+        Notes
+        -----
+        The center point is assumed to be at the (dimX/2, dimY/2) pixel
+        coordinates, rounded down. Corner is taken to be the (0,0)-th pixel.
+        """
+        standardizedBBox = {}
+        centerX, centerY = int(dimX / 2), int(dimY / 2)
+
+        centerSkyCoord = wcs.pixel_to_world(centerX, centerY)
+        topleft = wcs.pixel_to_world(0, 0)
+        topright = wcs.pixel_to_world(dimX, 0)
+        botright = wcs.pixel_to_world(0, dimY)
+        botleft = wcs.pixel_to_world(dimX, dimY)
+
+        standardizedBBox["ra"] = centerSkyCoord.ra.deg
+        standardizedBBox["dec"] = centerSkyCoord.dec.deg
+
+        standardizedBBox["ra_tl"] = topleft.ra.deg
+        standardizedBBox["dec_tl"] = topleft.dec.deg
+
+        standardizedBBox["ra_tr"] = topright.ra.deg
+        standardizedBBox["dec_tr"] = topright.dec.deg
+
+        standardizedBBox["ra_br"] = botleft.ra.deg
+        standardizedBBox["dec_br"] = botleft.dec.deg
+
+        standardizedBBox["ra_bl"] = botright.ra.deg
+        standardizedBBox["dec_bl"] = botright.dec.deg
+
+        return standardizedBBox

--- a/tests/test_butlerstd.py
+++ b/tests/test_butlerstd.py
@@ -55,10 +55,17 @@ class TestButlerStandardizer(unittest.TestCase):
         fits = FitsFactory.get_fits(7, spoof_data=True)
         hdr = fits["PRIMARY"].header
         expected = {
+            "dataId": "7",
+            "datasetType": "test_datasettype_name",
+            "visit": int(f"{hdr['EXPNUM']}{hdr['CCDNUM']}"),
+            "detector": hdr["CCDNUM"],
+            "exposureTime": hdr["EXPREQ"],
+            "OBSID": hdr["OBSID"],
+            "GAINA": hdr["GAINA"],
+            "GAINB": hdr["GAINB"],
+            "DTNSANAM": hdr["DTNSANAM"],
             "mjd": Time(hdr["DATE-AVG"], format="isot").mjd,
             "filter": hdr["FILTER"],
-            "dataId": "7",
-            "visit": hdr["EXPID"],
         }
 
         for k, v in expected.items():
@@ -84,8 +91,8 @@ class TestButlerStandardizer(unittest.TestCase):
         # fmt: on
 
         # these are not easily comparable so just assert they exist
-        self.assertTrue(standardized["meta"]["wcs"])
-        self.assertTrue(standardized["meta"]["bbox"])
+        # self.assertTrue(standardized["meta"]["wcs"])
+        # self.assertTrue(standardized["meta"]["bbox"])
 
     def test_roundtrip(self):
         """Test ButlerStandardizer can instantiate itself from standardized
@@ -99,7 +106,6 @@ class TestButlerStandardizer(unittest.TestCase):
         standardized2 = std2.standardize()
         # TODO: I got to come up with some reasonable way of comparing this
         for k in [
-            "bbox",
             "mjd",
             "filter",
             "dataId",

--- a/tests/test_butlerstd.py
+++ b/tests/test_butlerstd.py
@@ -90,10 +90,6 @@ class TestButlerStandardizer(unittest.TestCase):
         np.testing.assert_equal([fits["MASK"].data,], standardized["mask"])
         # fmt: on
 
-        # these are not easily comparable so just assert they exist
-        # self.assertTrue(standardized["meta"]["wcs"])
-        # self.assertTrue(standardized["meta"]["bbox"])
-
     def test_roundtrip(self):
         """Test ButlerStandardizer can instantiate itself from standardized
         data and a Data Butler."""

--- a/tests/test_imagecollection.py
+++ b/tests/test_imagecollection.py
@@ -42,8 +42,8 @@ class TestImageCollection(unittest.TestCase):
 
         # Make sure the arrays are not empty. In case there are no wcs or
         # bboxes - we're still expecting arrays of None
-        self.assertEqual(len(ic.wcs), 3)
-        self.assertEqual(len(ic.bbox), 3)
+        self.assertEqual(len(list(ic.wcs)), 3)
+        self.assertEqual(len(list(ic.bbox)), 3)
 
         # Test indexing works as expected
         # * int -> row
@@ -74,7 +74,17 @@ class TestImageCollection(unittest.TestCase):
             "location",
             "ra",
             "dec",
+            "ra_tl",
+            "dec_tl",
+            "ra_tr",
+            "dec_tr",
+            "ra_bl",
+            "dec_bl",
+            "ra_br",
+            "dec_br",
+            "wcs",
         ]
+
         self.assertEqual(list(ic.columns.keys()), expected_cols)
         self.assertEqual(list(row.keys()), expected_cols)
 

--- a/tests/test_standardizer.py
+++ b/tests/test_standardizer.py
@@ -234,14 +234,6 @@ class TestKBMODV1(unittest.TestCase):
         np.testing.assert_equal(empty_array, next(standardized["variance"]))
         np.testing.assert_equal(empty_array.astype(np.int32), next(standardized["mask"]))
 
-        # these are not easily comparable because they are fits file dependent
-        # so just assert they exist
-        # TODO: this is an interesting question, is it the job of standardizers
-        # to deal with serialization of WCS into metadata or not. Right now, IC
-        # does it for WCS and Config and it kinda makes sense, but I don't know
-        # self.assertTrue(standardized["meta"]["wcs"])
-        # self.assertTrue(standardized["meta"]["bbox"])
-
     def test_roundtrip(self):
         """Test KBMODV1 can instantiate itself from standardized data."""
         std = Standardizer.get(self.fits, force=KBMODV1)

--- a/tests/test_standardizer.py
+++ b/tests/test_standardizer.py
@@ -236,8 +236,11 @@ class TestKBMODV1(unittest.TestCase):
 
         # these are not easily comparable because they are fits file dependent
         # so just assert they exist
-        self.assertTrue(standardized["meta"]["wcs"])
-        self.assertTrue(standardized["meta"]["bbox"])
+        # TODO: this is an interesting question, is it the job of standardizers
+        # to deal with serialization of WCS into metadata or not. Right now, IC
+        # does it for WCS and Config and it kinda makes sense, but I don't know
+        # self.assertTrue(standardized["meta"]["wcs"])
+        # self.assertTrue(standardized["meta"]["bbox"])
 
     def test_roundtrip(self):
         """Test KBMODV1 can instantiate itself from standardized data."""

--- a/tests/utils/mock_butler.py
+++ b/tests/utils/mock_butler.py
@@ -81,7 +81,8 @@ class DatasetId:
         # with closest matching header values.
         hdul = FitsFactory.get_fits(self.ref % FitsFactory.n_files)
         prim = hdul["PRIMARY"].header
-        self.band = prim["FILTER"]
+        self.physical_filter = prim["FILTER"]
+        self.band = self.physical_filter.split(" ")[0]
         self.visit = prim["EXPID"]
         self.detector = prim["CCDNUM"]
 
@@ -254,6 +255,9 @@ class MockButler:
 
     def getDataset(self, datid):
         return self.get(datid)
+
+    def get_dataset(self, datid, dimension_records=False, datastore_records=False):
+        return DatasetRef(datid)
 
     def get(self, ref, collections=None, dataId=None):
         orig_ref = ref


### PR DESCRIPTION
This PR is mostly intended for large ImageCollection optimizations really. 
The measured performance benefits are substantial in terms of loading times and memory footprint of large image collections:
```
before 
real	47m44.168s 

after
real	7m42.795s
```

per-standardizer row we save another 5K of data, or approximately 50% of memory we used to take. I wanted to test the impact on the standardization times, since those must not be significantly impacted, but someone is currently really thrashing the disks so I can't get reliable results. For 3 datasetrefs, should be on the order of a second, I got the following results:
```
old
Time to standardize A0a collection: 14.083693213993683
Time to standardize A0a collection: 12.05290256603621
Time to standardize A0a collection: 16.573551627923734

new
Time to standardize A0a collection: 16.573551627923734
Time to standardize A0a collection: 4.487202679971233
Time to standardize A0a collection: 13.363859862089157
```
so I'm going to have to repeat these tests to see what's the damage. I expect a slight increase in time because of the serialization of the WCS takes a bit more steps now, but I don't think it should be that bad.

Speedups include:
- not loading all BBOX and WCS as objects at IC init time
- adding the ability to disable lazy loading
- serializing BBOX as columns to save on data volume of IC
- serializing WCS as dict to save on size of IC
- serializing WCS and config with the smallest separators possible
- trimming padding and spaces from the serialized objects

Changes to BBox and WCS handling:
- WCS is now a mandatory part of the standardized data
- Location was removed as mandatory part of standardized data
- BBox is now unravelled as columns instead of dicts.
- BBox is now defined as on-sky coordinates of the 4 chip corners of the chip, clockwise, and center pixel
- WCS is not longer part of the standardized metadata WCS is now serialized by the IC.
- WCS is serialized as a dictionary
- WCS remains an attribute of the standardizers

Changes to IC:
- lazy loading can be turned of at instantiation time now. Lazy loading only happens if _standardized list exists.
- `standardizers`, `wcs` and `bbox` properties are now iterators
- `get_wcs` and `get_bbox` are now getters that do not support lazy loading
- `get_standardizer` continues to support lazy loading