### PR TITLE
Add a KBMOD results filter for matching "known objects" 

### DIFF
--- a/src/kbmod/__init__.py
+++ b/src/kbmod/__init__.py
@@ -10,6 +10,8 @@ import time
 import logging as _logging
 from logging import config as _config
 
+from scipy.special import erfinv
+
 # Import the rest of the package
 from kbmod.search import Logging
 

--- a/src/kbmod/__init__.py
+++ b/src/kbmod/__init__.py
@@ -10,8 +10,6 @@ import time
 import logging as _logging
 from logging import config as _config
 
-from scipy.special import erfinv
-
 # Import the rest of the package
 from kbmod.search import Logging
 

--- a/src/kbmod/filters/__init__.py
+++ b/src/kbmod/filters/__init__.py
@@ -1,5 +1,6 @@
 from . import (
     clustering_filters,
+    known_object_filters,
     sigma_g_filter,
     stamp_filters,
 )

--- a/src/kbmod/filters/known_object_filters.py
+++ b/src/kbmod/filters/known_object_filters.py
@@ -158,7 +158,6 @@ class KnownObjsMatcher:
         """
         return SkyCoord(ra=self.data[self.ra_col], dec=self.data[self.dec_col], unit="deg")
 
-
     def match(self, result_data, wcs):
         """This function takes a list of results and matches them to known objects.
 

--- a/src/kbmod/filters/known_object_filters.py
+++ b/src/kbmod/filters/known_object_filters.py
@@ -5,7 +5,6 @@ import kbmod.search as kb
 
 from astropy.table import Table
 from astropy.coordinates import search_around_sky, SkyCoord
-# import astropy units
 import astropy.units as u
 
 from kbmod.trajectory_utils import trajectory_predict_skypos

--- a/src/kbmod/filters/known_object_filters.py
+++ b/src/kbmod/filters/known_object_filters.py
@@ -158,6 +158,7 @@ class KnownObjsMatcher:
         """
         return SkyCoord(ra=self.data[self.ra_col], dec=self.data[self.dec_col], unit="deg")
 
+
     def match(self, result_data, wcs):
         """This function takes a list of results and matches them to known objects.
 
@@ -284,6 +285,9 @@ class KnownObjsMatcher:
         """
         Create a column corresponding to the known objects that were matched to a result
         based on the minimum number of observations that matched to that known object.
+        Note that the ratio is calculated based on the total number of observations
+        that were within `time_sep_thresh_s` of the `obstimes` we are matching to. Observations
+        outside of that time range are not considered.
 
         Note that a given result can match to multiple objects.
 

--- a/src/kbmod/filters/known_object_filters.py
+++ b/src/kbmod/filters/known_object_filters.py
@@ -1,24 +1,28 @@
-import numpy as np
-
-from kbmod.results import Results
-import kbmod.search as kb
-
-from astropy.table import Table
-from astropy.coordinates import search_around_sky, SkyCoord
 import astropy.units as u
+import numpy as np
+from astropy.coordinates import SkyCoord, search_around_sky
 
+import kbmod.search as kb
 from kbmod.trajectory_utils import trajectory_predict_skypos
-
 
 logger = kb.Logging.getLogger(__name__)
 
 
-class KnownObjs:
+class KnownObjsMatcher:
     """
     A class which ingests an astopy table of KnownObj data for easy maniuplation.
     """
 
-    def __init__(self, table, mjd_col="mjd_mid", ra_col="RA", dec_col="DEC", name_col="Name"):
+    def __init__(
+        self,
+        table,
+        obstimes,
+        filter_params,
+        mjd_col="mjd_mid",
+        ra_col="RA",
+        dec_col="DEC",
+        name_col="Name",
+    ):
         """
         Parameters
         ----------
@@ -40,11 +44,12 @@ class KnownObjs:
 
         Returns
         -------
-        KnownObjs
-            A KnownObjs object.
+        KnownObjsMatcher
+            A KnownObjsMatcher object.
         """
         self.data = table
 
+        # Map our required columns to any specified column names.
         self.mjd_col = mjd_col
         self.ra_col = ra_col
         self.dec_col = dec_col
@@ -55,6 +60,24 @@ class KnownObjs:
         invalid_cols = user_cols - set(self.data.colnames)
         if invalid_cols:
             raise ValueError(f"{invalid_cols} not found in KnownObjs data.")
+
+        self.obstimes = obstimes
+        self.filter_params = filter_params
+        if len(self.obstimes) == 0:
+            raise ValueError("No obstimes provided")
+        if not self.filter_params:
+            raise ValueError("No filter_params provided")
+
+        self.time_sep_thresh_s = (
+            self.filter_params["known_obj_sep_time_thresh_s"]
+            if "known_obj_sep_time_thresh_s" in self.filter_params
+            else 1200.0
+        )
+        self.filter_rows_by_time()
+
+        # Column names for recovered objects using either filtering method.
+        self.match_min_obs_col = "recovered_" + self.filter_params["filter_type"] + "_min_obs"
+        self.match_obs_ratio_col = "recovered_" + self.filter_params["filter_type"] + "_obs_ratio"
 
     def __len__(self):
         return len(self.data)
@@ -89,7 +112,7 @@ class KnownObjs:
         """
         return SkyCoord(ra=self.data[self.ra_col], dec=self.data[self.dec_col], unit="deg")
 
-    def filter_rows_by_time(self, start_mjd, end_mjd):
+    def filter_rows_by_time(self):
         """
         Returns a new KnownObjs filtered down to within a given time range.
 
@@ -105,119 +128,190 @@ class KnownObjs:
         KnownObjs
             A new KnownObjs object filtered down withing the given time range.
         """
