### PR TITLE
Add a test for the core-most search

### DIFF
--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -88,11 +88,14 @@ class SearchRunner:
             bnds = [25, 75]
         clipper = SigmaGClipping(bnds[0], bnds[1], 2, clip_negative)
 
-        logger.info("Retrieving Results")
+        total_found = search.get_number_total_results()
+        logger.info(f"Retrieving Results (total={total_found})")
         likelihood_limit = False
         res_num = 0
         total_count = 0
-        while likelihood_limit is False:
+
+        # Keep retrieving results until they fall below the threshold or we run out of results.
+        while likelihood_limit is False and res_num < total_found:
             logger.info(f"Chunk Start = {res_num} (size={chunk_size})")
             results = search.get_results(res_num, chunk_size)
             logger.info(f"Chunk Max Likelihood = {results[0].lh}")

--- a/src/kbmod/search/pydocs/stack_search_docs.h
+++ b/src/kbmod/search/pydocs/stack_search_docs.h
@@ -161,6 +161,15 @@ static const auto DOC_StackSearch_prepare_psi_phi = R"doc(
   Compute the cached psi and phi data.
   )doc";
 
+static const auto DOC_StackSearch_get_number_total_results = R"doc(
+  Getthe total number of cached results.
+
+  Returns
+  -------
+  result : `int`
+      The number of cached results.
+  )doc";
+                                        
 static const auto DOC_StackSearch_get_results = R"doc(
   Get a batch of cached results.
 

--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -312,6 +312,8 @@ static void stack_search_bindings(py::module& m) {
                  pydocs::DOC_StackSearch_get_phi_curves)
             .def("prepare_psi_phi", &ks::prepare_psi_phi, pydocs::DOC_StackSearch_prepare_psi_phi)
             .def("clear_psi_phi", &ks::clear_psi_phi, pydocs::DOC_StackSearch_clear_psi_phi)
+            .def("get_number_total_results", &ks::get_number_total_results,
+                 pydocs::DOC_StackSearch_get_number_total_results)
             .def("get_results", &ks::get_results, pydocs::DOC_StackSearch_get_results)
             .def("set_results", &ks::set_results, pydocs::DOC_StackSearch_set_results)
             .def("compute_max_results", &ks::compute_max_results, pydocs::DOC_StackSearch_compute_max_results)

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -56,6 +56,7 @@ public:
     void finish_search();
 
     // Gets the vector of result trajectories from the grid search.
+    uint64_t get_number_total_results() { return results.get_size(); }
     std::vector<Trajectory> get_results(uint64_t start, uint64_t count);
 
     // Getters for the Psi and Phi data.

--- a/tests/test_core_search_exact.py
+++ b/tests/test_core_search_exact.py
@@ -1,0 +1,76 @@
+"""Test that the core search can perfectly recover an object with linear motion. This test turns off
+all filtering and just checks the GPU search code."""
+
+import logging
+import unittest
+
+from kbmod.configuration import SearchConfiguration
+from kbmod.fake_data.fake_data_creator import add_fake_object, make_fake_layered_image
+from kbmod.run_search import SearchRunner
+from kbmod.search import *
+from kbmod.trajectory_generator import VelocityGridSearch
+
+
+class test_search_exact(unittest.TestCase):
+    def test_core_search_exact(self):
+        # image properties
+        img_count = 20
+        dim_y = 200
+        dim_x = 300
+        noise_level = 1.0
+        variance = noise_level**2
+        p = PSF(1.0)
+
+        # object properties -- The object is moving in a straight line
+        object_flux = 250.0
+        start_x = 70
+        start_y = 45
+        xvel = 40.0
+        yvel = -10.0
+        trj = Trajectory(
+            x=start_x,
+            y=start_y,
+            vx=xvel,
+            vy=yvel,
+        )
+
+        # create image set with single moving object
+        imlist = []
+        for i in range(img_count):
+            time = i / img_count
+            im = make_fake_layered_image(dim_x, dim_y, noise_level, variance, time, p, seed=i)
+            add_fake_object(
+                im,
+                trj.get_x_pos(time),
+                trj.get_y_pos(time),
+                object_flux,
+                p,
+            )
+            imlist.append(im)
+        stack = ImageStack(imlist)
+
+        # Turn off all filtering and use a custom trajectory generator that
+        # tests 1681 velocities per pixel and includes the true velocity.
+        config = SearchConfiguration()
+        config.set("do_clustering", False)
+        config.set("do_mask", False)
+        config.set("do_stamp_filter", False)
+        config.set("lh_level", 0.0)
+        config.set("num_obs", 1)
+        config.set("sigmaG_lims", [5, 95])
+        gen = VelocityGridSearch(41, -80.0, 80.0, 41, -20.0, 20.0)
+
+        # Run the search.
+        runner = SearchRunner()
+        results = runner.do_gpu_search(config, stack, gen)
+        self.assertGreater(len(results), 0)
+
+        # Check that the best result is the true one.
+        self.assertEqual(results["x"][0], start_x)
+        self.assertEqual(results["y"][0], start_y)
+        self.assertEqual(results["vx"][0], xvel)
+        self.assertEqual(results["vy"][0], yvel)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Create a test for the accuracy of the core GPU search by checking that the best result we recover is the fake object that we insert.

As a bonus fix an out-of-bounds error that can happen if we use a likelihood filtering of 0.0.