### PR TITLE
Fix various issues related to ImageCollection and Standardizers.

### DIFF
--- a/src/kbmod/image_collection.py
+++ b/src/kbmod/image_collection.py
@@ -720,7 +720,7 @@ class ImageCollection:
 
     def validate(self):
         """Validate the metadata table has all the required values
-        and that non of them are falsy.
+        and that none of them are false.
 
         Requires all columns in ``required_cols`` and ``_supporting_cols``
         attributes exist.

--- a/src/kbmod/image_collection.py
+++ b/src/kbmod/image_collection.py
@@ -878,5 +878,5 @@ class ImageCollection:
                 layeredImages.append(img)
         imgstack = ImageStack(layeredImages)
         if None not in self.wcs:
-            return WorkUnit(imgstack, search_config, per_image_wcs=list(self.wcs), collection=self)
+            return WorkUnit(imgstack, search_config, per_image_wcs=list(self.wcs))
         return WorkUnit(imgstack, search_config)

--- a/src/kbmod/image_collection.py
+++ b/src/kbmod/image_collection.py
@@ -419,7 +419,8 @@ class ImageCollection:
         if len(self.data) != len(other.data):
             return False
 
-        # before we compare the entire tables (minus WCS, not comparable)
+        # before we compare the entire tables
+        # WCS not comparable, BBox not compared
         cols = [col for col in self.columns if col not in ("wcs", "bbox")]
         # I think it's a bug in AstropyTables, but this sometimes returns
         # a boolean instead of an array of booleans (only when False)
@@ -608,14 +609,14 @@ class ImageCollection:
         Parameters
         ----------
         *args : tuple, optional
-            Positional arguments passed through to data writer. If supplied the
-            first argument is the output filename.
+            Positional arguments passed through to data reader. If supplied the
+            first argument is the input filename.
         format : `str`
             File format specified, one of AstroPy IO formats that must support
             comments.  Default: `ascii.ecsv`
         units : `list`
             List or dict of units to apply to columns.
-        descriptions : `list```
+        descriptions : `list`
             List or dict of descriptions to apply to columns
         unpack : `bool`
             If reading a packed image collection, unpack the shared values.
@@ -783,6 +784,7 @@ class ImageCollection:
         ic : `ImageCollection`
             Extended image collection.
         """
+        self.unpack()
         std_offset = self.meta["n_stds"]
 
         old_metas, old_offsets = [], []
@@ -798,12 +800,7 @@ class ImageCollection:
                 if ic._standardizers is not None:
                     self._standardizers.extend(ic._standardizers)
                 else:
-                    self._standardizers.extend(
-                        [
-                            None,
-                        ]
-                        * n_stds
-                    )
+                    self._standardizers.extend([None] * n_stds)
             std_offset += n_stds
 
         self.data = vstack([self.data, *data], metadata_conflicts="silent")

--- a/src/kbmod/image_collection.py
+++ b/src/kbmod/image_collection.py
@@ -508,7 +508,11 @@ class ImageCollection:
     @property
     def columns(self):
         """Return metadata columns."""
