### PR TITLE
Remove unused functions

### DIFF
--- a/notebooks/Kbmod_Reference.ipynb
+++ b/notebooks/Kbmod_Reference.ipynb
@@ -231,22 +231,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Like the psf, `LayeredImage` provides a `stats_string` function that will summarize useful information about the images including their size, observation time, the bounds (min/max) of layers, etc."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(im.stats_string())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "The image pixels' values can be retrieved as a 2D numpy array"
    ]
   },
@@ -264,7 +248,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A LayeredImage can have its layers set from any numpy array with type `float32` and observation time. We use -1.0 to indicate no time is given."
+    "A LayeredImage can have its layers set from any numpy array with type `float32` and observation time."
    ]
   },
   {
@@ -274,7 +258,7 @@
    "outputs": [],
    "source": [
     "all_ones = np.ones((im.get_height(), im.get_width()))\n",
-    "raw = kb.RawImage(all_ones.astype(np.float32), -1.0)"
+    "raw = kb.RawImage(all_ones.astype(np.float32))"
    ]
   },
   {
@@ -526,6 +510,13 @@
     "# These top_results are all be duplicating searches on the same bright object we added.\n",
     "top_results[:20]"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/src/kbmod/search/layered_image.cpp
+++ b/src/kbmod/search/layered_image.cpp
@@ -225,32 +225,6 @@ double LayeredImage::compute_fraction_masked() const {
     return masked_count / total_count;
 }
 
-std::string LayeredImage::stats_string() const {
-    std::stringstream result;
-
-    result << "LayeredImage Stats:\n"
-           << "  Image Size = (" << std::to_string(height) << ", " << std::to_string(width) << ")\n"
-           << "  Obs Time = " << std::to_string(get_obstime()) << "\n";
-
-    // Output the stats for the science and variance layers.
-    std::array<float, 2> sci_bnds = science.compute_bounds();
-    std::array<double, 2> sci_stats = science.compute_mean_std();
-    result << "  Science layer: bounds = [" << std::to_string(sci_bnds[0]) << ", "
-           << std::to_string(sci_bnds[1]) << "], mean = " << std::to_string(sci_stats[0])
-           << ", std = " << std::to_string(sci_stats[1]) << "\n";
-
-    std::array<float, 2> var_bnds = variance.compute_bounds();
-    std::array<double, 2> var_stats = variance.compute_mean_std();
-    result << "  Variance layer: bounds = [" << std::to_string(var_bnds[0]) << ", "
-           << std::to_string(var_bnds[1]) << "], mean = " << std::to_string(var_stats[0])
-           << ", std = " << std::to_string(var_stats[1]) << "\n";
-
-    // Compute the fraction of science pixels that are masked.
-    result << "  Fraction masked = " << std::to_string(compute_fraction_masked()) << "\n";
-
-    return result.str();
-}
-
 #ifdef Py_PYTHON_H
 static void layered_image_bindings(py::module& m) {
     using li = search::LayeredImage;
@@ -313,7 +287,6 @@ static void layered_image_bindings(py::module& m) {
             .def("set_obstime", &li::set_obstime, pydocs::DOC_LayeredImage_set_obstime)
             .def("compute_fraction_masked", &li::compute_fraction_masked,
                  pydocs::DOC_LayeredImage_compute_fraction_masked)
-            .def("stats_string", &li::stats_string, pydocs::DOC_LayeredImage_stats_string)
             .def("generate_psi_image", &li::generate_psi_image, pydocs::DOC_LayeredImage_generate_psi_image)
             .def("generate_phi_image", &li::generate_phi_image, pydocs::DOC_LayeredImage_generate_phi_image);
 }

--- a/src/kbmod/search/layered_image.h
+++ b/src/kbmod/search/layered_image.h
@@ -88,7 +88,6 @@ public:
 
     // Debugging and statistics functions.
     double compute_fraction_masked() const;
-    std::string stats_string() const;
 
 private:
     unsigned width;

--- a/src/kbmod/search/pydocs/layered_image_docs.h
+++ b/src/kbmod/search/pydocs/layered_image_docs.h
@@ -232,16 +232,6 @@ static const auto DOC_LayeredImage_compute_fraction_masked = R"doc(
       The fraction of pixels in the science image that are masked.
   )doc";
 
-static const auto DOC_LayeredImage_stats_string = R"doc(
-  Compute a range of statistics about the ``LayeredImage`` and format
-  them into a user readable string that can be logged printed.
-
-  Returns
-  -------
-  result : `str`
-      A user readable string about the ``LayeredImage``.
-  )doc";
-
 }  // namespace pydocs
 
 #endif /* LAYEREDIMAGE_DOCS  */

