### PR TITLE
Fix segfault in weighted variance stamps

### DIFF
--- a/src/kbmod/image_collection.py
+++ b/src/kbmod/image_collection.py
@@ -270,6 +270,10 @@ class ImageCollection:
             of the registered standardizers can be provided. Optionally,
             provide the `Standardizer` class itself in which case it will be
             called for each target in the iterable.
+        config : `~StandardizerConfig`, `dict` or `None`, optional
+            Standardizer configuration or dictionary containing the config
+            parameters for standardization. When `None` default values for the
+            appropriate `Standardizer` will be used.
         **kwargs : `dict`
             Remaining keyword arguments are passed to the `Standardizer`.
 
@@ -296,10 +300,14 @@ class ImageCollection:
         recursive : `bool`
             If the location is a local filesystem directory, scan it
             recursively including all sub-directories.
-        forceStandardizer : `Standardizer` or `None`
+        force : `Standardizer` or `None`
             If `None`, when applicable, determine the correct `Standardizer` to
             use automatically. Otherwise force the use of the given
             `Standardizer`.
+        config : `~StandardizerConfig`, `dict` or `None`, optional
+            Standardizer configuration or dictionary containing the config
+            parameters for standardization. When `None` default values for the
+            appropriate `Standardizer` will be used.
         **kwargs : `dict`
             Remaining kwargs, not listed here, are passed onwards to
             the underlying `Standardizer`.

--- a/src/kbmod/standardizers/fits_standardizers/fits_standardizer.py
+++ b/src/kbmod/standardizers/fits_standardizers/fits_standardizer.py
@@ -410,6 +410,10 @@ class FitsStandardizer(Standardizer):
         # copy. TODO: fix when/if CPP stuff is fixed.
         imgs = []
         for sci, var, mask, psf, t in zip(sciences, variances, masks, psfs, mjds):
+            # Make sure the science and variance layers are float32.
+            sci = sci.astype(np.float32)
+            var = var.astype(np.float32)
+
             # Converts nd array mask from bool to np.float32
             mask = mask.astype(np.float32)
             imgs.append(LayeredImage(RawImage(sci, t), RawImage(var, t), RawImage(mask, t), psf))


### PR DESCRIPTION
The weighted variance stamps were causing a segfault when the number of returned stamps was less than the number of images. This could happen because of `use_index` which is set by the sigma-G filtering. The fix is to set `num_images` to the number of returned stamps.

This PR includes a few cleanups found during the debugging, including adding some docstring comments and fixing a numpy conversion error on old (v0.5) data.