-        new_data = self.data[(self.data[self.mjd_col] >= start_mjd) & (self.data[self.mjd_col] <= end_mjd)]
-        return KnownObjs(
-            new_data, mjd_col=self.mjd_col, ra_col=self.ra_col, dec_col=self.dec_col, name_col=self.name_col
+        start_mjd = max(0, min(self.obstimes) - 2 - self.time_sep_thresh_s)
+        end_mjd = max(self.obstimes) + 2 + self.time_sep_thresh_s
+
+        self.data = self.data[(self.data[self.mjd_col] >= start_mjd) & (self.data[self.mjd_col] <= end_mjd)]
+
+    def get_counts(self):
+        """
+        Returns the number of known objects in the table.
+        """
+        cnts = {}
+        for i in range(len(self.data)):
+            if self.data[self.name_col][i] not in cnts:
+                cnts[self.data[self.name_col][i]] = 0
+            cnts[self.data[self.name_col][i]] += 1
+
+        return cnts
+
+    def match_known_obj_filters(self, result_data, wcs):
+        """This function takes a list of results and matches them to known objects.
+
+        Parameters
+        ----------
+        result_data: `Results`
+            The set of results to filter. This data gets modified directly by
+            the filtering.
+        known_objs: `KnownObjs`
+            The known objects to filter against.
+        obstimes: list(float)
+            The mjd times of each possible observation.
+        wcs: `astropy.wcs.WCS`
+            The common WCS object for the stack of images.
+        filter_params : dict
+            Contains values concerning the image and search settings including:
+            filter_type, filter_params, and filter_obs.
+        remove_match_obs : bool
+            If True, remove observations that match to known objects from the results
+
+        Returns
+        -------
+        list(dict)
+            A list where each element is a dictionary of matching known objects for the
+            corresponding result in ``result_data``. The dictionary maps the name of the
+            known object to a boolean array of length equal to the number of valid observations
+            in the result. Each element of the array is True if that known object matched to
+            the corresponding observation, and False otherwise.
+
+        Raises
+        ------
+            Raises a ValueError if the parameters are not valid.
+            Raises a TypeError if ``result_data`` is of an unsupported type.
+        """
+        all_matches = []
+
+        sep_thresh = (
+            self.filter_params["known_obj_sep_thresh"]
+            if "known_obj_sep_thresh" in self.filter_params
+            else 1.0
         )
+        sep_thresh = sep_thresh * u.arcsec
 
+        # Get the RA and DEC of the known objects and the trajectories of the results for matching
+        known_objs_ra_dec = self.to_skycoords()
+        trj_list = result_data.make_trajectory_list()
 
-def apply_known_obj_filters(result_data, known_objs, obstimes, wcs, filter_params, remove_match_obs=True):
-    """This function takes a list of results and matches them to known objects.
+        new_obs_valid = result_data["obs_valid"]
+        for result_idx in range(len(result_data)):
+            valid_obstimes = self.obstimes[result_data[result_idx]["obs_valid"]]
+            trj_skycoords = trajectory_predict_skypos(trj_list[result_idx], wcs, valid_obstimes)
+            # Becauase we're only using the valid obstimes, we can user this below to map back to
+            # the original observation index.
+            trj_idx_to_obs_idx = np.where(result_data[result_idx]["obs_valid"])[0]
 
-    Parameters
-    ----------
-    result_data: `Results`
-        The set of results to filter. This data gets modified directly by
-        the filtering.
-    known_objs: `KnownObjs`
-        The known objects to filter against.
-    obstimes: list(float)
-        The mjd times of each possible observation.
-    wcs: `astropy.wcs.WCS`
-        The common WCS object for the stack of images.
-    filter_params : dict
-        Contains values concerning the image and search settings including:
-        filter_type, filter_params, and filter_obs.
-    remove_match_obs : bool
-        If True, remove observations that match to known objects from the results
+            # Now we can compare the SkyCoords of the known objects to the SkyCoords of the trajectories using search_around_sky
+            # This will return a list of indices of known objects that are within sep_thresh of a trajectory
+            trjs_idx, known_objs_idx, _, _ = search_around_sky(trj_skycoords, known_objs_ra_dec, sep_thresh)
 
-    Returns
-    -------
-    list(dict)
-        A list where each element is a dictionary of matching known objects for the
-        corresponding result in ``result_data``. The dictionary maps the name of the
-        known object to a boolean array of length equal to the number of valid observations
-        in the result. Each element of the array is True if that known object matched to
-        the corresponding observation, and False otherwise.
+            # Now we can count per-known object how many observations matched within this result
+            matched_known_objs = {}
+            for t_idx, ko_idx in zip(trjs_idx, known_objs_idx):
+                # Check the time separation is witihin our threshold
+                if abs(self.get_mjd(ko_idx) - valid_obstimes[t_idx]) * 3600 <= self.time_sep_thresh_s:
+                    # The name of the object that matched to this observation
+                    obj_name = self.get_name(ko_idx)
+                    # Create an array of dimension trj_skycoords where each value is false
+                    if obj_name not in matched_known_objs:
+                        # Note that we need to use the length of all obstimes, not just the presently valid ones
+                        matched_known_objs[obj_name] = np.full(len(self.obstimes), False)
+                    # Map to the original of all obstimes (valid or invalid) since that's what we
+                    # want for results filtering.
+                    obs_idx = trj_idx_to_obs_idx[t_idx]
+                    if obs_idx >= len(matched_known_objs[obj_name]):
+                        raise ValueError(
+                            f"obs_idx: {obs_idx}, \n t_idx: {t_idx}, \n trj_idx_to_obs_idx: {trj_idx_to_obs_idx}, \nvalid_obstimes: {valid_obstimes}\n,trjs_idx: {trjs_idx},\n known_objs_idx: {known_objs_idx}"
+                        )
 
-    Raises
-    ------
-        Raises a ValueError if the parameters are not valid.
-        Raises a TypeError if ``result_data`` is of an unsupported type.
-    """
-    if "filter_type" not in filter_params:
-        raise ValueError("Missing filter_type parameter")
-    filter_type = filter_params["filter_type"]
+                    matched_known_objs[obj_name][obs_idx] = True
+            all_matches.append(matched_known_objs)
+            # Only consider observations valid if they did not match to any known objects
+            new_obs_valid[result_idx] &= ~np.any(np.array(list(matched_known_objs.values())), axis=0)
 
-    all_matches = []
-    # Skip filtering if there is nothing to filter.
-    if len(result_data) == 0 or len(obstimes) == 0:
-        logger.info(f"{filter_type} : skipping, no results.")
-        return all_matches
+        # Add matches as a result column
+        result_data.table[self.filter_params["filter_type"]] = all_matches
 
-    # Skip matching known objects if there are none
-    if len(known_objs) == 0:
-        logger.info("Known Object Filtering : skipping, no objects to match agains.")
-        return all_matches
+        return result_data
 
-    known_obj_thresh = filter_params["known_obj_thresh"]
+    def apply_known_obj_valid_obs_filter(
+        self,
+        result_data,
+        wcs,
+        update_obs_valid=True,
+    ):
+        # Skip filtering if there is nothing to filter.
+        if len(result_data) == 0 or len(self.obstimes) == 0:
+            logger.info(f'{self.filter_params["filter_type"]} : skipping, no results.')
+            return []
 
-    sep_thresh = filter_params["known_obj_sep_thresh"] if "known_obj_sep_thresh" in filter_params else 1.0
-    sep_thresh = sep_thresh * u.arcsec
+        # Skip matching known objects if there are none
+        if len(self.data) == 0:
+            logger.info("Known Object Filtering : skipping, no objects to match agains.")
+            return []
+        result_data = self.match_known_obj_filters(result_data, wcs)
 
-    time_sep_thresh_s = (
-        filter_params["known_obj_sep_time_thresh_s"]
-        if "known_obj_sep_time_thresh_s" in filter_params
-        else 1200.0
-    )
+        matched_known_objs = result_data.table[self.filter_params["filter_type"]]
+        if update_obs_valid:
+            new_obs_valid = result_data["obs_valid"]
+            for result_idx in range(len(result_data)):
+                # A result can match to multiple objects, so we want to AND our valid
+                # obsesrvations against against all known objects that matched.
+                new_obs_valid[result_idx] &= ~np.any(
+                    np.array(list(matched_known_objs[result_idx].values())), axis=0
+                )
+            result_data.update_obs_valid(new_obs_valid)
 
-    # First filter down our cached data to a range of possible obstimes to speed up the search
-    start_mjd = max(0, min(obstimes) - 2 - time_sep_thresh_s)
-    end_mjd = max(obstimes) + 2 + time_sep_thresh_s
-    known_objs = known_objs.filter_rows_by_time(start_mjd, end_mjd)
-    known_objs_ra_dec = known_objs.to_skycoords()
+        return matched_known_objs
 
-    trj_list = result_data.make_trajectory_list()
-    new_obs_valid = result_data["obs_valid"]
-    for result_idx in range(len(result_data)):
-        valid_obstimes = obstimes[result_data[result_idx]["obs_valid"]]
-        trj_skycoords = trajectory_predict_skypos(trj_list[result_idx], wcs, valid_obstimes)
-        # Becauase we're only using the valid obstimes, we can user this below to map back to
-        # the original observation index.
-        trj_idx_to_obs_idx = np.where(result_data[result_idx]["obs_valid"])[0]
+    def apply_known_obj_match_min_obs(
+        self,
+        result_data,
+    ):
+        matched_objs = []
+        for idx in range(len(result_data)):
+            matched_objs.append(set([]))
+            matches = result_data[self.filter_params["filter_type"]][idx]
+            for name in matches:
+                if np.count_nonzero(matches[name]) >= self.filter_params["known_obj_match_min_obs"]:
+                    matched_objs[-1].add(name)
+        result_data.table[self.match_min_obs_col] = matched_objs
+        return result_data
 
-        # Now we can compare the SkyCoords of the known objects to the SkyCoords of the trajectories using search_around_sky
-        # This will return a list of indices of known objects that are within sep_thresh of a trajectory
-        trjs_idx, known_objs_idx, _, _ = search_around_sky(trj_skycoords, known_objs_ra_dec, sep_thresh)
+    def apply_known_obj_match_obs_ratio(
+        self,
+        result_data,
+    ):
+        known_obj_cnts = self.get_counts()
 
-        # Now we can count per-known object how many observations matched within this result
-        matched_known_objs = {}
-        for t_idx, ko_idx in zip(trjs_idx, known_objs_idx):
-            # Check the time separation is witihin our threshold
-            if abs(known_objs.get_mjd(ko_idx) - valid_obstimes[t_idx]) * 3600 <= time_sep_thresh_s:
-                # The name of the object that matched to this observation
-                obj_name = known_objs.get_name(ko_idx)
-                # Create an array of dimension trj_skycoords where each value is false
-                if obj_name not in matched_known_objs:
-                    # Note that we need to use the length of all obstimes, not just the presently valid ones
-                    matched_known_objs[obj_name] = np.full(len(obstimes), False)
-                # Map to the original of all obstimes (valid or invalid) since that's what we
-                # want for results filtering.
-                obs_idx = trj_idx_to_obs_idx[t_idx]
-                if obs_idx >= len(matched_known_objs[obj_name]):
-                    raise ValueError(
-                        f"obs_idx: {obs_idx}, \n t_idx: {t_idx}, \n trj_idx_to_obs_idx: {trj_idx_to_obs_idx}, \nvalid_obstimes: {valid_obstimes}\n,trjs_idx: {trjs_idx},\n known_objs_idx: {known_objs_idx}"
-                    )
+        matched_objs = []
+        for idx in range(len(result_data)):
+            matched_objs.append(set([]))
+            matches = result_data[self.filter_params["filter_type"]][idx]
+            for name in matches:
+                if name not in known_obj_cnts:
+                    raise ValueError(f"Unknown known object {name}")
 
-                matched_known_objs[obj_name][obs_idx] = True
-        all_matches.append(matched_known_objs)
-        # Only consider observations valid if they did not match to any known objects
-        new_obs_valid[result_idx] &= ~np.any(np.array(list(matched_known_objs.values())), axis=0)
+                obs_ratio = np.count_nonzero(matches[name]) / known_obj_cnts[name]
+                if obs_ratio <= self.filter_params["known_obj_match_obs_ratio"]:
+                    matched_objs[-1].add(name)
 
-    # Add matches as a result column
-    result_data.table[filter_params["filter_type"]] = all_matches
+        result_data.table[self.match_obs_ratio_col] = matched_objs
+        return result_data
 
-    if remove_match_obs:
-        result_data.update_obs_valid(new_obs_valid)
+    def filter_known_obj(
+        self,
+        result_data,
+        match_col,
+        filter_label,
+    ):
+        # Only keep results that did not match to any known objects in our specified column
+        idx_to_keep = np.array([len(x) == 0 for x in result_data[match_col]])
+        return result_data.filter_rows(idx_to_keep, filter_label)
 
-    return all_matches
+    def get_recovered_objects(self, result_data, expected_objects, match_obj_col):
+        """ """
+        matched_objects = set(result_data[match_obj_col])
+        recovered_objects = matched_objects.intersection(expected_objects)
+        missing_objects = expected_objects - recovered_objects
+
+        return recovered_objects, missing_objects

--- a/src/kbmod/filters/known_object_filters.py
+++ b/src/kbmod/filters/known_object_filters.py
@@ -213,7 +213,7 @@ class KnownObjsMatcher:
             matched_known_objs = {}
             for t_idx, ko_idx in zip(trjs_idx, known_objs_idx):
                 # The observation spatially matched but now check that the time separation is witihin our threshold
-                if abs(self.get_mjd(ko_idx) - valid_obstimes[t_idx]) * 3600 <= self.time_thresh_s:
+                if abs(self.get_mjd(ko_idx) - valid_obstimes[t_idx]) * 24 * 3600 <= self.time_thresh_s:
                     # The name of the object that matched to this observation
                     obj_name = self.get_name(ko_idx)
                     if obj_name not in matched_known_objs:

--- a/src/kbmod/filters/known_object_filters.py
+++ b/src/kbmod/filters/known_object_filters.py
@@ -34,7 +34,6 @@ class KnownObjsMatcher:
         matcher_name,
         sep_thresh=1.0,
         time_thresh_s=600.0,
-        match_obs_ratio=0.5,
         mjd_col="mjd_mid",
         ra_col="RA",
         dec_col="DEC",
@@ -98,7 +97,6 @@ class KnownObjsMatcher:
         self.matcher_name = matcher_name
         self.sep_thresh = sep_thresh * u.arcsec
         self.time_thresh_s = time_thresh_s
-        self.match_obs_ratio = match_obs_ratio
 
         # Pre-filter down our data to window of temporally relevant observations to speed up matching.
         time_thresh_days = self.time_thresh_s / (24 * 3600)  # Convert seconds to days

--- a/src/kbmod/filters/known_object_filters.py
+++ b/src/kbmod/filters/known_object_filters.py
@@ -4,20 +4,29 @@ from astropy.coordinates import SkyCoord, search_around_sky
 
 import kbmod.search as kb
 from kbmod.trajectory_utils import trajectory_predict_skypos
+from collections import Counter
 
 logger = kb.Logging.getLogger(__name__)
 
 
 class KnownObjsMatcher:
     """
-    A class which ingests an astopy table of KnownObj data for easy maniuplation.
+    A class which ingests an astopy table of object data expected in the dataset
+    (either real objects or inserted synthetic fakes) and provides methods for
+    for matching to the observations in KBMOD Results. It is intended to
+    both provide spatial and temporal matching and supports filtering individual
+    observations and entire result trajectories based on this matching.
     """
 
     def __init__(
         self,
         table,
         obstimes,
-        filter_params,
+        matcher_name,
+        sep_thresh=1.0,
+        time_thresh_s=600.0,
+        match_min_obs=5,
+        match_obs_ratio=0.5,
         mjd_col="mjd_mid",
         ra_col="RA",
         dec_col="DEC",
@@ -27,15 +36,34 @@ class KnownObjsMatcher:
         Parameters
         ----------
         table : astropy.table.Table
-            The table containing the known objects.
-        mjd_col : str
-            The name of the column containing the MJD of the known objects.
-        ra_col : str
-            The name of the column containing the RA of the known objects.
-        dec_col : str
-            The name of the column containing the DEC of the known objects.
-        name_col : str
-            The name of the column containing the name of the known objects.
+            A table containing our catalog of observations of known objects.
+        obstimes : list(float)
+            The MJD times of each observation within KBMOD results we want to match to
+            the known objects.
+        matcher_name : str
+            The name of the filter to apply to the results. This both determines
+            the name of any columns applied to the results table and how the filtering
+            and matching phases are identified within KBMOD logs.
+        sep_thresh : float, optional
+            The maximum separation in arcseconds between a known object and a result
+            to be considered a match. Default is 1.0.
+        time_thresh_s : float, optional
+            The maximum time separation in seconds between a known object and the observation
+            used in a KBMOD result. Default is 600.0.
+        match_min_obs : int, optional
+            The minimum number of observations within a KBMOD result that must match to a known
+            object for that result to be considered a match. Default is 5.
+        match_obs_ratio : float, optional
+            The minimum ratio of observations within a KBMOD result that must match to the total
+            observations within our catalog of known objects for that result to be considered a match. Default is 0.5.
+        mjd_col : str, optional
+            The name of the catalog column containing the MJD of the known objects. Default is "mjd_mid".
+        ra_col : str, optional
+            The name of the catalog column containing the RA of the known objects. Default is "RA".
+        dec_col : str, optional
+            The name of the catalog column containing the DEC of the known objects. Default is "DEC".
+        name_col : str, optional
+            The name of the catalog column containing the name of the known objects. Default is "Name".
 
         Raises
         ------
@@ -62,24 +90,27 @@ class KnownObjsMatcher:
             raise ValueError(f"{invalid_cols} not found in KnownObjs data.")
 
         self.obstimes = obstimes
-        self.filter_params = filter_params
         if len(self.obstimes) == 0:
             raise ValueError("No obstimes provided")
-        if not self.filter_params:
-            raise ValueError("No filter_params provided")
 
-        self.time_sep_thresh_s = (
-            self.filter_params["known_obj_sep_time_thresh_s"]
-            if "known_obj_sep_time_thresh_s" in self.filter_params
-            else 1200.0
-        )
+        self.matcher_name = matcher_name
+        self.sep_thresh = sep_thresh * u.arcsec
+        self.time_thresh_s = time_thresh_s
+        self.match_min_obs = match_min_obs
+        self.match_obs_ratio = match_obs_ratio
+
         self.filter_rows_by_time()
 
-        # Column names for recovered objects using either filtering method.
-        self.match_min_obs_col = "recovered_" + self.filter_params["filter_type"] + "_min_obs"
-        self.match_obs_ratio_col = "recovered_" + self.filter_params["filter_type"] + "_obs_ratio"
+    def match_min_obs_col(self):
+        """A colummn name for objects that matched results based on the minimum number of observations."""
+        return "recovered_" + self.matcher_name + "_min_obs"
+
+    def match_obs_ratio_col(self):
+        """A column name for objects that matched results based on the proportion of observations that matched to the known observations for that object within the catalog"""
+        return "recovered_" + self.matcher_name + "_obs_ratio"
 
     def __len__(self):
+        """Returns the number of observations known objects of interest in this matcher's catalog."""
         return len(self.data)
 
     def get_mjd(self, ko_idx):
@@ -128,24 +159,14 @@ class KnownObjsMatcher:
         KnownObjs
             A new KnownObjs object filtered down withing the given time range.
         """
-        start_mjd = max(0, min(self.obstimes) - 2 - self.time_sep_thresh_s)
-        end_mjd = max(self.obstimes) + 2 + self.time_sep_thresh_s
+        DAYS_OFFSET = 2
+        time_thresh_days = self.time_thresh_s / (24 * 3600)  # Convert seconds to days
+        start_mjd = max(0, min(self.obstimes) - DAYS_OFFSET - time_thresh_days)
+        end_mjd = max(self.obstimes) + DAYS_OFFSET + time_thresh_days
 
         self.data = self.data[(self.data[self.mjd_col] >= start_mjd) & (self.data[self.mjd_col] <= end_mjd)]
 
-    def get_counts(self):
-        """
-        Returns the number of known objects in the table.
-        """
-        cnts = {}
-        for i in range(len(self.data)):
-            if self.data[self.name_col][i] not in cnts:
-                cnts[self.data[self.name_col][i]] = 0
-            cnts[self.data[self.name_col][i]] += 1
-
-        return cnts
-
-    def match_known_obj_filters(self, result_data, wcs):
+    def match(self, result_data, wcs):
         """This function takes a list of results and matches them to known objects.
 
         Parameters
@@ -159,10 +180,7 @@ class KnownObjsMatcher:
             The mjd times of each possible observation.
         wcs: `astropy.wcs.WCS`
             The common WCS object for the stack of images.
-        filter_params : dict
-            Contains values concerning the image and search settings including:
-            filter_type, filter_params, and filter_obs.
-        remove_match_obs : bool
+        update_obs_valid : bool
             If True, remove observations that match to known objects from the results
 
         Returns
@@ -181,18 +199,10 @@ class KnownObjsMatcher:
         """
         all_matches = []
 
-        sep_thresh = (
-            self.filter_params["known_obj_sep_thresh"]
-            if "known_obj_sep_thresh" in self.filter_params
-            else 1.0
-        )
-        sep_thresh = sep_thresh * u.arcsec
-
         # Get the RA and DEC of the known objects and the trajectories of the results for matching
         known_objs_ra_dec = self.to_skycoords()
         trj_list = result_data.make_trajectory_list()
 
-        new_obs_valid = result_data["obs_valid"]
         for result_idx in range(len(result_data)):
             valid_obstimes = self.obstimes[result_data[result_idx]["obs_valid"]]
             trj_skycoords = trajectory_predict_skypos(trj_list[result_idx], wcs, valid_obstimes)
@@ -202,13 +212,16 @@ class KnownObjsMatcher:
 
             # Now we can compare the SkyCoords of the known objects to the SkyCoords of the trajectories using search_around_sky
             # This will return a list of indices of known objects that are within sep_thresh of a trajectory
-            trjs_idx, known_objs_idx, _, _ = search_around_sky(trj_skycoords, known_objs_ra_dec, sep_thresh)
+            # Note that subsequent calls by default will use the same underlying KD-Tree iin coords2.cache.
+            trjs_idx, known_objs_idx, _, _ = search_around_sky(
+                trj_skycoords, known_objs_ra_dec, self.sep_thresh
+            )
 
             # Now we can count per-known object how many observations matched within this result
             matched_known_objs = {}
             for t_idx, ko_idx in zip(trjs_idx, known_objs_idx):
                 # Check the time separation is witihin our threshold
-                if abs(self.get_mjd(ko_idx) - valid_obstimes[t_idx]) * 3600 <= self.time_sep_thresh_s:
+                if abs(self.get_mjd(ko_idx) - valid_obstimes[t_idx]) * 3600 <= self.time_thresh_s:
                     # The name of the object that matched to this observation
                     obj_name = self.get_name(ko_idx)
                     # Create an array of dimension trj_skycoords where each value is false
@@ -225,15 +238,13 @@ class KnownObjsMatcher:
 
                     matched_known_objs[obj_name][obs_idx] = True
             all_matches.append(matched_known_objs)
-            # Only consider observations valid if they did not match to any known objects
-            new_obs_valid[result_idx] &= ~np.any(np.array(list(matched_known_objs.values())), axis=0)
 
         # Add matches as a result column
-        result_data.table[self.filter_params["filter_type"]] = all_matches
+        result_data.table[self.matcher_name] = all_matches
 
         return result_data
 
-    def apply_known_obj_valid_obs_filter(
+    def mark_match_obs_invalid(
         self,
         result_data,
         wcs,
@@ -241,16 +252,16 @@ class KnownObjsMatcher:
     ):
         # Skip filtering if there is nothing to filter.
         if len(result_data) == 0 or len(self.obstimes) == 0:
-            logger.info(f'{self.filter_params["filter_type"]} : skipping, no results.')
+            logger.info(f"{self.matcher_name} : skipping, no results.")
             return []
 
         # Skip matching known objects if there are none
         if len(self.data) == 0:
             logger.info("Known Object Filtering : skipping, no objects to match agains.")
             return []
-        result_data = self.match_known_obj_filters(result_data, wcs)
+        result_data = self.match(result_data, wcs)
 
-        matched_known_objs = result_data.table[self.filter_params["filter_type"]]
+        matched_known_objs = result_data.table[self.matcher_name]
         if update_obs_valid:
             new_obs_valid = result_data["obs_valid"]
             for result_idx in range(len(result_data)):
@@ -263,55 +274,155 @@ class KnownObjsMatcher:
 
         return matched_known_objs
 
-    def apply_known_obj_match_min_obs(
+    def match_on_min_obs(
         self,
         result_data,
     ):
+        """
+        Create a column corresponding to the known objects that were matched to a result
+        based on the minimum number of observations that matched to that known object.
+
+        Note that a given result can match to multiple objects.
+
+        Parameters
+        ----------
+        result_data : `Results`
+            The results to filter.
+
+        Returns
+        -------
+        `Results`
+            The modified `Results` object returned for chaining.
+        """
         matched_objs = []
         for idx in range(len(result_data)):
             matched_objs.append(set([]))
-            matches = result_data[self.filter_params["filter_type"]][idx]
+            matches = result_data[self.matcher_name][idx]
             for name in matches:
-                if np.count_nonzero(matches[name]) >= self.filter_params["known_obj_match_min_obs"]:
+                if np.count_nonzero(matches[name]) >= self.match_min_obs:
                     matched_objs[-1].add(name)
-        result_data.table[self.match_min_obs_col] = matched_objs
+        result_data.table[self.match_min_obs_col()] = matched_objs
+
         return result_data
 
-    def apply_known_obj_match_obs_ratio(
+    def match_on_obs_ratio(
         self,
         result_data,
     ):
-        known_obj_cnts = self.get_counts()
+        """
+        Create a column corresponding to the known objects that were matched to a result
+        based on the proportion of observations that matched to that known object within the catalog.
 
+        Note that a given result can match to multiple objects.
+
+        Parameters
+        ----------
+        result_data : `Results`
+            The results to filter.
+
+        Returns
+        -------
+        `Results`
+            The modified `Results` object returned for chaining.
+        """
+        # Create a dictionary of how many observations we have for each known object
+        # in our catalog
+        known_obj_cnts = dict(Counter(self.data[self.name_col]))
         matched_objs = []
         for idx in range(len(result_data)):
             matched_objs.append(set([]))
-            matches = result_data[self.filter_params["filter_type"]][idx]
+            matches = result_data[self.matcher_name][idx]
             for name in matches:
                 if name not in known_obj_cnts:
                     raise ValueError(f"Unknown known object {name}")
 
                 obs_ratio = np.count_nonzero(matches[name]) / known_obj_cnts[name]
-                if obs_ratio <= self.filter_params["known_obj_match_obs_ratio"]:
+                if obs_ratio <= self.match_obs_ratio:
                     matched_objs[-1].add(name)
 
-        result_data.table[self.match_obs_ratio_col] = matched_objs
+        result_data.table[self.match_obs_ratio_col()] = matched_objs
+
         return result_data
 
-    def filter_known_obj(
-        self,
-        result_data,
-        match_col,
-        filter_label,
-    ):
-        # Only keep results that did not match to any known objects in our specified column
-        idx_to_keep = np.array([len(x) == 0 for x in result_data[match_col]])
-        return result_data.filter_rows(idx_to_keep, filter_label)
+    def get_recovered_objects(self, result_data, match_col):
+        """
+        Get the set of objects that were recovered or missed in the results.
 
-    def get_recovered_objects(self, result_data, expected_objects, match_obj_col):
-        """ """
-        matched_objects = set(result_data[match_obj_col])
+        For our purposes, a recovered object is one that was matched to a result based on the
+        matching column of choice in the results table and a missing object are objects in
+        the catalog that were not matched. Note that not all catalogs may be
+        constructed in a way where all objects could be spatially present and
+        recoverable in the results.
+
+        Parameters
+        ----------
+        result_data : `Results`
+            The results to filter.
+        match_col : str
+            The name of the column in the results table that contains the matched objects.
+
+        Returns
+        -------
+        set, set
+            A tuple of sets where the first set contains the names of objects that were recovered
+            and the second set contains the names objects that were missed
+
+        Raises
+        ------
+        ValueError
+            If the `match_col` is not present in the results table
+        """
+        if match_col not in result_data.table.colnames:
+            raise ValueError(f"Column {match_col} not found in results table.")
+
+        if len(result_data) == 0:
+            logger.info(f"{self.matcher_name} : skipping, no results.")
+            return set(), set()
+
+        if len(self.data) == 0:
+            logger.info(f"{self.matcher_name} : skipping, no objects to match against.")
+            return set(), set()
+
+        expected_objects = set(self.data[self.name_col])
+        matched_objects = set()
+        for idx in range(len(result_data)):
+            matched_objects.update(result_data[match_col][idx])
         recovered_objects = matched_objects.intersection(expected_objects)
-        missing_objects = expected_objects - recovered_objects
+        missed_objects = expected_objects - recovered_objects
 
-        return recovered_objects, missing_objects
+        return recovered_objects, missed_objects
+
+    def filter_matches(self, result_data, match_col):
+        """
+        Filter out the results table to only include results that did not match to any known objects.
+
+        Parameters
+        ----------
+        result_data : `Results`
+            The results to filter.
+        match_col : str
+            The name of the column in the results table that contains the matched objects.
+
+        Returns
+        -------
+        `Results`
+            The modified `Results` object returned for chaining.
+
+        Raises
+        ------
+        ValueError
+            If the `match_col` is not present in the results table.
+        """
+        if match_col not in result_data.table.colnames:
+            raise ValueError(f"Column {match_col} not found in results table.")
+
+        if len(result_data) == 0:
+            logger.info(f"{self.matcher_name} : skipping, no results.")
+            return result_data
+
+        # Only keep results that did not match to any known objects in our column
+        idx_to_keep = np.array([len(x) == 0 for x in result_data[match_col]])
+        # Use the name of our matching column as the filter name
+        result_data = result_data.filter_rows(idx_to_keep, match_col)
+
+        return result_data

--- a/src/kbmod/filters/known_object_filters.py
+++ b/src/kbmod/filters/known_object_filters.py
@@ -121,7 +121,8 @@ class KnownObjsMatcher:
         return "recovered_" + self.matcher_name + "_min_obs"
 
     def match_obs_ratio_col(self):
-        """A column name for objects that matched results based on the proportion of observations that matched to the known observations for that object within the catalog"""
+        # A column name for objects that matched results based on the proportion of observations that
+        # matched to the known observations for that object within the catalog.
         return "recovered_" + self.matcher_name + "_obs_ratio"
 
     def __len__(self):
@@ -232,7 +233,7 @@ class KnownObjsMatcher:
 
         return result_data
 
-    def mark_match_obs_invalid(
+    def mark_matched_obs_invalid(
         self,
         result_data,
         drop_empty_rows=True,
@@ -259,7 +260,7 @@ class KnownObjsMatcher:
         """
         # Skip filtering if there is nothing to filter.
         if len(result_data) == 0 or len(self.obstimes) == 0 or len(self.data) == 0:
-            return []
+            return result_data
 
         if self.matcher_name not in result_data.table.colnames:
             raise ValueError(
@@ -269,8 +270,10 @@ class KnownObjsMatcher:
         matched_known_objs = result_data.table[self.matcher_name]
         new_obs_valid = result_data["obs_valid"]
         for result_idx in range(len(result_data)):
-            # A result can match to multiple objects, so we want to AND our valid
-            # observations against all known objects that matched.
+            # A result can match to multiple objects, so we want to logically OR
+            # against all matching objects with a logical OR using np.any.
+            # We can then use bitwise NOT and AND to mark any previously valid
+            # observations that matched to known objects as invalid.
             new_obs_valid[result_idx] &= ~np.any(
                 np.array(list(matched_known_objs[result_idx].values())), axis=0
             )

--- a/src/kbmod/filters/known_object_filters.py
+++ b/src/kbmod/filters/known_object_filters.py
@@ -1,0 +1,219 @@
+import numpy as np
+
+from kbmod.results import Results
+import kbmod.search as kb
+
+from astropy.table import Table
+from astropy.coordinates import search_around_sky, SkyCoord
+# import astropy units
+import astropy.units as u
+
+from kbmod.trajectory_utils import trajectory_predict_skypos
+
+
+logger = kb.Logging.getLogger(__name__)
+
+
+class KnownObjs:
+    """
+    A class which ingests an astopy table of KnownObj data for easy maniuplation.
+    """
+
+    def __init__(self, table, mjd_col="mjd_mid", ra_col="RA", dec_col="DEC", name_col="Name"):
+        """
+        Parameters
+        ----------
+        table : astropy.table.Table
+            The table containing the known objects.
+        mjd_col : str
+            The name of the column containing the MJD of the known objects.
+        ra_col : str
+            The name of the column containing the RA of the known objects.
+        dec_col : str
+            The name of the column containing the DEC of the known objects.
+        name_col : str
+            The name of the column containing the name of the known objects.
+
+        Raises
+        ------
+        ValueError
+            If the required columns are not present in the table.
+        
+        Returns
+        -------
+        KnownObjs
+            A KnownObjs object.
+        """
+        self.data = table
+
+        self.mjd_col = mjd_col
+        self.ra_col = ra_col
+        self.dec_col = dec_col
+        self.name_col = name_col
+
+        # Check that the required columns are present
+        user_cols = set([self.mjd_col, self.ra_col, self.dec_col, self.name_col])
+        invalid_cols = user_cols - set(self.data.colnames)
+        if invalid_cols:
+            raise ValueError(f"{invalid_cols} not found in KnownObjs data.")
+
+    def __len__(self):
+        return len(self.data)
+
+    def get_mjd(self, ko_idx):
+        """
+        Returns the MJD of the known object at a given index.
+        """
+        return self.data[ko_idx][self.mjd_col]
+    
+    def get_ra(self, ko_idx):
+        """
+        Returns the RA of the known object at a given index.
+        """
+        return self.data[ko_idx][self.ra_col]
+    
+    def get_dec(self, ko_idx):
+        """
+        Returns the DEC of the known object at a given index.
+        """
+        return self.data[ko_idx][self.dec_col]
+    
+    def get_name(self, ko_idx):
+        """
+        Returns the name of the known object at a given index.
+        """
+        return self.data[ko_idx][self.name_col]
+    
+    def to_skycoords(self):
+        """
+        Returns a SkyCoord representation of the known objects.
+        """
+        return SkyCoord(ra=self.data[self.ra_col], dec=self.data[self.dec_col], unit="deg")
+
+    def filter_rows_by_time(self, start_mjd, end_mjd):
+        """
+        Returns a new KnownObjs filtered down to within a given time range.
+
+        Parameters
+        ----------
+        start_mjd : float
+            The start of the time range.
+        end_mjd : float
+            The end of the time range.
+
+        Returns
+        -------
+        KnownObjs
+            A new KnownObjs object filtered down withing the given time range.
+        """
+        new_data = self.data[(self.data[self.mjd_col] >= start_mjd) & (self.data[self.mjd_col] <= end_mjd)]
+        return KnownObjs(new_data,
+                         mjd_col=self.mjd_col,
+                         ra_col=self.ra_col,
+                         dec_col=self.dec_col,
+                         name_col=self.name_col)
+
+def apply_known_obj_filters(result_data, known_objs, obstimes, wcs, filter_params, remove_match_obs=True):
+    """This function takes a list of results and matches them to known objects.
+
+    Parameters
+    ----------
+    result_data: `Results`
+        The set of results to filter. This data gets modified directly by
+        the filtering.
+    known_objs: `KnownObjs`
+        The known objects to filter against.
+    obstimes: list(float)
+        The mjd times of each possible observation.
+    wcs: `astropy.wcs.WCS`
+        The common WCS object for the stack of images.
+    filter_params : dict
+        Contains values concerning the image and search settings including:
+        filter_type, filter_params, and filter_obs.
+    remove_match_obs : bool
+        If True, remove observations that match to known objects from the results
+    
+    Returns
+    -------
+    list(dict)
+        A list where each element is a dictionary of matching known objects for the
+        corresponding result in ``result_data``. The dictionary maps the name of the
+        known object to a boolean array of length equal to the number of valid observations
+        in the result. Each element of the array is True if that known object matched to
+        the corresponding observation, and False otherwise.
+
+    Raises
+    ------
+        Raises a ValueError if the parameters are not valid.
+        Raises a TypeError if ``result_data`` is of an unsupported type.
+    """
+    if "filter_type" not in filter_params:
+        raise ValueError("Missing filter_type parameter")
+    filter_type = filter_params["filter_type"]
+
+    all_matches = []
+    # Skip filtering if there is nothing to filter.
+    if len(result_data) == 0 or len(obstimes) == 0:
+        logger.info(f"{filter_type} : skipping, no results.")
+        return all_matches
+    
+    # Skip matching known objects if there are none
+    if len(known_objs) == 0:
+        logger.info("Known Object Filtering : skipping, no objects to match agains.")
+        return all_matches
+
+    known_obj_thresh = filter_params['known_obj_thresh']
+
+    sep_thresh = filter_params['known_obj_sep_thresh'] if 'known_obj_sep_thresh' in filter_params else 1.0
+    sep_thresh = sep_thresh * u.arcsec
+
+    time_sep_thresh_s = filter_params['known_obj_sep_time_thresh_s'] if "known_obj_sep_time_thresh_s" in filter_params else 1200.0
+
+    # First filter down our cached data to a range of possible obstimes to speed up the search
+    start_mjd = max(0, min(obstimes) - 2 - time_sep_thresh_s)
+    end_mjd = max(obstimes) + 2 + time_sep_thresh_s
+    known_objs = known_objs.filter_rows_by_time(start_mjd, end_mjd)
+    known_objs_ra_dec = known_objs.to_skycoords()
+
+    trj_list = result_data.make_trajectory_list()
+    new_obs_valid = result_data["obs_valid"]
+    for result_idx in range(len(result_data)):
+        valid_obstimes = obstimes[result_data[result_idx]["obs_valid"]]
+        trj_skycoords = trajectory_predict_skypos(trj_list[result_idx], wcs, valid_obstimes)
+        # Becauase we're only using the valid obstimes, we can user this below to map back to
+        # the original observation index.
+        trj_idx_to_obs_idx = np.where(result_data[result_idx]["obs_valid"])[0]
+        
+        # Now we can compare the SkyCoords of the known objects to the SkyCoords of the trajectories using search_around_sky
+        # This will return a list of indices of known objects that are within sep_thresh of a trajectory
+        trjs_idx, known_objs_idx, _, _ = search_around_sky(trj_skycoords, known_objs_ra_dec, sep_thresh)
+
+        # Now we can count per-known object how many observations matched within this result
+        matched_known_objs = {}
+        for t_idx, ko_idx in zip(trjs_idx, known_objs_idx):
+            # Check the time separation is witihin our threshold
+            if abs(known_objs.get_mjd(ko_idx) - valid_obstimes[t_idx])*3600 <= time_sep_thresh_s:
+                # The name of the object that matched to this observation
+                obj_name = known_objs.get_name(ko_idx)
+                # Create an array of dimension trj_skycoords where each value is false
+                if obj_name not in matched_known_objs:
+                    # Note that we need to use the length of all obstimes, not just the presently valid ones
+                    matched_known_objs[obj_name] = np.full(len(obstimes), False)
+                # Map to the original of all obstimes (valid or invalid) since that's what we
+                # want for results filtering.
+                obs_idx = trj_idx_to_obs_idx[t_idx]
+                if obs_idx >= len(matched_known_objs[obj_name]):
+                    raise ValueError(f"obs_idx: {obs_idx}, \n t_idx: {t_idx}, \n trj_idx_to_obs_idx: {trj_idx_to_obs_idx}, \nvalid_obstimes: {valid_obstimes}\n,trjs_idx: {trjs_idx},\n known_objs_idx: {known_objs_idx}")
+
+                matched_known_objs[obj_name][obs_idx] = True
+        all_matches.append(matched_known_objs)
+        # Only consider observations valid if they did not match to any known objects
+        new_obs_valid[result_idx] &= ~np.any(np.array(list(matched_known_objs.values())), axis=0)
+
+    # Add matches as a result column
+    result_data.table[filter_params["filter_type"]] = all_matches
+    
+    if remove_match_obs:
+        result_data.update_obs_valid(new_obs_valid)
+    
+    return all_matches

--- a/tests/test_known_object_filters.py
+++ b/tests/test_known_object_filters.py
@@ -235,20 +235,28 @@ class TestKnownObjFilters(unittest.TestCase):
             self.match_obs_ratio,
             self.match_min_obs,
         )
-        matches = empty_objs.mark_match_obs_invalid(
+        self.res = empty_objs.match(
             self.res,
             wcs=self.wcs,
         )
+        matches = self.res[empty_objs.matcher_name]
         self.assertEqual(0, sum([len(m.keys()) for m in matches]))
-        self.assertEqual(10, len(self.res))
+
+        # Test that we can apply the filter even when there are knwon results
+        self.res = empty_objs.mark_match_obs_invalid(self.res, drop_empty_rows=True)
+        self.assertEqual(0, len(self.res))
 
         # Test that the filter is not applied when there were no results.
-        matches = empty_objs.mark_match_obs_invalid(
-            Results(),
+        empty_res = Results()
+        empty_res = empty_objs.match(
+            empty_res,
             wcs=self.wcs,
         )
+        matches = empty_res[empty_objs.matcher_name]
         self.assertEqual(0, sum([len(m.keys()) for m in matches]))
-        self.assertEqual(10, len(self.res))
+
+        empty_res = empty_objs.mark_match_obs_invalid(empty_res, drop_empty_rows=True)
+        self.assertEqual(0, len(empty_res))
 
     def test_apply_known_obj_filtering(self):
         expected_matches = set(["spatial_close_time_close_1", "sparse_8"])
@@ -264,17 +272,18 @@ class TestKnownObjFilters(unittest.TestCase):
         )
 
         # Call our filter for generating matches
-        matches = matcher.mark_match_obs_invalid(
+        self.res = matcher.match(
             self.res,
             wcs=self.wcs,
         )
-
+        matches = self.res[self.matcher_name]
         # Assert the expected result
         obs_matches = set()
         for m in matches:
             obs_matches.update(m.keys())
         self.assertEqual(expected_matches, obs_matches)
 
+        self.res = matcher.mark_match_obs_invalid(self.res, drop_empty_rows=True)
         self.assertEqual(9, len(self.res))
 
         # Check that the close known object we inserted near result 1 is present
@@ -303,11 +312,14 @@ class TestKnownObjFilters(unittest.TestCase):
             self.match_min_obs,
         )
 
-        matches = matcher.mark_match_obs_invalid(
+        self.res = matcher.match(
             self.res,
             wcs=self.wcs,
         )
+        matches = self.res[matcher.matcher_name]
         self.assertEqual(0, sum([len(m.keys()) for m in matches]))
+
+        self.res = matcher.mark_match_obs_invalid(self.res, drop_empty_rows=True)
         self.assertEqual(10, len(self.res))
 
     def test_apply_known_obj_spatial_filtering(self):
@@ -324,16 +336,18 @@ class TestKnownObjFilters(unittest.TestCase):
             self.match_min_obs,
         )
 
-        matches = matcher.mark_match_obs_invalid(
+        self.res = matcher.match(
             self.res,
             wcs=self.wcs,
         )
+        matches = self.res[matcher.matcher_name]
 
         obs_matches = set()
         for m in matches:
             obs_matches.update(m.keys())
         self.assertEqual(expected_matches, obs_matches)
 
+        self.res = matcher.mark_match_obs_invalid(self.res, drop_empty_rows=True)
         self.assertEqual(8, len(self.res))
 
         # Check that the close known object we inserted near result 1 is present
@@ -385,15 +399,18 @@ class TestKnownObjFilters(unittest.TestCase):
             self.match_min_obs,
         )
 
-        matches = matcher.mark_match_obs_invalid(
+        self.res = matcher.match(
             self.res,
             wcs=self.wcs,
         )
+        matches = self.res[matcher.matcher_name]
 
         obs_matches = set()
         for m in matches:
             obs_matches.update(m.keys())
         self.assertEqual(expected_matches, obs_matches)
+
+        self.res = matcher.mark_match_obs_invalid(self.res, drop_empty_rows=True)
         self.assertEqual(0, len(self.res))
 
         # Check that every result matches to  of our known objects
@@ -435,16 +452,18 @@ class TestKnownObjFilters(unittest.TestCase):
             self.match_min_obs,
         )
 
-        matches = matcher.mark_match_obs_invalid(
+        self.res = matcher.match(
             self.res,
             wcs=self.wcs,
         )
+        matches = self.res[matcher.matcher_name]
         obs_matches = set()
         for m in matches:
             obs_matches.update(m.keys())
         self.assertEqual(expected_matches, obs_matches)
 
         # Each result should have matched to every object
+        self.res = matcher.mark_match_obs_invalid(self.res, drop_empty_rows=True)
         self.assertEqual(0, len(self.res))
 
         # Check that every result matches to all of expected known objects
@@ -478,13 +497,14 @@ class TestKnownObjFilters(unittest.TestCase):
                 match_obs_ratio=obs_ratio,
             )
 
-            matcher.mark_match_obs_invalid(
+            self.res = matcher.match(
                 self.res,
                 wcs=self.wcs,
-                update_obs_valid=False,
             )
+
             # Validate that we did not filter any results
             assert self.matcher_name in self.res.table.columns
+            self.res = matcher.mark_match_obs_invalid(self.res, drop_empty_rows=False)
             self.assertEqual(10, len(self.res))
 
             # Generate the recovered ratio column
@@ -526,13 +546,13 @@ class TestKnownObjFilters(unittest.TestCase):
                 match_min_obs=min_obs,
             )
 
-            matcher.mark_match_obs_invalid(
+            matcher.match(
                 self.res,
                 wcs=self.wcs,
-                update_obs_valid=False,
             )
             # Validate that we did not filter any results
             assert self.matcher_name in self.res.table.columns
+            self.res = matcher.mark_match_obs_invalid(self.res, drop_empty_rows=False)
             self.assertEqual(10, len(self.res))
 
             # Generate the recovered object column for a minimum number of observations

--- a/tests/test_known_object_filters.py
+++ b/tests/test_known_object_filters.py
@@ -59,12 +59,8 @@ class TestKnownObjFilters(unittest.TestCase):
         assert set(self.res.table.columns) == set(['x','y','vx','vy','likelihood','flux','obs_count', 'obs_valid'])
 
         # Use the results' trajectories to generate a set of known objects that we can use to test the filter
-        # 1) a known object that is slightly different in time and space then in the trajcectory
-        # 2) a known object that is slightly different in time but not space
-        # 3) a known object that is slightly different in space but not time
-        # 4) a known object with a very different trajectory but interects both the start and endpoints
-        # Now we want to create a data set of known objects some
-        # of which will intersect or previous results, 
+        # Now we want to create a data set of known objects that interset our generated results in various
+	# ways.
         known_obj_table = Table({"Name": np.empty(0, dtype=str), "RA": [], "DEC": [], "mjd_mid": []})
 
         # Case 1: Near in space (<1") and near in time (>1 s) and near in time to result 1
@@ -94,7 +90,7 @@ class TestKnownObjFilters(unittest.TestCase):
             spatial_offset=5,
             time_offset=0.00025)
 
-        # Case 5: A similar trajectory to result 7, but far off spatially and temporally
+        # Case 4: A similar trajectory to result 7, but far off spatially and temporally
         self.generate_known_obj_from_result(
             known_obj_table,
             7, # Base off result 7
@@ -104,7 +100,7 @@ class TestKnownObjFilters(unittest.TestCase):
             time_offset=0.3)
 
 
-        # Check for a trajectory matching result 8 but with only a few observations.
+        # Case 5: a trajectory matching result 8 but with only a few observations.
         self.generate_known_obj_from_result(
             known_obj_table,
             8, # Base off result 8
@@ -112,34 +108,10 @@ class TestKnownObjFilters(unittest.TestCase):
             "sparse_8",
             spatial_offset=0.0001,
             time_offset=0.00025)
-        """
-        curr_trj_skycoords = trajectory_predict_skypos(
-            self.res.make_trajectory_list()[8],
-            self.wcs,
-            self.obstimes, # Note that we use all obstimes and not just the valid ones for this result.
-        )
-        for i in range(len(self.obstimes)):
-            known_obj_table.add_row({
-                "Name": "sparse_8",
-                "RA": curr_trj_skycoords[i].ra.degree,
-                "DEC": curr_trj_skycoords[i].dec.degree, 
-                "mjd_mid": self.obstimes[i],
-            })
-        """
-
-        # Check that intersect 1 and intersect 2 both match to result 7, but only to one observation
-        # each
-
-
-        # Check for an object that is an exact spatial match but omitted is outside the larger time
-        # window we apply during the filtering steps.
-        # Check for the max time step separation
-
-
-
+        
         self.known_objs = KnownObjs(known_obj_table)
-    def test_known_obj_init(self):
-        # Test a table with no columns specified raises a ValueError
+
+    def test_known_obj_init(self): # Test a table with no columns specified raises a ValueError
         with self.assertRaises(ValueError):
             KnownObjs(Table())
 
@@ -180,11 +152,7 @@ class TestKnownObjFilters(unittest.TestCase):
             spatial_offset=0.0001,
             time_offset=0.00025,
         ):
-        """ Helper function to generate a known object based on existing result trajectory 
-        Parameters
-        ----------
-
-        """
+        """ Helper function to generate a known object based on existing result trajectory """
         trj_skycoords = trajectory_predict_skypos(
             self.res.make_trajectory_list()[res_idx],
             self.wcs,
@@ -197,12 +165,6 @@ class TestKnownObjFilters(unittest.TestCase):
                 "DEC": trj_skycoords[i].dec.degree + spatial_offset, 
                 "mjd_mid": obstimes[i] + time_offset,
             })
-
-    def test_known_obj_filter_rows_by_time(self):
-        assert True
-
-    def test_known_obj_filter_wrapper(self):
-        assert True
 
     def test_apply_known_obj_empty(self):
         # Here we test that the filter across various empty parameters
@@ -368,7 +330,3 @@ class TestKnownObjFilters(unittest.TestCase):
                         np.count_nonzero(matches[i][obj_name])
                     )
 
