### PR TITLE
Make SkyWcs the default bbox WCS and calculate WCS errors.

### DIFF
--- a/tests/test_butlerstd.py
+++ b/tests/test_butlerstd.py
@@ -77,8 +77,8 @@ class TestButlerStandardizer(unittest.TestCase):
         # definition uses the pixel in the center of the CCD. The permissible
         # deviation should be on the scale of half a CCD's footprint, unless
         # it's DECam then it could be as big as half an FOV of the focal plane
-        self.assertAlmostEqual(standardized["meta"]["ra"], fits[1].header["CRVAL1"], 1)
-        self.assertAlmostEqual(standardized["meta"]["dec"], fits[1].header["CRVAL2"], 1)
+        self.assertAlmostEqual(standardized["meta"]["ra"], fits[1].header["CRVAL1"], 0)
+        self.assertAlmostEqual(standardized["meta"]["dec"], fits[1].header["CRVAL2"], 0)
 
         # compare standardized images
         # fmt: off

--- a/tests/utils/mock_butler.py
+++ b/tests/utils/mock_butler.py
@@ -368,6 +368,22 @@ class MockButler:
     def mock_wcs(self, ref):
         hdul = FitsFactory.get_fits(ref % FitsFactory.n_files)
         mocked = mock.Mock(name="SkyWcs")
+
+        mocked_coord = mock.Mock(name="RubinCoord")
+        wcs = WCS(hdul[1].header)
+
+        def fake_skywcs_transform(*args, **kwargs):
+            coord = wcs.pixel_to_world(*args, **kwargs)
+            mocked_angle = mock.Mock(name="RubinAngle")
+            mocked_angle.asDegrees.return_value = coord.ra.deg
+            mocked_coord.getRa.return_value = mocked_angle
+            mocked_angle = mock.Mock(name="RubinAngle")
+            mocked_angle.asDegrees.return_value = coord.dec.deg
+            mocked_coord.getDec.return_value = mocked_angle
+            return mocked_coord
+
+        mocked.pixelToSky.side_effect = fake_skywcs_transform
+
         mocked.getFitsMetadata.return_value = hdul[1].header
         return mocked
 


### PR DESCRIPTION
Add wcs error column to the butler standardizer. 
Make SkyWcs the default way to calculate BBOXes so that we can confidently say that's correct. 
Rejigger the ordering of the points in the BBOX to match AstroPy convention. 