-        return self.data.columns[*self._userColumns]
+        # interesting, in python 3.10.9  using unpacking operator * inside bracket
+        # operator is considered SyntaxError. But casting the columns into a tuple
+        # (basically what unpacking operator would've done) is a-ok. TODO: update
+        # to unpacking operator when 3.10 stops being supported.
+        return self.data.columns[tuple(self._userColumns)]
 
     def get_standardizer(self, index, **kwargs):
         """Get the standardizer and extension index for the selected row of the

--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -7,14 +7,13 @@ import uuid
 
 import astropy.nddata as bitmask
 from astropy.wcs import WCS
-from astropy.time import Time
 import astropy.units as u
 
 import numpy as np
 from scipy.signal import convolve2d
 
 from .standardizer import Standardizer, StandardizerConfig
-from kbmod.search import LayeredImage, RawImage, PSF
+from kbmod.search import LayeredImage, PSF
 
 
 __all__ = [
@@ -242,12 +241,16 @@ class ButlerStandardizer(Standardizer):
         # Name mjd into mjd_mid - make it obvious it's mdidle of exposure
         # and add time scale like mjd_mid_utc
         self._metadata["mjd_start"] = mjd_start.mjd
-        self._metadata["mjd"] = half_way.mjd
+        self._metadata["mjd_mid"] = half_way.mjd
 
         self._metadata["object"] = visit.object
         self._metadata["pointing_ra"] = visit.boresightRaDec.getRa().asDegrees()
         self._metadata["pointing_dec"] = visit.boresightRaDec.getDec().asDegrees()
         self._metadata["airmass"] = visit.boresightAirmass
+        obs = visit.getObservatory()
+        self._metadata["obs_lon"] = obs.getLongitude()
+        self._metadata["obs_lat"] = obs.getLatitude()
+        self._metadata["obs_elev"] = obs.getElevation()
 
         # Pointing information is hard to standardize because the
         # dimensions of the detector are not easily availible. We get
@@ -431,7 +434,7 @@ class ButlerStandardizer(Standardizer):
                 self.standardizeVarianceImage()[0],
                 mask,
                 self.standardizePSF()[0],
-                self._metadata["mjd"],
+                self._metadata["mjd_mid"],
             ),
         ]
         return imgs

--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -248,8 +248,8 @@ class ButlerStandardizer(Standardizer):
         self._metadata["pointing_dec"] = visit.boresightRaDec.getDec().asDegrees()
         self._metadata["airmass"] = visit.boresightAirmass
         obs = visit.getObservatory()
-        self._metadata["obs_lon"] = obs.getLongitude()
-        self._metadata["obs_lat"] = obs.getLatitude()
+        self._metadata["obs_lon"] = obs.getLongitude().asDegrees()
+        self._metadata["obs_lat"] = obs.getLatitude().asDegrees()
         self._metadata["obs_elev"] = obs.getElevation()
 
         # Pointing information is hard to standardize because the

--- a/src/kbmod/standardizers/fits_standardizers/fits_standardizer.py
+++ b/src/kbmod/standardizers/fits_standardizers/fits_standardizer.py
@@ -80,8 +80,6 @@ class FitsStandardizer(Standardizer):
     valid_extensions = [".fit", ".fits", ".fits.fz"]
     """File extensions this processor can handle."""
 
-    key_columns = ["location"]
-
     @classmethod
     def resolveFromPath(cls, tgt):
         """Successfully resolves FITS files on a local file system, that are

--- a/src/kbmod/standardizers/fits_standardizers/kbmodv1.py
+++ b/src/kbmod/standardizers/fits_standardizers/kbmodv1.py
@@ -142,7 +142,7 @@ class KBMODV1(MultiExtensionFits):
         ======== ========== ===================================================
         Key      Header Key Description
         ======== ========== ===================================================
-        mjd      DATE-AVG   Decimal MJD timestamp of the middle of the exposure
+        mjd_mid  DATE-AVG   Decimal MJD timestamp of the middle of the exposure
         filter   FILTER     Filter band
         visit_id IDNUM      Visit ID
         observat OBSERVAT   Observatory name
@@ -154,15 +154,23 @@ class KBMODV1(MultiExtensionFits):
         # this is the 1 mandatory piece of metadata we need to extract
         standardizedHeader = {}
         obs_datetime = Time(self.primary["DATE-AVG"], format="isot")
-        standardizedHeader["mjd"] = obs_datetime.mjd
+        # add another half a second for DECam shutter opening time
+        offset_to_mid = (self.primary["EXPREQ"] + 0.5) / 2.0 / 60.0 / 60.0 / 24.0
+        standardizedHeader["mjd_mid"] = obs_datetime.mjd + offset_to_mid
+        standardizedHeader["obs_lon"] = self.primary["OBS-LONG"]
+        standardizedHeader["obs_lat"] = self.primary["OBS-LAT"]
+        standardizedHeader["obs_elev"] = self.primary["OBS-ELEV"]
 
         # these are all optional things
-        standardizedHeader["filter"] = self.primary["FILTER"]
-        standardizedHeader["visit_id"] = self.primary["IDNUM"]
-        standardizedHeader["observat"] = self.primary["OBSERVAT"]
-        standardizedHeader["obs_lat"] = self.primary["OBS-LAT"]
-        standardizedHeader["obs_lon"] = self.primary["OBS-LONG"]
-        standardizedHeader["obs_elev"] = self.primary["OBS-ELEV"]
+        standardizedHeader["FILTER"] = self.primary["FILTER"]
+        standardizedHeader["IDNUM"] = self.primary["IDNUM"]
+        standardizedHeader["OBSID"] = self.primary["OBSID"]
+        standardizedHeader["DTNSANAM"] = self.primary["DTNSANAM"]
+        standardizedHeader["AIRMASS"] = self.primary["AIRMASS"]
+        d2s = 0.0 if self.primary["DIMM2SEE"] == "NaN" else float(self.primary["DIMM2SEE"])
+        standardizedHeader["DIMM2SEE"] = d2s
+        standardizedHeader["GAINA"] = self.primary["GAINA"]
+        standardizedHeader["GAINB"] = self.primary["GAINB"]
 
         return standardizedHeader
 

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -1,10 +1,7 @@
-import math
 import os
 
 from astropy.io import fits
