### PR TITLE
Save additional metadata to results file

### DIFF
--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -616,7 +616,7 @@ class Results:
 
         return self
 
-    def write_table(self, filename, overwrite=True, cols_to_drop=()):
+    def write_table(self, filename, overwrite=True, cols_to_drop=(), addition_meta=None):
         """Write the unfiltered results to a single (ecsv) file.
 
         Parameter
@@ -627,6 +627,8 @@ class Results:
             Overwrite the file if it already exists. [default: True]
         cols_to_drop : `tuple`
             A tuple of columns to drop (to save space). [default: ()]
+        addition_meta : `dict`, optional
+            Any additional meta data to save with the table.
         """
         logger.info(f"Saving results to {filename}")
 
@@ -643,7 +645,12 @@ class Results:
 
         # Add global meta data that we can retrieve.
         if self.wcs is not None:
+            logger.debug("Saving WCS to Results table meta data.")
             write_table.meta["wcs"] = serialize_wcs(self.wcs)
+        if addition_meta is not None:
+            for key, val in addition_meta.items():
+                logger.debug(f"Saving {key} to Results table meta data.")
+                write_table.meta[key] = val
 
         # Write out the table.
         write_table.write(filename, overwrite=overwrite)

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -245,6 +245,7 @@ class SearchRunner:
             stack.copy_to_gpu()
             append_coadds(keep, stack, config["coadds"], config["stamp_radius"])
             stack.clear_from_gpu()
+        logger.info(f"Found {len(keep)} potential trajectories.")
 
         # Extract all the stamps for all time steps and append them onto the result rows.
         if config["save_all_stamps"]:
@@ -253,7 +254,13 @@ class SearchRunner:
         # Append the WCS information if it is provided. This will be saved with the results.
         keep.table.wcs = wcs
 
-        logger.info(f"Found {len(keep)} potential trajectories.")
+        # Create and save any additional meta data that should be saved with the results.
+        num_img = stack.img_count()
+        meta = {
+            "num_img": num_img,
+            "dims": (stack.get_width(), stack.get_height()),
+            "mjd_mid": [stack.get_obstime(i) for i in range(num_img)],
+        }
 
         # Save the results in as an ecsv file and/or a legacy text file.
         if config["legacy_filename"] is not None:
@@ -263,9 +270,9 @@ class SearchRunner:
         if config["result_filename"] is not None:
             logger.info(f"Saving results table to {config['result_filename']}")
             if not config["save_all_stamps"]:
-                keep.write_table(config["result_filename"], cols_to_drop=["all_stamps"])
+                keep.write_table(config["result_filename"], cols_to_drop=["all_stamps"], addition_meta=meta)
             else:
-                keep.write_table(config["result_filename"])
+                keep.write_table(config["result_filename"], addition_meta=meta)
         full_timer.stop()
 
         return keep

--- a/tests/test_regression_test.py
+++ b/tests/test_regression_test.py
@@ -336,6 +336,11 @@ def run_full_test():
         found = loaded_data.make_trajectory_list()
         logger.debug("Found %i trajectories vs %i used." % (len(found), len(trjs)))
 
+        # Check that we saved the correct meta data for the table.
+        assert loaded_data.table.meta["num_img"] == num_times
+        assert loaded_data.table.meta["dims"] == (stack.get_width(), stack.get_height())
+        assert np.allclose(loaded_data.table.meta["mjd_mid"], times)
+
         # Determine which trajectories we did not recover.
         overlap = find_unique_overlap(trjs, found, 3.0, [0.0, 2.0])
         missing = find_set_difference(trjs, found, 3.0, [0.0, 2.0])

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -416,8 +416,13 @@ class test_results(unittest.TestCase):
             with self.assertRaises(OSError):
                 table.write_table(file_path, overwrite=False, cols_to_drop=["other"])
 
-            # We can overwrite with droped columns
-            table.write_table(file_path, overwrite=True, cols_to_drop=["other"])
+            # We can overwrite with droped columns and additional meta data.
+            table.write_table(
+                file_path,
+                overwrite=True,
+                cols_to_drop=["other"],
+                addition_meta={"times": [1, 2, 3, 4, 5], "other": 100.0},
+            )
 
             table3 = Results.read_table(file_path)
             self.assertEqual(len(table2), max_save)
@@ -425,6 +430,12 @@ class test_results(unittest.TestCase):
             # We only dropped the table from the save file.
             self.assertFalse("other" in table3.colnames)
             self.assertTrue("other" in table.colnames)
+
+            # We saved the additional meta data, including the WCS.
+            self.assertTrue(np.array_equal(table3.table.meta["times"], [1, 2, 3, 4, 5]))
+            self.assertEqual(table3.table.meta["other"], 100.0)
+            self.assertIsNotNone(table3.wcs)
+            self.assertTrue(wcs_fits_equal(table3.wcs, fake_wcs))
 
     def test_save_and_load_trajectories(self):
         table = Results.from_trajectories(self.trj_list)


### PR DESCRIPTION
Add option for passing more metadata when `Results` writes out its table. Automatically include some additional information, including the image time stamps, the number of images, and the image dimensions.