### PR TITLE
Lazy reprojection

### DIFF
--- a/src/kbmod/reprojection.py
+++ b/src/kbmod/reprojection.py
@@ -3,9 +3,13 @@ import concurrent.futures
 import reproject
 from astropy.nddata import CCDData
 from astropy.wcs import WCS
+from astropy.io import fits
+import os
+from copy import copy
 
 from kbmod.search import KB_NO_DATA, PSF, ImageStack, LayeredImage, RawImage
 from kbmod.work_unit import WorkUnit
+from kbmod.wcs_utils import append_wcs_to_hdu_header
 
 # The number of executors to use in the parallel reprojecting function.
 MAX_PROCESSES = 8
@@ -314,6 +318,87 @@ def _reproject_work_unit_in_parallel(
 
     return new_wunit
 
+def _reproject_lazy_work_unit_in_parallel(
+    work_unit, common_wcs, directory, filename, frame="original", max_parallel_processes=MAX_PROCESSES
+):
+    """Given a WorkUnit and a WCS, reproject all of the images in the ImageStack
+    into a common WCS. This function uses multiprocessing to reproject the images
+    in parallel.
+
+    Attributes
+    ----------
+    work_unit : `kbmod.WorkUnit`
+        The WorkUnit to be reprojected.
+    common_wcs : `astropy.wcs.WCS`
+        The WCS to reproject all the images into.
+    frame : `str`
+        The WCS frame of reference to use when reprojecting.
+        Can either be 'original' or 'ebd' to specify whether to
+        use the WorkUnit._per_image_wcs or ._per_image_ebd_wcs
+        respectively.
+    max_parallel_processes : `int`
+        The maximum number of parallel processes to use when reprojecting.
+        Default is 8. For more see `concurrent.futures.ProcessPoolExecutor` in
+        the Python docs.
+
+    Returns
+    ----------
+    A `kbmod.WorkUnit` reprojected with a common `astropy.wcs.WCS`.
+    """
+
+    # get all the unique obstimes
+    all_obstimes = np.array(work_unit.get_all_obstimes())
+    unique_obstimes = np.unique(all_obstimes)
+
+    # Create the list of lists of indicies for each unique obstimes. i.e. [[0], [1], [2,3]]
+    unique_obstimes_indices = [list(np.where(all_obstimes == time)[0]) for time in unique_obstimes]
+
+    future_reprojections = []
+    with concurrent.futures.ProcessPoolExecutor(max_parallel_processes) as executor:
+        # for a given list of obstime indices, collect all the science, variance, and mask images.
+        for obstime_index, indices in enumerate(unique_obstimes_indices):
+            original_wcs = _validate_original_wcs(work_unit, indices, frame)
+            # get the list of images for each unique obstime
+            file_paths_at_obstime = [work_unit.file_paths[i] for i in indices]
+
+            obstime = all_obstimes[indices[0]]
+
+            # call `_reproject_images` in parallel.
+            future_reprojections.append(
+                executor.submit(
+                    _load_images_and_reproject,
+                    file_paths=file_paths_at_obstime,
+                    indices=indices,
+                    obstime=obstime,
+                    obstime_index=obstime_index,
+                    common_wcs=common_wcs,
+                    original_wcs=original_wcs,
+                    directory=directory,
+                    filename=filename,
+                )
+            )
+
+    concurrent.futures.wait(future_reprojections, return_when=concurrent.futures.ALL_COMPLETED)
+
+    for result in future_reprojections:
+        if not result.result():
+            raise RuntimeError("one or more jobs failed.")
+
+    # TODO: ensure all the jobs completed successfully before writing
+    # the rest of the `WorkUnit` metadata
+
+    # TODO: Write the `WorkUnit` metadata
+    new_work_unit = copy(work_unit)
+    new_work_unit._per_image_indices = unique_obstimes_indices
+    new_work_unit.wcs = common_wcs
+    new_work_unit.reprojected = True
+
+    hdul = new_work_unit.metadata_to_primary_header()
+    hdul.writeto(os.path.join(directory, filename))
+
+    # TODO: add an option to materialize and return
+    # the `WorkUnit` after the reprojection is finished.
+
 
 def _validate_original_wcs(work_unit, indices, frame="original"):
     """Given a work unit and a set of indices, verify that the WCS is not None for
@@ -391,6 +476,72 @@ def _get_first_psf_at_time(work_unit, time):
     return images[index].get_psf()
 
 
+def _load_images_and_reproject(file_paths, indices, obstime, obstime_index, common_wcs, original_wcs, directory, filename):
+    """Load image data from `WorkUnit` shards.
+
+    Parameters
+    ----------
+    file_paths : `list[str]`
+        List of strings comtaining the images to be reprojected and stitched.
+    inidces : `list[int]`
+        List of `WorkUnit` indices corresponding to the original positions
+        of the images within the `ImageStack`.
+    mask_images : `list[numpy.ndarray]`
+        List of ndarrays that represent the mask images to be reprojected.
+    obstimes : `list[float]`
+        List of observation times for each image.
+    common_wcs : `astropy.wcs.WCS`
+        The WCS to reproject all the images into.
+    original_wcs : `list[astropy.wcs.WCS]`
+        The list of WCS objects for these images.
+    """
+    # TODO: Implement
+    science_images = []
+    variance_images = []
+    mask_images = []
+    psfs = []
+
+    for file_path, index in zip(file_paths, indices):
+        with fits.open(file_path) as hdul:
+            science_images.append(hdul[f"SCI_{index}"].data.astype(np.single))
+            variance_images.append(hdul[f"VAR_{index}"].data.astype(np.single))
+            mask_images.append(hdul[f"MSK_{index}"].data.astype(np.single))
+            psfs.append(PSF(hdul[f"PSF_{index}"].data))
+
+    science_add, variance_add, mask_add, _ = _reproject_images(
+        science_images,
+        variance_images,
+        mask_images,
+        obstime,
+        common_wcs,
+        original_wcs,
+    )
+
+    n_indices = len(indices)
+    sub_hdul = fits.HDUList()
+
+    sci_hdu = image_add_to_hdu(science_add, f"SCI_{obstime_index}", obstime, common_wcs)
+    sci_hdu.header["NIND"] = n_indices
+    for j in range(n_indices):
+        sci_hdu.header[f"IND_{j}"] = indices[j]
+    sub_hdul.append(sci_hdu)
+
+    var_hdu = image_add_to_hdu(variance_add, f"VAR_{obstime_index}", obstime)
+    sub_hdul.append(var_hdu)
+
+    msk_hdu = image_add_to_hdu(mask_add, f"MSK_{obstime_index}", obstime)
+    sub_hdul.append(msk_hdu)
+
+    p = psfs[0]
+    psf_array = np.array(p.get_kernel()).reshape((p.get_dim(), p.get_dim()))
+    psf_hdu = fits.hdu.image.ImageHDU(psf_array)
+    psf_hdu.name = f"PSF_{obstime_index}"
+    sub_hdul.append(psf_hdu)
+    sub_hdul.writeto(os.path.join(directory, f"{obstime_index}_{filename}"))
+
+    return True
+
+
 def _reproject_images(science_images, variance_images, mask_images, obstimes, common_wcs, original_wcs):
     """This is the worker function that will be parallelized across multiple processes.
     Given a set of science, variance, and mask images, use astropy's reproject
@@ -433,7 +584,7 @@ def _reproject_images(science_images, variance_images, mask_images, obstimes, co
     footprint_add = np.zeros(common_wcs.array_shape, dtype=np.ubyte)
 
     # all the obstimes should be identical, so we can just use the first one.
-    time = obstimes[0]
+    time = obstimes
 
     for science, variance, mask, this_original_wcs in zip(
         science_images, variance_images, mask_images, original_wcs
@@ -468,3 +619,29 @@ def _reproject_images(science_images, variance_images, mask_images, obstimes, co
     mask_add = np.where(np.isclose(mask_add, 0.0, atol=0.2), np.float32(0.0), np.float32(1.0))
 
     return science_add, variance_add, mask_add, time
+
+def image_add_to_hdu(add, name, obstime, wcs=None):
+    """Helper function that creates a HDU out of RawImage.
+
+    Parameters
+    ----------
+    img : `RawImage`
+        The RawImage to convert.
+    wcs : `astropy.wcs.WCS`
+        An optional WCS to include in the header.
+
+    Returns
+    -------
+    hdu : `astropy.io.fits.hdu.image.ImageHDU`
+        The image extension.
+    """
+    hdu = fits.hdu.image.ImageHDU(add)
+
+    # If the WCS is given, copy each entry into the header.
+    if wcs is not None:
+        append_wcs_to_hdu_header(wcs, hdu.header)
+
+    # Set the time stamp.
+    hdu.header["MJD"] = obstime
+    hdu.name = name
+    return hdu

--- a/src/kbmod/reprojection.py
+++ b/src/kbmod/reprojection.py
@@ -510,7 +510,7 @@ def _load_images_and_reproject(
         with fits.open(file_path) as hdul:
             science_images.append(hdul[f"SCI_{index}"].data.astype(np.single))
             variance_images.append(hdul[f"VAR_{index}"].data.astype(np.single))
-            mask_images.append(hdul[f"MSK_{index}"].data.astype(np.single))
+            mask_images.append(hdul[f"MSK_{index}"].data.astype(bool))
             psfs.append(PSF(hdul[f"PSF_{index}"].data))
 
     science_add, variance_add, mask_add, _ = _reproject_images(
@@ -624,12 +624,16 @@ def _reproject_images(science_images, variance_images, mask_images, obstime, com
 
 
 def image_add_to_hdu(add, name, obstime, wcs=None):
-    """Helper function that creates a HDU out of RawImage.
+    """Helper function that creates a HDU out of post reproject added image.
 
     Parameters
     ----------
-    img : `RawImage`
-        The RawImage to convert.
+    add : `np.ndarray`
+        The image to convert.
+    name : `str`
+        The name of the image (type + index).
+    obstime : `float`
+        The observation time.
     wcs : `astropy.wcs.WCS`
         An optional WCS to include in the header.
 

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -558,7 +558,9 @@ class WorkUnit:
         if Path(primary_file).is_file() and not overwrite:
             raise FileExistsError(f"WorkUnit file {filename} already exists.")
         if self.lazy:
-            raise ValueError("WorkUnit was lazy loaded, must load all ImageStack data to output new WorkUnit.")
+            raise ValueError(
+                "WorkUnit was lazy loaded, must load all ImageStack data to output new WorkUnit."
+            )
 
         for i in range(self.im_stack.img_count()):
             layered = self.im_stack.get_single_image(i)
@@ -650,7 +652,7 @@ class WorkUnit:
             reprojected = primary[0].header["REPRJCTD"]
             heliocentric_distance = primary[0].header["HELIO"]
             geocentric_distances = []
-            for i in range(num_images):
+            for i in range(n_constituents):
                 geocentric_distances.append(primary[0].header[f"GEO_{i}"])
 
             per_image_wcs = []

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -62,6 +62,13 @@ class WorkUnit:
         A list of lists containing the indicies of `constituent_images` at each layer
         of the `ImageStack`. Used for finding corresponding original images when we
         stitch images together during reprojection.
+    lazy : `bool`
+        Whether or not to load the image data for the `WorkUnit`.
+    file_paths : `list[str]`
+        The paths for the shard files, only created if the `WorkUnit` is loaded
+        in lazy mode.
+    obstimes : `list[float]`
+        The MJD obstimes of the images.
     """
 
     def __init__(
@@ -743,8 +750,7 @@ class WorkUnit:
         if self.wcs is not None:
             append_wcs_to_hdu_header(self.wcs, pri.header)
 
-        n_constituents = len(self.constituent_images)
-        pri.header["NCON"] = n_constituents
+        pri.header["NCON"] = len(self.constituent_images)
 
         hdul.append(pri)
 


### PR DESCRIPTION
closes #615 

builds on the changes made in #664 

- adds in a `reproject_lazy_work_unit` function that can take in a lazy loaded `WorkUnit` and reproject it in parallel, only loading in the necessary data per task which significantly keeps the amount of memory used significantly lower from ~200 gb to ~2 gb.
- Also writes the reprojected `WorkUnit` into a sharded work unit.
- Slight refactor of the `WorkUnit` fits functionality, now have separate functions to write out the metadata.
- Minor change in the `_reproject_images` function to only pass a single `obstime` to the function.