### PR TITLE
Allow empty values in IC

### DIFF
--- a/src/kbmod/image_collection.py
+++ b/src/kbmod/image_collection.py
@@ -716,14 +716,12 @@ class ImageCollection:
                 warnings.simplefilter("ignore", category=FutureWarning)
                 test1 = None in self.data[col]
                 test1 = test1 if isinstance(test1, bool) else test1.any()
-                test2 = "" in self.data[col]
-                test2 = test2 if isinstance(test2, bool) else test2.any()
-                if test1 or test2:
-                    return False, "missing required self.data values: {col}"
+                if test1:
+                    return False, f"missing required self.data values: {col}"
 
         for col in shared_cols:
             if self.data.meta[col] is None or self.data.meta[col] == "":
-                return False, "missing required self.data values: {col}"
+                return False, f"missing required self.data values: {col}"
 
         return True, ""
 


### PR DESCRIPTION
Allow some values in columns to be empty strings, or their equivalent falsy values. 
This is not a good fix because autocasting rules sometimes could cast the column as masked column, but required for the data that was processed with the different stack version. The fix is to set a default non-falsy value in the ButlerStandardizers for the properties that the new stack versions may return as `None` or "" when using an older stack version.

Blocked by https://github.com/dirac-institute/kbmod/pull/694 