-    def test_apply_known_obj_matching(self):
-        # Here we apply the filter successively without removing matching observations,
-        # then successively pare down observations more aggressively.
-        assert True

--- a/tests/test_known_object_filters.py
+++ b/tests/test_known_object_filters.py
@@ -1,0 +1,374 @@
+import unittest
+from unittest.mock import MagicMock
+import numpy as np
+from astropy.table import Table
+from astropy.time import Time
+from astropy.units import Quantity
+from astropy.wcs import WCS
+from astropy.coordinates import SkyCoord
+from kbmod.results import Results
+from kbmod.work_unit import WorkUnit
+from kbmod.filters.known_object_filters import apply_known_obj_filters, KnownObjs
+import unittest
+from unittest.mock import MagicMock
+
+import random
+
+from kbmod.results import Results
+from kbmod.search import Trajectory
+from kbmod.trajectory_utils import trajectory_predict_skypos
+
+from kbmod.fake_data.fake_data_creator import *
+from kbmod.search import *
+from kbmod.wcs_utils import make_fake_wcs, wcs_fits_equal
+
+class TestKnownObjFilters(unittest.TestCase):
+    def setUp(self):
+        self.seed = 500 # Seed for reproducibility
+        np.random.seed(self.seed)
+        random.seed(self.seed)
+
+        self.filter_params = {
+            "filter_type": "known_obj_matches",
+            "known_objs_filepath": "/path/to/known_objs.csv",
+            "known_obj_thresh": 0.5,
+            "known_obj_sep_thresh": 1.0,
+            "known_obj_sep_time_thresh_s": 600,
+        }
+
+        num_images = 25
+        self.obstimes = np.array(create_fake_times(num_images))
+        # Create a fake dataset with 15 x 10 images.
+        ds = FakeDataSet(15, 10, self.obstimes, use_seed=True)
+        self.wcs = make_fake_wcs(10.0, 15.0, 15, 10)
+        ds.set_wcs(self.wcs)
+
+        num_results = 10
+        # Randomly generate a Trajectory for each result, generating random x, y, vx, and vy
+        for i in range(num_results):
+            ds.insert_random_object(self.seed)
+        self.res = Results.from_trajectories(ds.trajectories)
+        self.assertEqual(len(ds.trajectories), num_results)
+
+        # Generate which observations are valid observations for each result
+        self.obs_valid = np.full((num_results, num_images), True)
+        for i in range(num_results):
+            invalid_obs = np.random.choice(num_images, 5, replace=False)
+            self.obs_valid[i][invalid_obs] = False
+        self.res.update_obs_valid(self.obs_valid)
+        assert set(self.res.table.columns) == set(['x','y','vx','vy','likelihood','flux','obs_count', 'obs_valid'])
+
+        # Use the results' trajectories to generate a set of known objects that we can use to test the filter
+        # 1) a known object that is slightly different in time and space then in the trajcectory
+        # 2) a known object that is slightly different in time but not space
+        # 3) a known object that is slightly different in space but not time
+        # 4) a known object with a very different trajectory but interects both the start and endpoints
+        # Now we want to create a data set of known objects some
+        # of which will intersect or previous results, 
+        known_obj_table = Table({"Name": np.empty(0, dtype=str), "RA": [], "DEC": [], "mjd_mid": []})
+
+        # Case 1: Near in space (<1") and near in time (>1 s) and near in time to result 1
+        self.generate_known_obj_from_result(
+            known_obj_table,
+            1, # Base off result 1
+            self.obstimes, # Use all possible obstimes 
+            "spatial_close_time_close_1",
+            spatial_offset=0.00001,
+            time_offset=0.00025)
+
+        # Case 2 near in space to result 3, but farther in time.
+        self.generate_known_obj_from_result(
+            known_obj_table,
+            3, # Base off result 3
+            self.obstimes, # Use all possible obstimes 
+            "spatial_close_time_far_3",
+            spatial_offset=0.0001,
+            time_offset=0.3)
+
+        # Case 3: A similar trajectory to result 5, but farther in space with similar timestamps.
+        self.generate_known_obj_from_result(
+            known_obj_table,
+            5, # Base off result 5
+            self.obstimes, # Use all possible obstimes
+            "spatial_far_time_close_5",
+            spatial_offset=5,
+            time_offset=0.00025)
+
+        # Case 5: A similar trajectory to result 7, but far off spatially and temporally
+        self.generate_known_obj_from_result(
+            known_obj_table,
+            7, # Base off result 7
+            self.obstimes, # Use all possible obstimes
+            "spatial_far_time_far_7",
+            spatial_offset=5,
+            time_offset=0.3)
+
+
+        # Check for a trajectory matching result 8 but with only a few observations.
+        self.generate_known_obj_from_result(
+            known_obj_table,
+            8, # Base off result 8
+            self.obstimes[::10], # Samples down to every 5th observation
+            "sparse_8",
+            spatial_offset=0.0001,
+            time_offset=0.00025)
+        """
+        curr_trj_skycoords = trajectory_predict_skypos(
+            self.res.make_trajectory_list()[8],
+            self.wcs,
+            self.obstimes, # Note that we use all obstimes and not just the valid ones for this result.
+        )
+        for i in range(len(self.obstimes)):
+            known_obj_table.add_row({
+                "Name": "sparse_8",
+                "RA": curr_trj_skycoords[i].ra.degree,
+                "DEC": curr_trj_skycoords[i].dec.degree, 
+                "mjd_mid": self.obstimes[i],
+            })
+        """
+
+        # Check that intersect 1 and intersect 2 both match to result 7, but only to one observation
+        # each
+
+
+        # Check for an object that is an exact spatial match but omitted is outside the larger time
+        # window we apply during the filtering steps.
+        # Check for the max time step separation
+
+
+
+        self.known_objs = KnownObjs(known_obj_table)
+    def test_known_obj_init(self):
+        # Test a table with no columns specified raises a ValueError
+        with self.assertRaises(ValueError):
+            KnownObjs(Table())
+
+        # Test a table with no Name column raises a ValueError
+        with self.assertRaises(ValueError):
+            KnownObjs(Table({"RA": [], "DEC": [], "mjd_mid": []}))
+
+        # Test a table with no RA column raises a ValueError
+        with self.assertRaises(ValueError):
+            KnownObjs(Table({"Name": [], "DEC": [], "mjd_mid": []}))
+        
+        # Test a table with no DEC column raises a ValueError
+        with self.assertRaises(ValueError):
+            KnownObjs(Table({"Name": [], "RA": [], "mjd_mid": []}))
+
+        # Test a table with no mjd_mid column raises a ValueError
+        with self.assertRaises(ValueError):
+            KnownObjs(Table({"Name": [], "RA": [], "DEC": []}))
+
+        # Test a table with all columns specified does not raise an error
+        self.assertEqual(0, len(KnownObjs(Table({"Name": [], "RA": [], "DEC": [], "mjd_mid": []}))))
+
+        # Test a table where we override the names for each column
+        self.assertEqual(0, len(KnownObjs(
+            Table({"my_Name": [], "my_RA": [], "my_DEC": [], "my_mjd_mid": []}),
+            mjd_col="my_mjd_mid",
+            ra_col="my_RA",
+            dec_col="my_DEC", 
+            name_col="my_Name",
+        )))
+
+    def generate_known_obj_from_result(
+            self,
+            known_obj_table,
+            res_idx,
+            obstimes,
+            name,
+            spatial_offset=0.0001,
+            time_offset=0.00025,
+        ):
+        """ Helper function to generate a known object based on existing result trajectory 
+        Parameters
+        ----------
+
+        """
+        trj_skycoords = trajectory_predict_skypos(
+            self.res.make_trajectory_list()[res_idx],
+            self.wcs,
+            obstimes, 
+        )
+        for i in range(len(obstimes)):
+            known_obj_table.add_row({
+                "Name": name,
+                "RA": trj_skycoords[i].ra.degree + spatial_offset,
+                "DEC": trj_skycoords[i].dec.degree + spatial_offset, 
+                "mjd_mid": obstimes[i] + time_offset,
+            })
+
+    def test_known_obj_filter_rows_by_time(self):
+        assert True
+
+    def test_known_obj_filter_wrapper(self):
+        assert True
+
+    def test_apply_known_obj_empty(self):
+        # Here we test that the filter across various empty parameters
+
+        # Test that the filter is not applied when no known objects were provided
+        empty_objs = KnownObjs(
+            Table({"Name": np.empty(0, dtype=str), "RA": [], "DEC": [], "mjd_mid": []}))
+        matches = apply_known_obj_filters(self.res, empty_objs, obstimes=self.obstimes, wcs=self.wcs, filter_params=self.filter_params)
+        self.assertEqual(0, sum([len(m.keys()) for m in matches]))
+        self.assertEqual(10, len(self.res))
+
+        # Test that the filter is not applied when there were no results.
+        matches = apply_known_obj_filters(Results(), self.known_objs, obstimes=self.obstimes, wcs=self.wcs, filter_params=self.filter_params)
+        self.assertEqual(0, sum([len(m.keys()) for m in matches]))
+        self.assertEqual(10, len(self.res))
+
+        # Test that the filter is not applied when there were no obstimes
+        matches = apply_known_obj_filters(self.res, self.known_objs, obstimes=[], wcs=self.wcs, filter_params=self.filter_params)
+        self.assertEqual(0, sum([len(m.keys()) for m in matches]))
+        self.assertEqual(10, len(self.res))
+
+    def test_apply_known_obj_filtering(self):
+        expected_matches = set(["spatial_close_time_close_1", "sparse_8"])
+
+        # Call the function under test
+        matches = apply_known_obj_filters(self.res, self.known_objs, obstimes=self.obstimes, wcs=self.wcs, filter_params=self.filter_params)
+        
+        # Assert the expected result
+        obs_matches = set()
+        for m in matches:
+            obs_matches.update(m.keys())
+        self.assertEqual(expected_matches, obs_matches)
+
+        self.assertEqual(9, len(self.res))
+
+        # Check that the close known object we inserted near result 1 is present
+        self.assertEqual(len(matches[1]), 1)
+        self.assertTrue("spatial_close_time_close_1" in matches[1])
+
+        self.assertEqual(len(matches[8]), 1)
+        self.assertTrue("sparse_8" in matches[8])
+
+        # Check that no results other than result 1 have a match
+        for i in range(len(self.res)):
+            if i != 1 and i != 8:
+                self.assertEqual(0, len(matches[i]))
+
+    def test_apply_known_obj_excessive_spatial_filtering(self):
+        # Here we only filter for exact spatial matches and should return no results
+        self.filter_params["known_obj_sep_thresh"] = 0.0
+        matches = apply_known_obj_filters(
+            self.res, self.known_objs, obstimes=self.obstimes, wcs=self.wcs, filter_params=self.filter_params)
+        self.assertEqual(0, sum([len(m.keys()) for m in matches]))
+        self.assertEqual(10, len(self.res))
+
+    def test_apply_known_obj_spatial_filtering(self):
+        # Here we use a filter that only matches spatially with an unreasonably generous time filter
+        self.filter_params["known_obj_sep_time_thresh_s"] = 1000000
+        expected_matches = set([
+            "spatial_close_time_close_1",
+            "spatial_close_time_far_3",
+            "sparse_8"])
+
+        matches = apply_known_obj_filters(
+            self.res, self.known_objs, obstimes=self.obstimes, wcs=self.wcs, filter_params=self.filter_params)
+    
+        obs_matches = set()
+        for m in matches:
+            obs_matches.update(m.keys())
+        self.assertEqual(expected_matches, obs_matches)
+
+        self.assertEqual(8, len(self.res))
+
+        # Check that the close known object we inserted near result 1 is present
+        self.assertEqual(1, len(matches[1]))
+        self.assertTrue("spatial_close_time_close_1" in matches[1])
+        self.assertEqual(np.count_nonzero(self.obs_valid[1]),
+                            np.count_nonzero(matches[1]["spatial_close_time_close_1"]))
+
+        # Check that the close known object we inserted near result 3 is present
+        self.assertEqual(1, len(matches[3]))
+        self.assertTrue("spatial_close_time_far_3" in matches[3])
+        self.assertEqual(np.count_nonzero(self.obs_valid[3]),
+                        np.count_nonzero(matches[3]["spatial_close_time_far_3"]))
+        
+        # Check that the sparse known object we inserted near result 8 is present
+        self.assertEqual(1, len(matches[8]))
+        self.assertTrue("sparse_8" in matches[8])
+        self.assertGreaterEqual(len(self.known_objs.data[self.known_objs.data["Name"] == "sparse_8"]),
+                        np.count_nonzero(matches[8]["sparse_8"]))
+
+        # Check that no results other than results 1 and 3 are full matches
+        # Since these are based off of random trajectories we can't guarantee there
+        # won't some overlapping observations.
+        for i in range(len(self.res)):
+            if i not in [1, 3]:
+                for obj_name in matches[i]:
+                    self.assertGreater(
+                            np.count_nonzero(self.obs_valid[i]),
+                            np.count_nonzero(matches[i][obj_name]))
+
+    def test_apply_known_obj_temporal_filtering(self):
+        # Here we use a filter that only matches temporally with an unreasonably generous spatial filter
+        self.filter_params["known_obj_sep_thresh"] = 100000
+        expected_matches = set([
+            "spatial_close_time_close_1",
+            "spatial_far_time_close_5",
+            "sparse_8"])
+        
+        matches = apply_known_obj_filters(
+            self.res, self.known_objs, obstimes=self.obstimes, wcs=self.wcs, filter_params=self.filter_params)
+        
+        obs_matches = set()
+        for m in matches:
+            obs_matches.update(m.keys())
+        self.assertEqual(expected_matches, obs_matches)
+        self.assertEqual(0, len(self.res))
+
+        # Check that every result matches to  of our known objects
+        for i in range(len(matches)):
+            self.assertEqual(expected_matches, set(matches[i].keys()))
+            # Check that all observations were matched to the known objects
+            for obj_name in matches[i]:
+                if obj_name == "sparse_8":
+                    self.assertGreaterEqual(
+                        len(self.known_objs.data[self.known_objs.data["Name"] == "sparse_8"]),
+                        np.count_nonzero(matches[i]["sparse_8"]))
+                else:
+                    self.assertEqual(
+                            np.count_nonzero(self.obs_valid[i]),
+                            np.count_nonzero(matches[i][obj_name])
+                        )
+
+    def test_apply_known_obj_time_no_filtering(self):
+        # Here we use generous temporal and spatial filters to uncover all objects
+        self.filter_params["known_obj_sep_thresh"] = 100000
+        self.filter_params["known_obj_sep_time_thresh_s"] = 1000000
+        expected_matches = set([
+            "spatial_close_time_close_1",
+            "spatial_close_time_far_3",
+            "spatial_far_time_close_5",
+            "spatial_far_time_far_7",
+            "sparse_8"])
+        
+        matches = apply_known_obj_filters(
+            self.res, self.known_objs, obstimes=self.obstimes, wcs=self.wcs, filter_params=self.filter_params)
+        
+        obs_matches = set()
+        for m in matches:
+            obs_matches.update(m.keys())
+        self.assertEqual(expected_matches, obs_matches)
+
+        # Each result should have matched to every object
+        self.assertEqual(0, len(self.res))
+        
+        # Check that every result matches to all of expected known objects
+        for i in range(len(matches)):
+            self.assertEqual(expected_matches, set(matches[i].keys()))
+            # Check that all observations were matched to the known objects
+            for obj_name in matches[i]:
+                self.assertEqual(
+                        np.count_nonzero(self.obs_valid[i]),
+                        np.count_nonzero(matches[i][obj_name])
+                    )
+
+    def test_apply_known_obj_matching(self):
+        # Here we apply the filter successively without removing matching observations,
+        # then successively pare down observations more aggressively.
+        assert True