-from astropy.table import Table
 from astropy.utils.exceptions import AstropyWarning
-from astropy.wcs import WCS
 from astropy.wcs.utils import skycoord_to_pixel
 from astropy.time import Time
 from astropy.coordinates import SkyCoord, EarthLocation
@@ -15,6 +12,7 @@ from yaml import dump, safe_load
 
 from kbmod.configuration import SearchConfiguration
 from kbmod.search import ImageStack, LayeredImage, PSF, RawImage, Logging
+
 from kbmod.wcs_utils import (
     append_wcs_to_hdu_header,
     extract_wcs_from_hdu_header,
@@ -85,13 +83,11 @@ class WorkUnit:
         per_image_indices=None,
         lazy=False,
         file_paths=None,
-        obstimes=None,
     ):
         self.im_stack = im_stack
         self.config = config
         self.lazy = lazy
         self.file_paths = file_paths
-        self._obstimes = obstimes
 
         # Handle WCS input. If both the global and per-image WCS are provided,
         # ensure they are consistent.
@@ -250,8 +246,6 @@ class WorkUnit:
             num_layers = len(hdul)
             if num_layers < 5:
                 raise ValueError(f"WorkUnit file has too few extensions {len(hdul)}.")
-
-            # TODO - Read in provenance metadata from extension #1.
 
             # Read in the search parameters from the 'kbmod_config' extension.
             config = SearchConfiguration.from_hdu(hdul["kbmod_config"])

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -1,7 +1,10 @@
+import math
 import os
 
 from astropy.io import fits
+from astropy.table import Table
 from astropy.utils.exceptions import AstropyWarning
+from astropy.wcs import WCS
 from astropy.wcs.utils import skycoord_to_pixel
 from astropy.time import Time
 from astropy.coordinates import SkyCoord, EarthLocation
@@ -12,7 +15,6 @@ from yaml import dump, safe_load
 
 from kbmod.configuration import SearchConfiguration
 from kbmod.search import ImageStack, LayeredImage, PSF, RawImage, Logging
-
 from kbmod.wcs_utils import (
     append_wcs_to_hdu_header,
     extract_wcs_from_hdu_header,

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -85,11 +85,13 @@ class WorkUnit:
         per_image_indices=None,
         lazy=False,
         file_paths=None,
+        obstimes=None,
     ):
         self.im_stack = im_stack
         self.config = config
         self.lazy = lazy
         self.file_paths = file_paths
+        self._obstimes = obstimes
 
         # Handle WCS input. If both the global and per-image WCS are provided,
         # ensure they are consistent.
@@ -248,6 +250,8 @@ class WorkUnit:
             num_layers = len(hdul)
             if num_layers < 5:
                 raise ValueError(f"WorkUnit file has too few extensions {len(hdul)}.")
+
+            # TODO - Read in provenance metadata from extension #1.
 
             # Read in the search parameters from the 'kbmod_config' extension.
             config = SearchConfiguration.from_hdu(hdul["kbmod_config"])

--- a/tests/test_imagecollection.py
+++ b/tests/test_imagecollection.py
@@ -3,7 +3,6 @@ import shutil
 import tempfile
 import unittest
 
-import numpy as np
 import astropy.table as atbl
 
 from kbmod import ImageCollection, Standardizer
@@ -57,20 +56,25 @@ class TestImageCollection(unittest.TestCase):
 
         self.assertIsInstance(ic["location"], atbl.Column)
         self.assertEqual(len(ic["location"]), 3)
