### PR TITLE
Save the WCS as a column in the results table

### DIFF
--- a/src/kbmod/reprojection_utils.py
+++ b/src/kbmod/reprojection_utils.py
@@ -28,8 +28,8 @@ def correct_parallax(
     use_bounds=False,
 ):
     """Calculate the parallax corrected postions for a given object at a given
-    time, observation location on Earth, and user defined distance from th
-    e Sun.
+    time, observation location on Earth, and user defined distance from the Sun.
+
     By default, this function will use the geometric solution for objects beyond 1au.
     If the distance is less than 1au, the function will use the scipy minimizer
     to find the best geocentric distance.
@@ -66,7 +66,6 @@ def correct_parallax(
     ICRS, and the best fit geocentric distance (float).
 
     """
-
     if use_minimizer or heliocentric_distance < 1.02:
         return correct_parallax_with_minimizer(
             coord, obstime, point_on_earth, heliocentric_distance, geocentric_distance, method, use_bounds

--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -616,7 +616,7 @@ class Results:
 
         return self
 
-    def write_table(self, filename, overwrite=True, cols_to_drop=[]):
+    def write_table(self, filename, overwrite=True, cols_to_drop=()):
         """Write the unfiltered results to a single (ecsv) file.
 
         Parameter
@@ -625,8 +625,8 @@ class Results:
             The name of the result file.
         overwrite : `bool`
             Overwrite the file if it already exists. [default: True]
-        cols_to_drop : `list`
-            A list of columns to drop (to save space). [default: []]
+        cols_to_drop : `tuple`
+            A tuple of columns to drop (to save space). [default: ()]
         """
         logger.info(f"Saving results to {filename}")
 

--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -30,7 +30,7 @@ class Results:
     table : `astropy.table.Table`
         The stored results data.
     wcs : `astropy.wcs.WCS`
-        A gloabl WCS for all the results. This is optional and primarily used when saving
+        A global WCS for all the results. This is optional and primarily used when saving
         the results to a file so as to preserve the WCS for future analysis.
     track_filtered : `bool`
         Whether to track (save) the filtered trajectories. This will use

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -189,24 +189,24 @@ class SearchRunner:
 
     def run_search(self, config, stack, trj_generator=None, wcs=None):
         """This function serves as the highest-level python interface for starting
-         a KBMOD search given an ImageStack and SearchConfiguration.
+        a KBMOD search given an ImageStack and SearchConfiguration.
 
-         Parameters
-         ----------
-         config : `SearchConfiguration`
-             The configuration parameters
-         stack : `ImageStack`
-             The stack before the masks have been applied. Modified in-place.
-         trj_generator : `TrajectoryGenerator`, optional
-             The object to generate the candidate trajectories for each pixel.
-             If None uses the default EclipticCenteredSearch
-         wcs : `astropy.wcs.WCS`, optional
-             A global WCS for all images in the search.
+        Parameters
+        ----------
+        config : `SearchConfiguration`
+            The configuration parameters
+        stack : `ImageStack`
+            The stack before the masks have been applied. Modified in-place.
+        trj_generator : `TrajectoryGenerator`, optional
+            The object to generate the candidate trajectories for each pixel.
+            If None uses the default EclipticCenteredSearch
+        wcs : `astropy.wcs.WCS`, optional
+            A global WCS for all images in the search.
 
         Returns
-         -------
-         keep : `Results`
-             The results.
+        -------
+        keep : `Results`
+            The results.
         """
         if not kb.HAS_GPU:
             logger.warning("Code was compiled without GPU.")

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -250,9 +250,8 @@ class SearchRunner:
         if config["save_all_stamps"]:
             append_all_stamps(keep, stack, config["stamp_radius"])
 
-        # Append the WCS information if it is provided.
-        if wcs is not None:
-            keep.table["wcs"] = [wcs] * len(keep)
+        # Append the WCS information if it is provided. This will be saved with the results.
+        keep.table.wcs = wcs
 
         logger.info(f"Found {len(keep)} potential trajectories.")
 

--- a/src/kbmod/wcs_utils.py
+++ b/src/kbmod/wcs_utils.py
@@ -437,11 +437,11 @@ def wcs_to_dict(wcs):
     result : `dict`
         A dictionary containing the WCS header information.
     """
-    result = {}
-    if wcs is not None:
-        wcs_header = wcs.to_header()
-        for key in wcs_header:
-            result[key] = wcs_header[key]
+    result = dict(wcs.to_header(relax=True))
+    if wcs.pixel_shape is not None:
+        header["NAXIS1"], header["NAXIS2"] = wcs.pixel_shape
+    elif wcs.array_shape is not None:
+        header["NAXIS2"], header["NAXIS1"] = wcs.array_shape
     return result
 
 
@@ -458,10 +458,10 @@ def serialize_wcs(wcs):
     wcs_str : `str`
         The serialized WCS.
     """
-    # Since AstroPy's WCS does not output NAXIS, we need to manually save that.
-    wcs_dict = wcs_to_dict(wcs)
-    wcs_dict["_array_shape"] = wcs.array_shape
-    return json.dumps(wcs_dict)
+    # Since AstroPy's WCS does not output NAXIS, we need to manually add those.
+    header = wcs.to_header(relax=True)
+    header["NAXIS1"], header["NAXIS2"] = wcs.pixel_shape
+    return json.dumps(dict(header))
 
 
 def deserialize_wcs(wcs_str):
@@ -478,9 +478,8 @@ def deserialize_wcs(wcs_str):
         The resulting WCS.
     """
     wcs_dict = json.loads(wcs_str)
-    saved_shape = wcs_dict.pop("_array_shape")  # Extract the array shape to apply later.
     wcs = astropy.wcs.WCS(wcs_dict)
-    wcs.array_shape = saved_shape  # Re-apply the array shape.
+    wcs.pixel_shape = (wcs_dict["NAXIS1"], wcs_dict["NAXIS2"])
     return wcs
 
 
@@ -587,5 +586,11 @@ def wcs_fits_equal(wcs_a, wcs_b):
             return False
         if header_a[key] != header_b[key]:
             return False
+
+    # Check that we correctly kept the shape of the matrix.
+    if wcs_a.array_shape != wcs_b.array_shape:
+        return False
+    if wcs_a.pixel_shape != wcs_b.pixel_shape:
+        return False
 
     return True

--- a/src/kbmod/wcs_utils.py
+++ b/src/kbmod/wcs_utils.py
@@ -3,6 +3,7 @@
 import astropy.coordinates
 import astropy.units
 import astropy.wcs
+import json
 import numpy
 
 
@@ -442,6 +443,45 @@ def wcs_to_dict(wcs):
         for key in wcs_header:
             result[key] = wcs_header[key]
     return result
+
+
+def serialize_wcs(wcs):
+    """Convert a WCS into a JSON string.
+
+    Parameters
+    ----------
+    wcs : `astropy.wcs.WCS`
+        The WCS to convert.
+
+    Returns
+    -------
+    wcs_str : `str`
+        The serialized WCS.
+    """
+    # Since AstroPy's WCS does not output NAXIS, we need to manually save that.
+    wcs_dict = wcs_to_dict(wcs)
+    wcs_dict["_array_shape"] = wcs.array_shape
+    return json.dumps(wcs_dict)
+
+
+def deserialize_wcs(wcs_str):
+    """Convert a JSON string into a WCS object.
+
+    Parameters
+    ----------
+    wcs_str : `str`
+        The serialized WCS.
+
+    Returns
+    -------
+    wcs : `astropy.wcs.WCS`
+        The resulting WCS.
+    """
+    wcs_dict = json.loads(wcs_str)
+    saved_shape = wcs_dict.pop("_array_shape")  # Extract the array shape to apply later.
+    wcs = astropy.wcs.WCS(wcs_dict)
+    wcs.array_shape = saved_shape  # Re-apply the array shape.
+    return wcs
 
 
 def make_fake_wcs_info(center_ra, center_dec, height, width, deg_per_pixel=None):

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -391,7 +391,6 @@ class test_results(unittest.TestCase):
 
         # Create a fake WCS to use for serialization tests.
         fake_wcs = make_fake_wcs(25.0, -7.5, 800, 600, deg_per_pixel=0.01)
-        fake_wcs.pixel_shape = (800, 600)
         table.wcs = fake_wcs
 
         # Test read/write to file.

--- a/tests/test_wcs_utils.py
+++ b/tests/test_wcs_utils.py
@@ -57,6 +57,16 @@ class test_wcs_conversion(unittest.TestCase):
             self.assertTrue(key in new_dict)
             self.assertAlmostEqual(new_dict[key], self.header_dict[key])
 
+    def test_serialization(self):
+        self.wcs.array_shape = (200, 250)
+        wcs_str = serialize_wcs(self.wcs)
+        self.assertTrue(isinstance(wcs_str, str))
+
+        wcs2 = deserialize_wcs(wcs_str)
+        self.assertTrue(isinstance(wcs2, WCS))
+        self.assertEqual(self.wcs.array_shape, wcs2.array_shape)
+        self.assertTrue(wcs_fits_equal(self.wcs, wcs2))
+
     def test_append_wcs_to_hdu_header(self):
         for use_dictionary in [True, False]:
             if use_dictionary:

--- a/tests/test_wcs_utils.py
+++ b/tests/test_wcs_utils.py
@@ -58,13 +58,13 @@ class test_wcs_conversion(unittest.TestCase):
             self.assertAlmostEqual(new_dict[key], self.header_dict[key])
 
     def test_serialization(self):
-        self.wcs.array_shape = (200, 250)
+        self.wcs.pixel_shape = (200, 250)
         wcs_str = serialize_wcs(self.wcs)
         self.assertTrue(isinstance(wcs_str, str))
 
         wcs2 = deserialize_wcs(wcs_str)
         self.assertTrue(isinstance(wcs2, WCS))
-        self.assertEqual(self.wcs.array_shape, wcs2.array_shape)
+        self.assertEqual(self.wcs.pixel_shape, wcs2.pixel_shape)
         self.assertTrue(wcs_fits_equal(self.wcs, wcs2))
 
     def test_append_wcs_to_hdu_header(self):


### PR DESCRIPTION
Adds the ability to save the WCS to the results table. Adds:
- A custom serializer and deserializer for WCS to capture the dropped NAXIS information,
- Include the WCS as global meta data.

Co-authored-by: DinoBektesevic <dinob@uw.edu>