### PR DESCRIPTION
Adds a filter for matching KBMOD results to "known objects", as defined by a user-provided astropy table specifying a catalog of objects we expect to find in the KBMOD data as part of addressing https://github.com/dirac-institute/kbmod/issues/528. The catalog of known objects can either be cached information of real known objects from a service such as astroquery or a catalog of inserted synthetic fakes a user has added to the data. The KBMOD results can either use the matching observations to identify which objects are recovered, which to be filtered out, and/or which individual result observations to be marked as invalid due to a match.

Such a catalog must have columns representing an object's:
* Name (either a synthetically generated or real target name as defined in https://astroquery.readthedocs.io/en/latest/imcce/imcce.html)
* it's RA and Dec for each observation (which can be reflex-corrected to a given guess distance if the user wants to compare against reflex-corrected results)
* the mjd of each observation

On klone/hyak loading and filtering with an approximately 750 mb catalog of cached astroquery results data corresponding to cone searches around bore sights in the DEEP search was tested, and loading and filtering took about 30 seconds. So there is room for optimization but currently would likely not be a scaling bottle neck.

The filter can be called either in the kbmod search wrokflow in [src/kbmod/run_search.py](https://github.com/dirac-institute/kbmod/blob/main/src/kbmod/run_search.py) where it can be called multiple times for different data sources or from any post-processing steps with a saved KBMOD Results object and its saved WCS. 

The matcher can match each result observation to potentially multiple objects with the user being able to apply thresholds for how close they need to be both spatially and temporally. Observations that match to known objects can the be set as invalid in the Results table's "obs_valid" column, and `remove_match_obs=True` Results table filtering is applied by the filter to remove results that no longer have enough matching observations. This is useful for results filtering because we can have cases where we constructed a result trajectory from a synthetic object on Day X that intersected with a known object on Day Y. Neither the matcher on the fakes catalog or on an astroquery generated catalog will have enough information to completely invalidate the result, but by each marking invalid observations, the entire result can be filtered out from new objects to investigate. 

The matcher stores within the KBMOD results table which known objects matched to which observation for each KBMOD result (regardless of how many observations matched and the truth value of `remove_match_obs`). This preserves as much matching information as possible for cases such as when multiple known objects intersect different parts of a result trajectory. While this PR does not provide a convenient list of which expected recovered objects were not in the KBMOD results as requested in https://github.com/dirac-institute/kbmod/issues/528, the caller of the filter has all of the information needed to construct that.


An example workflow for filtering out known objects, identifying recovered fakes, and then processing potentially real results is provided below:

```
from kbmod.filters.known_object_filters import KnownObjsMatcher
from kbmod.results import Results

from astropy.table import Table

# Example setup
res = Results.read_table("/path/to/results")
obstimes = range(10) # Dummy obstimes
wcs = res["wcs"][0] # Dummy WCS

# Remove all real observations from real objects from results
real_obj_table = Table("/path/to/real_obj_table/")
real_obj_matcher = KnownObjsMatcher(
    real_obj_table,
    obstimes,
    matcher_name="real_obj_matcher",
    sep_thresh=1.0,
    time_thresh_s=600.0,
    match_min_obs=5,
)
res = real_obj_matcher.match(
            res,
            wcs = res["wcs"][0],
            update_obs_valid=True,
        )
# Filter out the matching observations as invalid, dropping any results that
# No longer have valid observations
res = real_obj_matcher.mark_match_obs_invalid(res, drop_empty_rows=True)


# Identify all recovered fakes
fake_table = Table("/path/to/real_obj_table/")
fake_matcher = KnownObjsMatcher(
    fake_table,
    obstimes,
    matcher_name="fakes_matcher",
    sep_thresh=1.0,
    time_thresh_s=600.0,
    match_obs_ratio=0.5,
)

# Here we match observations to our fakes. Note that this does not update the "obs_valid"
# column of the Results table
res = fake_matcher.match(
            res,
            wcs = res["wcs"][0],
        )

# Apply a threshold for how many observations from the fake catalog we had to recover
# in order for the fake to be found. (note that we already filter near the obstimes for this
# KBMOD run, so fakes on distant nights shouldn't matter).
res = fake_matcher.filter_obs_ratio(res)

# Get the recovered fakes and missed fakes
recovered, missed = fake_matcher.get_recovered_objects(res, fake_matcher.match_obs_ratio_col())
print(f"Recovered {len(recovered)} fakes and missed {len(missed)} fakes")

# Now we can filter out all recovered fakes to continue processing potential results with ML
res = fake_matcher.filter_matches(res, fake_matcher.match_obs_ratio_col())
res = ml_magic_yay(res)
```