-        self.assertIsInstance(ic["mjd", "location"], atbl.Table)
+        self.assertIsInstance(ic["mjd_mid", "location"], atbl.Table)
 
         # This is kind of a thing of the standardizers themselves, but to
         # ensure the standardization results are becoming columns we test for
         # content, knowing KBMODV1 is the standardizer in question.
         # Test internal book-keeping columns are not returned
         expected_cols = [
-            "mjd",
-            "filter",
-            "visit_id",
-            "observat",
-            "obs_lat",
+            "mjd_mid",
             "obs_lon",
+            "obs_lat",
             "obs_elev",
+            "FILTER",
+            "IDNUM",
+            "OBSID",
+            "DTNSANAM",
+            "AIRMASS",
+            "DIMM2SEE",
+            "GAINA",
+            "GAINB",
             "location",
             "ra",
             "dec",
@@ -84,7 +88,6 @@ class TestImageCollection(unittest.TestCase):
             "dec_br",
             "wcs",
         ]
-
         self.assertEqual(list(ic.columns.keys()), expected_cols)
         self.assertEqual(list(row.keys()), expected_cols)
 
@@ -119,7 +122,7 @@ class TestImageCollection(unittest.TestCase):
 
         # We can't compare location, ra, dec spoofing data changes the
         # image data which updates header metadata related to these values
-        subset = ("mjd", "filter", "obs_lon")
+        subset = ("mjd_mid", "FILTER", "obs_lon")
         self.assertTrue((ic[subset] == ic2[subset]).all())
 
         fname = os.path.join(tmpdir, "reachable.ecsv")
@@ -130,6 +133,92 @@ class TestImageCollection(unittest.TestCase):
 
         # cleanup resources
         shutil.rmtree(tmpdir)
+
+    def test_bintablehdu(self):
+        ic2 = ImageCollection.fromTargets(self.fits)
+
+        tbl = ic2.toBinTableHDU()
+        test = ImageCollection.fromBinTableHDU(tbl)
+        self.assertEqual(ic2, test)
+
+        ic2.pack()
+        tbl = ic2.toBinTableHDU()
+        test = ImageCollection.fromBinTableHDU(tbl)
+        self.assertEqual(ic2, test)
+
+    def test_workunit(self):
+        """Tests imagecollection exports a work unit without error."""
+        # not too sure how to validate, so just call to make sure
+        # no errors are thrown. Of course WU throws an error because
+        # no config was given even though its an optional.
+        from kbmod.configuration import SearchConfiguration
+
+        data = self.fitsFactory.get_n(3, spoof_data=True)
+        ic = ImageCollection.fromTargets(data)
+        wu = ic.toWorkUnit(search_config=SearchConfiguration())
+        with tempfile.TemporaryDirectory() as dir_name:
+            wu.to_fits(f"{dir_name}/test.fits")
+
+    def test_packing(self):
+        """Test packing behaves as expected."""
+        ic = ImageCollection.fromTargets(self.fits)
+        ic2 = ImageCollection.fromTargets(self.fits)
+
+        old_meta = ic2.meta
+        self.assertEqual(ic, ic2)
+
+        ic2.pack()
+        self.assertNotEqual(ic, ic2)
+        self.assertTrue("shared_cols" in ic2.meta)
+        for k in ic2.meta["shared_cols"]:
+            with self.subTest("Shared key not found in meta: ", key=k):
+                self.assertTrue(k in ic2.meta)
+
+        ic2.unpack()
+        self.assertEqual(old_meta, ic2.meta)
+        self.assertEqual(ic, ic2)
+
+    def test_indexing(self):
+        """Tests indexing behaves as expected."""
+        # mostly what we can hope for here is none of the operations
+        # raise an error.
+        fits = self.fitsFactory.get_n(5)
+        ic = ImageCollection.fromTargets(fits)
+
+        from astropy.table import Row, Column, Table
+
+        self.assertIsInstance(ic[0], Row)
+        self.assertIsInstance(ic["mjd_mid"], Column)
+        self.assertIsInstance(ic["mjd_mid", "FILTER"], Table)
+        self.assertIsInstance(ic[["mjd_mid", "FILTER"]], Table)
+        with self.assertRaisesRegex(ValueError, "Illegal type"):
+            ic[0, 1]
+        self.assertIsInstance(ic[[0, 1]], ImageCollection)
+        self.assertIsInstance(ic[:3], ImageCollection)
+        self.assertIsInstance(ic[1:3], ImageCollection)
+
+        old_stds = list(ic._standardizers.copy())
+        subset = ic[[0, 2, 3, 4]]
+        self.assertListEqual(list(subset._standardizers), old_stds)
+        self.assertListEqual(list(subset.data["std_idx"]), [0, 2, 3, 4])
+
+        subset.reset_lazy_loading_indices()
+        self.assertListEqual(list(subset.data["std_idx"]), [0, 1, 2, 3])
+        self.assertEqual(len(subset._standardizers), 4)
+        self.assertListEqual(list(subset._standardizers), list(ic._standardizers[[0, 2, 3, 4]]))
+
+        ic.data["std_idx"] = [0, 0, 1, 1, 2]
+        ic.data["ext_idx"] = [0, 1, 0, 1, 0]
+        ic._standardizers = ["first", "second", "third"]
+
+        subset = ic[[0, 2, 3, 4]]
+        self.assertListEqual(list(subset.data["std_idx"]), [0, 1, 1, 2])
+        self.assertListEqual(list(subset.data["ext_idx"]), [0, 0, 1, 0])
+
+        subset.reset_lazy_loading_indices()
+        self.assertListEqual(list(subset._standardizers), ["first", "second", "third"])
+        self.assertListEqual(list(subset.data["std_idx"]), [0, 1, 1, 2])
+        self.assertListEqual(list(subset.data["ext_idx"]), [0, 0, 1, 0])
 
 
 if __name__ == "__main__":

