### PR TITLE
Pass additional metadata to WorkUnit

### DIFF
--- a/src/kbmod/standardizers/fits_standardizers/kbmodv05.py
+++ b/src/kbmod/standardizers/fits_standardizers/kbmodv05.py
@@ -141,14 +141,15 @@ class KBMODV0_5(MultiExtensionFits):
         ]
 
     def translateHeader(self):
-        """Returns the following metadata, read from the primary header, as a
-        dictionary:
+        """Returns at least the following metadata, read from the primary header,
+         as a dictionary:
 
         ======== ========== ===================================================
         Key      Header Key Description
         ======== ========== ===================================================
         mjd      DATE-AVG   Decimal MJD timestamp of the middle of the exposure
         filter   FILTER     Filter band
+        visit    EXPID      Exposure ID
         ======== ========== ===================================================
         """
         # this is the 1 mandatory piece of metadata we need to extract
@@ -159,6 +160,7 @@ class KBMODV0_5(MultiExtensionFits):
 
         # these are all optional things
         standardizedHeader["filter"] = self.primary["FILTER"]
+        standardizedHeader["visit"] = self.primary["EXPID"]
 
         # If no observatory information is given, default to the Deccam data
         # (Cerro Tololo Inter-American Observatory).

--- a/tests/test_imagecollection.py
+++ b/tests/test_imagecollection.py
@@ -155,7 +155,15 @@ class TestImageCollection(unittest.TestCase):
 
         data = self.fitsFactory.get_n(3, spoof_data=True)
         ic = ImageCollection.fromTargets(data)
-        wu = ic.toWorkUnit(search_config=SearchConfiguration())
+        wu = ic.toWorkUnit(search_config=SearchConfiguration(), extra_meta=["FILTER"])
+        self.assertEqual(len(wu), 3)
+
+        # We can retrieve the meta data from the WorkUnit.
+        filter_info = wu.get_constituent_meta("FILTER")
+        self.assertEqual(len(filter_info), 3)
+        self.assertIsNotNone(filter_info[0])
+
+        # We can write the whole work unit to a file.
         with tempfile.TemporaryDirectory() as dir_name:
             wu.to_fits(f"{dir_name}/test.fits")
 


### PR DESCRIPTION
Extract arbitrary metadata from the standardizer's `standardizeMetadata()` function and save it to the `WorkUnit`. If the meta data is not present for that standardizer, this will just fill in `None`. By default we extract "visit" and "filter".