### PR TITLE
Cleanup tests that rely on legacy file formats

### DIFF
--- a/notebooks/create_fake_data.ipynb
+++ b/notebooks/create_fake_data.ipynb
@@ -4,8 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Create Fake Data\n",
-    "**Warning**: For the purposes this example we create (and possibly delete) a data directory at base_dir/fake_data. If that directory already exists, this notebook may overwrite the contents."
+    "# Create Fake Data\n"
    ]
   },
   {
@@ -87,45 +86,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Save the fake image files\n",
-    "\n",
-    "We save the fake images to a given base directory."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dir_path = \"./fake_data\"\n",
-    "ds.save_fake_data_to_dir(dir_path)\n",
-    "print(os.listdir(dir_path))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Delete the fake data files.\n",
-    "\n",
-    "We can (optionally) delete the fake data files using the delete_fake_data() function."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ds.delete_fake_data_dir(dir_path)\n",
-    "print(os.listdir(dir_path))"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -135,9 +95,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (.conda-kbmod)",
+   "display_name": "Jeremy's KBMOD",
    "language": "python",
-   "name": "conda-env-.conda-kbmod-py"
+   "name": "kbmod_jk"
   },
   "language_info": {
    "codemirror_mode": {
@@ -149,7 +109,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.1"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,

--- a/src/kbmod/data_interface.py
+++ b/src/kbmod/data_interface.py
@@ -92,54 +92,6 @@ def load_deccam_layered_image(filename, psf):
     return img
 
 
-def save_deccam_layered_image(img, filename, wcs=None, overwrite=True):
-    """Save a layered image to the legacy deccam format.
-
-    Parameters
-    ----------
-    img : `LayeredImage`
-        The image to save.
-    filename : `str`
-        The name of the file to save.
-    wcs : `astropy.wcs.WCS`, optional
-        The WCS of the image. If provided appends this information to the header.
-    overwrite : `bool`
-        Indicates whether to overwrite the current file if it exists.
-
-    Raises
-    ------
-    Raises a ``ValueError`` if the file exists and ``overwrite`` is ``False``.
-    """
-    if Path(filename).is_file() and not overwrite:
-        raise ValueError(f"{filename} already exists")
-
-    hdul = fits.HDUList()
-
-    # Create the primary header.
-    pri = fits.PrimaryHDU()
-    pri.header["MJD"] = img.get_obstime()
-    if wcs is not None:
-        append_wcs_to_hdu_header(wcs, pri.header)
-    hdul.append(pri)
-
-    # Append the science layer.
-    sci_hdu = raw_image_to_hdu(img.get_science(), wcs)
-    sci_hdu.name = f"science"
-    hdul.append(sci_hdu)
-
-    # Append the mask layer.
-    msk_hdu = raw_image_to_hdu(img.get_mask(), wcs)
-    msk_hdu.name = f"mask"
-    hdul.append(msk_hdu)
-
-    # Append the variance layer.
-    var_hdu = raw_image_to_hdu(img.get_variance(), wcs)
-    var_hdu.name = f"variance"
-    hdul.append(var_hdu)
-
-    hdul.writeto(filename, overwrite=overwrite)
-
-
 def load_input_from_individual_files(
     im_filepath,
     time_file,

--- a/src/kbmod/fake_data/fake_data_creator.py
+++ b/src/kbmod/fake_data/fake_data_creator.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from astropy.io import fits
 
 from kbmod.configuration import SearchConfiguration
-from kbmod.data_interface import save_deccam_layered_image
 from kbmod.file_utils import *
 from kbmod.search import *
 from kbmod.search import Logging
@@ -269,60 +268,6 @@ class FakeDataSet:
         self.insert_object(t)
 
         return t
-
-    def save_fake_data_to_dir(self, data_dir):
-        """Create the fake data in a given directory.
-
-        Parameters
-        ----------
-        data_dir : `str`
-            The path of the directory for the fake data.
-        """
-        # Make the subdirectory if needed.
-        dir_path = Path(data_dir)
-        if not dir_path.is_dir():
-            logger.info(f"Directory {data_dir} does not exist. Creating.")
-            os.mkdir(data_dir)
-
-        # Save each of the image files.
-        for i in range(self.stack.img_count()):
-            img = self.stack.get_single_image(i)
-            filename = os.path.join(data_dir, ("%06i.fits" % i))
-
-            # If the file already exists, delete it.
-            if Path(filename).exists():
-                os.remove(filename)
-
-            # Save the file.
-            save_deccam_layered_image(img, filename, wcs=self.fake_wcs)
-
-    def save_time_file(self, file_name):
-        """Save the mapping of visit ID -> timestamp to a file.
-
-        Parameters
-        ----------
-        file_name : `str`
-            The file name for the timestamp file.
-        """
-        mapping = {}
-        for i in range(self.num_times):
-            id_str = "%06i" % i
-            mapping[id_str] = self.times[i]
-        FileUtils.save_time_dictionary(file_name, mapping)
-
-    def delete_fake_data_dir(self, data_dir):
-        """Remove the fake data in a given directory.
-
-        Parameters
-        ----------
-        data_dir : `str`
-            The path of the directory for the fake data.
-        """
-        for i in range(self.stack.img_count()):
-            img = self.stack.get_single_image(i)
-            filename = os.path.join(data_dir, ("%06i.fits" % i))
-            if Path(filename).exists():
-                os.remove(filename)
 
     def save_fake_data_to_work_unit(self, filename, config=None):
         """Create the fake data in a WorkUnit file.

--- a/tests/test_fake_data_creator.py
+++ b/tests/test_fake_data_creator.py
@@ -83,42 +83,6 @@ class test_fake_image_creator(unittest.TestCase):
             pix_val = ds.stack.get_single_image(i).get_science().get_pixel(py, px)
             self.assertGreaterEqual(pix_val, 50.0)
 
-    def test_save_and_clean(self):
-        num_images = 7
-        ds = FakeDataSet(64, 64, create_fake_times(num_images))
-
-        with tempfile.TemporaryDirectory() as dir_name:
-            # Get all the file names.
-            filenames = []
-            for i in range(num_images):
-                filenames.append(os.path.join(dir_name, "%06i.fits" % i))
-
-            # Check no data exists yet.
-            for name in filenames:
-                self.assertFalse(Path(name).exists())
-
-            # Save the data and check the data now exists.
-            ds.save_fake_data_to_dir(dir_name)
-            for name in filenames:
-                self.assertTrue(Path(name).exists())
-
-            # Clean the data and check the data no longer exists.
-            ds.delete_fake_data_dir(dir_name)
-            for name in filenames:
-                self.assertFalse(Path(name).exists())
-
-    def test_save_times(self):
-        num_images = 50
-        ds = FakeDataSet(4, 4, create_fake_times(num_images))
-
-        with tempfile.TemporaryDirectory() as dir_name:
-            file_name = f"{dir_name}/times.dat"
-            ds.save_time_file(file_name)
-            self.assertTrue(Path(file_name).exists())
-
-            time_load = FileUtils.load_time_dictionary(file_name)
-            self.assertEqual(len(time_load), 50)
-
     def test_save_work_unit(self):
         num_images = 25
         ds = FakeDataSet(15, 10, create_fake_times(num_images))


### PR DESCRIPTION
Remove a bunch of tests that use legacy file formats (partial step toward all file reading happening through the standardizers):

- Remove the file reading and writing tests for `LayeredImage`
- Make the regression test create the `WorkUnit` in memory instead of a collection of legacy files.
- Remove `save_deccam_layered_image` which produces fits files that are not compatible with the standardizer.
- Removing the saving portion of the fake data creation notebook.