--- a/tests/test_standardizer.py
+++ b/tests/test_standardizer.py
@@ -212,14 +212,19 @@ class TestKBMODV1(unittest.TestCase):
 
         hdr = self.fits["PRIMARY"].header
         expected = {
-            "mjd": Time(hdr["DATE-AVG"], format="isot").mjd,
-            "filter": hdr["FILTER"],
-            "visit_id": hdr["IDNUM"],
-            "observat": hdr["OBSERVAT"],
+            "mjd_mid": Time(hdr["DATE-AVG"], format="isot").mjd
+            + (hdr["EXPREQ"] + 0.5) / 2.0 / 60.0 / 60.0 / 24.0,
             "obs_lat": hdr["OBS-LAT"],
             "obs_lon": hdr["OBS-LONG"],
             "obs_elev": hdr["OBS-ELEV"],
             "location": ":memory:",
+            "FILTER": hdr["FILTER"],
+            "IDNUM": hdr["IDNUM"],
+            "OBSID": hdr["OBSID"],
+            "DTNSANAM": hdr["DTNSANAM"],
+            "AIRMASS": hdr["AIRMASS"],
+            "GAINA": hdr["GAINA"],
+            "GAINB": hdr["GAINB"],
         }
 
         # There used to be an assertDictContainsSubset, but got deprecated?
@@ -344,7 +349,8 @@ class TestKBMODV1(unittest.TestCase):
 
         # Get the expected FITS files and extract the MJD from the header
         hdr = self.fits["PRIMARY"].header
-        expected_mjd = Time(hdr["DATE-AVG"], format="isot").mjd
+        offset_to_mid = (hdr["EXPREQ"] + 0.5) / 2.0 / 60.0 / 60.0 / 24.0
+        expected_mjd = Time(hdr["DATE-AVG"], format="isot").mjd + offset_to_mid
 
         # Get list of layered images from the standardizer
         layered_imgs = std.toLayeredImage()

--- a/tests/utils/mock_butler.py
+++ b/tests/utils/mock_butler.py
@@ -323,8 +323,8 @@ class MockButler:
         mocked_visit.date.return_value = expstart
 
         mocked_obs = mock.Mock(name="Observatory")
-        mocked_obs.getLongitude.return_value = prim["OBS-LONG"]
-        mocked_obs.getLatitude.return_value = prim["OBS-LAT"]
+        mocked_obs.getLongitude.return_value = Angle(prim["OBS-LONG"])
+        mocked_obs.getLatitude.return_value = Angle(prim["OBS-LAT"])
         mocked_obs.getElevation.return_value = prim["OBS-ELEV"]
 
         mocked_visit.getObservatory.return_value = mocked_obs

--- a/tests/utils/mock_butler.py
+++ b/tests/utils/mock_butler.py
@@ -39,6 +39,8 @@ class UUID:
 
     def __init__(self, dataId):
         self.id = dataId
+        self.ref = dataId
+        self.hex = dataId
 
     def __str__(self):
         return str(self.id)
@@ -108,9 +110,9 @@ class DatasetRef:
     def __init__(self, dataId):
         self.id = UUID(dataId)
         self.datasetType = DatasetType("test_datasettype_name")
-        self.ref = dataId.ref
         self.run = dataId.run
         self.dataId = dataId