--- a/src/kbmod/search/pydocs/raw_image_docs.h
+++ b/src/kbmod/search/pydocs/raw_image_docs.h
@@ -198,16 +198,7 @@ static const auto DOC_RawImage_compute_bounds = R"doc(
   bounds : `tuple`
       A ``(min, max)`` tuple.
   )doc";
-
-static const auto DOC_RawImage_compute_mean_std = R"doc(
-  Returns mean and standard deviation of the pixel values, ignoring the masked pixels.
-
-  Returns
-  -------
-  bounds : `tuple`
-      A ``(mean, std)`` tuple.
-  )doc";
-
+  
 static const auto DOC_RawImage_find_peak = R"doc(
   Returns the pixel coordinates of the maximum value.
 

--- a/src/kbmod/search/raw_image.cpp
+++ b/src/kbmod/search/raw_image.cpp
@@ -179,26 +179,6 @@ std::array<float, 2> RawImage::compute_bounds() const {
     return {min_val, max_val};
 }
 
-std::array<double, 2> RawImage::compute_mean_std() const {
-    double sum = 0.0;
-    double sum_sq = 0.0;
-    double count = 0.0;
-
-    for (auto elem : image.reshaped())
-        if (pixel_value_valid(elem)) {
-            sum += elem;
-            sum_sq += elem * elem;
-            count += 1.0;
-        }
-
-    // Avoid divide by zero.
-    if (count == 0) return {0, 0};
-
-    double mean = sum / count;
-    double std = sqrt(sum_sq / count - mean * mean);
-    return {mean, std};
-}
-
 void RawImage::convolve_cpu(PSF& psf) {
     Image result = Image::Zero(height, width);
 
@@ -528,7 +508,6 @@ static void raw_image_bindings(py::module& m) {
             .def("replace_masked_values", &rie::replace_masked_values, py::arg("value") = 0.0f,
                  pydocs::DOC_RawImage_replace_masked_values)
             .def("compute_bounds", &rie::compute_bounds, pydocs::DOC_RawImage_compute_bounds)
-            .def("compute_mean_std", &rie::compute_mean_std, pydocs::DOC_RawImage_compute_mean_std)
             .def("find_peak", &rie::find_peak, pydocs::DOC_RawImage_find_peak)
             .def("find_central_moments", &rie::find_central_moments,
                  pydocs::DOC_RawImage_find_central_moments)

--- a/src/kbmod/search/raw_image.h
+++ b/src/kbmod/search/raw_image.h
@@ -96,9 +96,6 @@ public:
     // Compute the min and max bounds of values in the image.
     std::array<float, 2> compute_bounds() const;
 
-    // Compute the mean and standard deviation of the valid pixel values.
-    std::array<double, 2> compute_mean_std() const;
-
     // Convolve the image with a point spread function.
     void convolve(PSF& psf);
     void convolve_cpu(PSF& psf);

--- a/tests/test_layered_image.py
+++ b/tests/test_layered_image.py
@@ -317,13 +317,6 @@ class test_LayeredImage(unittest.TestCase):
         template2.set_all(0.0)
         self.assertRaises(RuntimeError, self.image.sub_template, template2)
 
-    def test_stats_string(self):
-        result = self.image.stats_string()
-        self.assertGreater(len(result), 0)
-        self.assertTrue("Science layer: bounds" in result)
-        self.assertTrue("Variance layer: bounds" in result)
-        self.assertTrue("Fraction masked" in result)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -189,13 +189,6 @@ class test_RawImage(unittest.TestCase):
         self.assertAlmostEqual(lower, 0.1, delta=1e-6)
         self.assertAlmostEqual(upper, 100.0, delta=1e-6)
 
-    def test_compute_mean_std(self):
-        """Test RawImage masked min/max bounds."""
-        img = RawImage(self.masked_array)
-        mean, std = img.compute_mean_std()
-        self.assertAlmostEqual(mean, np.nanmean(img.image.flatten()), delta=1e-6)
-        self.assertAlmostEqual(std, np.nanstd(img.image.flatten()), delta=1e-6)
-
     def test_replace_masked_values(self):
         img2 = RawImage(np.copy(self.masked_array))
         img2.replace_masked_values(0.0)


### PR DESCRIPTION
Remove a few unused functions from the C++ code:
- `RawImage.compute_mean_std()`
- `LayeredImage.stats_string()`