+        self.ref = dataId.ref
 
     def makeComponentRef(self, name):
         newref = copy.deepcopy(self)
@@ -312,13 +314,22 @@ class MockButler:
     def mock_visitinfo(self, ref):
         hdul = FitsFactory.get_fits(ref % FitsFactory.n_files)
         prim = hdul["PRIMARY"].header
-        mocked = mock.Mock(name="VisitInfo")
-        mocked.exposureTime = prim["EXPREQ"]
+
+        mocked_visit = mock.Mock(name="VisitInfo")
+        mocked_visit.exposureTime = prim["EXPREQ"]
         expstart = Time(prim["DATE-AVG"], format="isot")
-        mocked.date.toAstropy.return_value = expstart
-        mocked.date.toAstropy.return_value = expstart
-        mocked.date.return_value = expstart
-        return mocked
+        mocked_visit.date.toAstropy.return_value = expstart
+        mocked_visit.date.toAstropy.return_value = expstart
+        mocked_visit.date.return_value = expstart
+
+        mocked_obs = mock.Mock(name="Observatory")
+        mocked_obs.getLongitude.return_value = prim["OBS-LONG"]
+        mocked_obs.getLatitude.return_value = prim["OBS-LAT"]
+        mocked_obs.getElevation.return_value = prim["OBS-ELEV"]
+
+        mocked_visit.getObservatory.return_value = mocked_obs
+
+        return mocked_visit
 
     def mock_summarystats(self, ref):
         hdul = FitsFactory.get_fits(ref % FitsFactory.n_files)


### PR DESCRIPTION
Resolves https://github.com/dirac-institute/kbmod/issues/665
Resolves https://github.com/dirac-institute/kbmod/issues/673
Resolves https://github.com/dirac-institute/kbmod/issues/672

I would also like to close https://github.com/dirac-institute/kbmod/issues/303.

I tried resolving https://github.com/dirac-institute/kbmod/issues/410 and resolving https://github.com/dirac-institute/kbmod/issues/589 but I couldn't really make my way around the work unit code tbh. There's a lot of nesting and some of the duplicated code makes it kind of fuzzy to understand what is the currently used codepath. 

The `WorkUnit` also seems to be broken. It doesn't require a configuration to be given, but it throws an unclear error (`None does not have keys`) when writing and reading to/from fits without providing one. Not sure if config is intended to be optional (then we need a better error) or we should just make it a required parameter to a work unit? 

I added an example of how we can package a flattened image collection into a header unit in the `to/from_fits` methods, but I'd love some direction from @maxwest-uw or @jeremykubica as to what you would like to see happen here? I think the metadata is serializable into a YAML or dict. WorkUnits have a lot of serialization for that, but is this used? 

There's a metadata but the docs aren't clear as to rules of what goes to primary as metadata vs "metadata" HDU? Values are stored in headers for both of them, even when the underlying HDU is BinTable or Table - but I don't think I can do that with image collection tbh. So I don't think that fits with your convention.

More broadly, I don't think this is safe to do. The `HIERARCH` and `CONTINUE` keywords are supported by astropy, but I don't think this is part of official standard. Astropy doesn't say much about limitations, but [CFITSIO seems to agree](https://github.com/HEASARC/cfitsio/blob/56640a39c59148b5143d8dd0833cce6a88a55d8c/docs/fitsio.tex#L1254) and says it will throw an error if the key-value pair is more than 40 chars long and if it's a string it will just forcefully truncate it without error-ing out. 

The changes:

Standardizers:
    - sync `KBMODV1` and `ButlerStandardizer`; they're not exact, but better.
    - rename `mjd` to `mjd_mid`, fix tests
    - extract obs `lon`, `lat` and `elevation` in `ButlerStandardizer`
    - make `MultiExt` and `SingleExt` standardizers not directly instantiabl (this was a complain from Max a while ago but I can't find an issue if there was one)

`ImageCollection`:
    - implement packing and unpacking of shared columns
    - implement to and from `BinTableHDU` cast for `ImageCollection`
    - add it to workunit as a metadata header unit as an example
    - add `vstack` method (have to test in wild) for image collection
    - adds a `copy` method
    - add a way to manually reset lazy loading indices after subsetting form a larger collection (useful only for really really large collections)

Flesh out a lot more tests for `ImageCollection` and `Standardizers`:
    - more explicit testing of more expected values
    - more explicit testing of lazy loading and indexing mechanism in IC