### PR TITLE
Save metadata

### DIFF
--- a/src/kbmod/image_collection.py
+++ b/src/kbmod/image_collection.py
@@ -888,7 +888,10 @@ class ImageCollection:
         for std in self.get_standardizers(**kwargs):
             for img in std["std"].toLayeredImage():
                 layeredImages.append(img)
+
         imgstack = ImageStack(layeredImages)
+        img_metadata = Table()
+
         if None not in self.wcs:
-            return WorkUnit(imgstack, search_config, per_image_wcs=list(self.wcs))
-        return WorkUnit(imgstack, search_config)
+            img_metadata["per_image_wcs"] = list(self.wcs)
+        return WorkUnit(imgstack, search_config, org_image_meta=img_metadata)

--- a/src/kbmod/reprojection.py
+++ b/src/kbmod/reprojection.py
@@ -288,8 +288,8 @@ def _reproject_work_unit(
     if write_output:
         new_work_unit = copy(work_unit)
         new_work_unit._per_image_indices = unique_obstime_indices
-        new_work_unit.reprojected = True
         new_work_unit.wcs = common_wcs
+        new_work_unit.reprojected = True
 
         hdul = new_work_unit.metadata_to_primary_hdul()
         hdul.writeto(os.path.join(directory, filename))
@@ -422,7 +422,7 @@ def _reproject_work_unit_in_parallel(
                 raise RuntimeError("one or more jobs failed.")
 
         new_work_unit = copy(work_unit)
-        new_work_unit._per_image_indices = unique_obstime_indices
+        new_work_unit._per_image_indices = unique_obstimes_indices
         new_work_unit.wcs = common_wcs
         new_work_unit.reprojected = True
 

--- a/src/kbmod/reprojection.py
+++ b/src/kbmod/reprojection.py
@@ -423,8 +423,8 @@ def _reproject_work_unit_in_parallel(
 
         new_work_unit = copy(work_unit)
         new_work_unit._per_image_indices = unique_obstime_indices
-        new_work_unit.reprojected = True
         new_work_unit.wcs = common_wcs
+        new_work_unit.reprojected = True
 
         hdul = new_work_unit.metadata_to_primary_hdul()
         hdul.writeto(os.path.join(directory, filename))
@@ -453,7 +453,7 @@ def _reproject_work_unit_in_parallel(
             config=work_unit.config,
             wcs=common_wcs,
             per_image_wcs=work_unit._per_image_wcs,
-            per_image_indices=unique_obstime_indices,
+            per_image_indices=unique_obstimes_indices,
             reprojected=True,
             org_image_meta=work_unit.org_img_meta,
         )
@@ -550,9 +550,9 @@ def reproject_lazy_work_unit(
 
     # We use new metadata for the new images and the same metadata for the original images.
     new_work_unit = copy(work_unit)
-    new_work_unit._per_image_indices = unique_obstime_indices
-    new_work_unit.reprojected = True
+    new_work_unit._per_image_indices = unique_obstimes_indices
     new_work_unit.wcs = common_wcs
+    new_work_unit.reprojected = True
 
     hdul = new_work_unit.metadata_to_primary_header()
     hdul.writeto(os.path.join(directory, filename))

--- a/src/kbmod/reprojection.py
+++ b/src/kbmod/reprojection.py
@@ -557,7 +557,7 @@ def reproject_lazy_work_unit(
     new_work_unit.wcs = common_wcs
     new_work_unit.reprojected = True
 
-    hdul = new_work_unit.metadata_to_primary_header()
+    hdul = new_work_unit.metadata_to_hdul()
     hdul.writeto(os.path.join(directory, filename))
 
 

--- a/src/kbmod/standardizers/fits_standardizers/kbmodv05.py
+++ b/src/kbmod/standardizers/fits_standardizers/kbmodv05.py
@@ -141,14 +141,15 @@ class KBMODV0_5(MultiExtensionFits):
         ]
 
     def translateHeader(self):
-        """Returns the following metadata, read from the primary header, as a
-        dictionary:
+        """Returns at least the following metadata, read from the primary header,
+         as a dictionary:
 
         ======== ========== ===================================================
         Key      Header Key Description
         ======== ========== ===================================================
         mjd      DATE-AVG   Decimal MJD timestamp of the middle of the exposure
         filter   FILTER     Filter band
+        visit    EXPID      Exposure ID
         ======== ========== ===================================================
         """
         # this is the 1 mandatory piece of metadata we need to extract
@@ -159,6 +160,7 @@ class KBMODV0_5(MultiExtensionFits):
 
         # these are all optional things
         standardizedHeader["filter"] = self.primary["FILTER"]
+        standardizedHeader["visit"] = self.primary["EXPID"]
 
         # If no observatory information is given, default to the Deccam data
         # (Cerro Tololo Inter-American Observatory).

--- a/src/kbmod/standardizers/fits_standardizers/kbmodv1.py
+++ b/src/kbmod/standardizers/fits_standardizers/kbmodv1.py
@@ -143,8 +143,9 @@ class KBMODV1(MultiExtensionFits):
         Key      Header Key Description
         ======== ========== ===================================================
         mjd_mid  DATE-AVG   Decimal MJD timestamp of the middle of the exposure
-        filter   FILTER     Filter band
-        visit_id IDNUM      Visit ID
+        FILTER   FILTER     Filter band
+        visit    EXPID      Exposure ID
+        IDNUM    IDNUM      Visit ID
         observat OBSERVAT   Observatory name
         obs_lat  OBS-LAT    Observatory Latitude
         obs_lon  OBS-LONG   Observatory Longitude
@@ -164,6 +165,7 @@ class KBMODV1(MultiExtensionFits):
         # these are all optional things
         standardizedHeader["FILTER"] = self.primary["FILTER"]
         standardizedHeader["IDNUM"] = self.primary["IDNUM"]
+        standardizedHeader["visit"] = self.primary["EXPID"]
         standardizedHeader["OBSID"] = self.primary["OBSID"]
         standardizedHeader["DTNSANAM"] = self.primary["DTNSANAM"]
         standardizedHeader["AIRMASS"] = self.primary["AIRMASS"]

--- a/src/kbmod/wcs_utils.py
+++ b/src/kbmod/wcs_utils.py
@@ -450,14 +450,17 @@ def serialize_wcs(wcs):
 
     Parameters
     ----------
-    wcs : `astropy.wcs.WCS`
+    wcs : `astropy.wcs.WCS` or None
         The WCS to convert.
 
     Returns
     -------
     wcs_str : `str`
-        The serialized WCS.
+        The serialized WCS. Returns an empty string if wcs is None.
     """
+    if wcs is None:
+        return ""
+
     # Since AstroPy's WCS does not output NAXIS, we need to manually add those.
     header = wcs.to_header(relax=True)
     header["NAXIS1"], header["NAXIS2"] = wcs.pixel_shape
@@ -474,9 +477,12 @@ def deserialize_wcs(wcs_str):
 
     Returns
     -------
-    wcs : `astropy.wcs.WCS`
-        The resulting WCS.
+    wcs : `astropy.wcs.WCS` or None
+        The resulting WCS or None if no data is provided.
     """
+    if wcs_str == "" or wcs_str.lower() == "none":
+        return None
+
     wcs_dict = json.loads(wcs_str)
     wcs = astropy.wcs.WCS(wcs_dict)
     wcs.pixel_shape = (wcs_dict["NAXIS1"], wcs_dict["NAXIS2"])

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -46,10 +46,19 @@ class WorkUnit:
         The image data for the KBMOD run.
     config : `kbmod.configuration.SearchConfiguration`
         The configuration for the KBMOD run.
+    n_images : `int`
+        The number of current images.
     n_constituents : `int`
         The number of original images making up the data in this WorkUnit. This might be
         different from the number of images stored in memory if the WorkUnit has been
         reprojected.
+    img_meta : `astropy.table.Table`
+        The meta data for each of the current images. These might differ from the
+        constituent images if the WorkUnit has been filtered or reprojected.
+          * wcs - The WCS of the image. This is set even if all image share a global WCS.
+          * per_image_indices - A lists containing the indicies of `constituent_images`
+            for each current image. Used for finding corresponding original images when we
+            stitch images together during reprojection.
     org_img_meta : `astropy.table.Table`
         The meta data for each constituent image. Includes columns:
         * data_loc - the original location of the image
@@ -60,9 +69,6 @@ class WorkUnit:
     wcs : `astropy.wcs.WCS`
         A global WCS for all images in the WorkUnit. Only exists
         if all images have been projected to same pixel space.
-    per_image_wcs : `list`
-        A list with one WCS for each image in the WorkUnit. Used for when
-        the images have *not* been standardized to the same pixel space.
     heliocentric_distance : `float`
         The heliocentric distance that was used when creating the `per_image_ebd_wcs`.
     reprojected : `bool`
@@ -88,26 +94,13 @@ class WorkUnit:
     wcs : `astropy.wcs.WCS`
         A global WCS for all images in the WorkUnit. Only exists
         if all images have been projected to same pixel space.
-    constituent_images: `list`
-        A list of strings with the original locations of images used
-        to construct the WorkUnit. This is necessary to maintain as metadata
-        because after reprojection we may stitch multiple images into one.
     per_image_wcs : `list`
         A list with one WCS for each image in the WorkUnit. Used for when
         the images have *not* been standardized to the same pixel space.
-    per_image_ebd_wcs : `list`
-        A list with one WCS for each image in the WorkUnit. Used to reproject the images
-        into EBD space.
-    heliocentric_distance : `float`
-        The heliocentric distance that was used when creating the `per_image_ebd_wcs`.
-    geocentric_distances : `list`
-        The best fit geocentric distances used when creating the `per_image_ebd_wcs`.
     reprojected : `bool`
         Whether or not the WorkUnit image data has been reprojected.
-    per_image_indices : `list` of `list`
-        A list of lists containing the indicies of `constituent_images` at each layer
-        of the `ImageStack`. Used for finding corresponding original images when we
-        stitch images together during reprojection.
+    heliocentric_distance : `float`
+        The heliocentric distance that was used when creating the `per_image_ebd_wcs`.
     lazy : `bool`
         Whether or not to load the image data for the `WorkUnit`.
     file_paths : `list[str]`
@@ -115,8 +108,10 @@ class WorkUnit:
         in lazy mode.
     obstimes : `list[float]`
         The MJD obstimes of the images.
-    per_image_meta : `dict` or `astropy.table.Table`
-        A table of additional per-image metadata.
+    img_meta : `dict` or `astropy.table.Table`, optional
+        The meta data for each of the current images.
+    org_image_meta : `dict` or `astropy.table.Table`, optional
+        A table of per-image data for the constituent images.
     """
 
     def __init__(
@@ -124,17 +119,14 @@ class WorkUnit:
         im_stack=None,
         config=None,
         wcs=None,
-        constituent_images=None,
         per_image_wcs=None,
-        per_image_ebd_wcs=None,
-        heliocentric_distance=None,
-        geocentric_distances=None,
         reprojected=False,
-        per_image_indices=None,
+        heliocentric_distance=None,
         lazy=False,
         file_paths=None,
         obstimes=None,
-        per_image_meta=None,
+        image_meta=None,
+        org_image_meta=None,
     ):
         self.im_stack = im_stack
         self.config = config
@@ -142,66 +134,108 @@ class WorkUnit:
         self.file_paths = file_paths
         self._obstimes = obstimes
 
-        # Determine the number of constituent images. If we are given a list of constituent_images,
-        # use that. Otherwise use the size of the image stack.
-        if constituent_images is None:
-            self.n_constituents = im_stack.img_count()
-        else:
-            self.n_constituents = len(constituent_images)
+        # Track the metadata for each of the current images.
+        self.img_meta = WorkUnit.create_meta(
+            constituent=False,
+            data=image_meta,
+            n_images=im_stack.img_count(),
+        )
 
-        # Track the meta data for each constituent image in the WorkUnit. For the original
-        # WCS, we track the per-image WCS if it is provided and otherwise the global WCS.
-        if per_image_meta is None:
-            self.org_img_meta = Table()
-        elif isinstance(per_image_meta, Table):
-            self.org_img_meta = per_image_meta.copy()
-        elif isinstance(per_image_meta, dict):
-            self.org_img_meta = Table(per_image_meta)
-        else:
-            raise ValueError(f"Invalid type for per_image_meta: {type(per_image_meta)}")
-        self.add_org_img_meta_data("data_loc", constituent_images)
-        self.add_org_img_meta_data("original_wcs", per_image_wcs, default=wcs)
+        # Base the number of current images on the metadata because in a lazy load,
+        # the ImageStack might be empty.
+        self.n_images = len(self.img_meta)
 
-        # Handle WCS input. If both the global and per-image WCS are provided,
-        # ensure they are consistent.
+        # Track the metadata for each constituent image in the WorkUnit. If no constituent
+        # data is provided, this will create an empty array the same size as the original.
+        no_org_img_meta_given = org_image_meta is None
+        self.org_img_meta = WorkUnit.create_meta(
+            constituent=True,
+            data=org_image_meta,
+            n_images=self.n_images,
+        )
+        self.n_constituents = len(self.org_img_meta)
+
+        # Handle WCS input.
         self.wcs = wcs
-        if per_image_wcs is None:
-            self._per_image_wcs = [None] * self.n_constituents
-            if self.wcs is None and per_image_ebd_wcs is None:
-                warnings.warn("No WCS provided.", Warning)
-        else:
-            if len(per_image_wcs) != self.n_constituents:
-                raise ValueError(f"Incorrect number of WCS provided. Expected {self.n_constituents}")
-            self._per_image_wcs = per_image_wcs
+        if per_image_wcs is not None:
+            # If we are given explicit per-image WCS, use those. Overwrite the values
+            # the current image metadata.
+            if len(per_image_wcs) != self.n_images:
+                raise ValueError(f"Incorrect number of WCS provided. Expected {self.n_images}")
+            self.img_meta["wcs"] = np.array(per_image_wcs)
+        elif "wcs" not in self.img_meta.colnames or np.all(self.img_meta["wcs"] == None):
+            # If we have no per-image WCS already, use the global one (which might be None).
+            self.img_meta["wcs"] = np.array([self.wcs] * self.n_images)
 
-            # Check if all the per-image WCS are None. This can happen during a load.
-            all_none = self.per_image_wcs_all_match(None)
-            if self.wcs is None and all_none:
-                warnings.warn("No WCS provided.", Warning)
+        # If no constituent data was provided, then save the current image's WCS as the original.
+        # This is needed to ensure that we always have a correct original WCS.
+        if no_org_img_meta_given:
+            for i in range(self.n_images):
+                self.org_img_meta["original_wcs"][i] = self.img_meta["wcs"][i]
 
-            # See if we can compress the per-image WCS into a global one.
-            if self.wcs is None and not all_none and self.per_image_wcs_all_match(self._per_image_wcs[0]):
-                self.wcs = self._per_image_wcs[0]
-                self._per_image_wcs = [None] * im_stack.img_count()
+        # If both the global and per-image WCS are provided, ensure they are consistent.
+        if self.wcs is not None and not np.all(self.img_meta["wcs"].value == None):
+            for idx in range(im_stack.img_count()):
+                if not wcs_fits_equal(self.wcs, self.img_meta["wcs"][idx]):
+                    raise ValueError(f"Inconsistent WCS at index {idx}.")
+        if self.wcs is None and np.any(self.img_meta["wcs"].value == None):
+            logger.warning("No WCS provided for at least one image.")
 
-        # Add the meta data needed for reprojection, including: the reprojected WCS, the geocentric
-        # distances, and each images indices in the original constituent images.
+        # Set the global metadata for reprojection.
         self.reprojected = reprojected
         self.heliocentric_distance = heliocentric_distance
-        self.add_org_img_meta_data("geocentric_distance", geocentric_distances)
-        self.add_org_img_meta_data("ebd_wcs", per_image_ebd_wcs)
-
-        # If we have mosaicked images, each image in the stack could link back
-        # to more than one constituents image. Build a mapping of image stack index
-        # to needed original image indices.
-        if per_image_indices is None:
-            self._per_image_indices = [[i] for i in range(self.n_constituents)]
-        else:
-            self._per_image_indices = per_image_indices
 
     def __len__(self):
         """Returns the size of the WorkUnit in number of images."""
         return self.im_stack.img_count()
+
+    @staticmethod
+    def create_meta(constituent=False, n_images=None, data=None):
+        """Create an img_meta table, filling in default values
+        for any unspecified columns.
+
+        Parameters
+        ----------
+        constituent : `bool`
+            Indicates the type of table. True indicates a table of constituent (original)
+            images. False indicates a table of current images.
+        data : `dict`, `astropy.table.Table`, or None
+            The data from which to seed the table.
+        n_images : `int`, optional
+            The number of images to include. Only use when no data is
+            provided in order to fill in defaults.
+
+        Returns
+        -------
+        img_meta : `astropy.table.Table`
+            The empty table of org_img_meta.
+        """
+        if data is None:
+            if n_images is None or n_images <= 0:
+                raise ValueError("If no data provided 'n_images' must be >= 1. Is {n_images}")
+
+            # Add a place holder column of the correct size.
+            data = Table({"_index": np.arange(n_images)})
+        elif isinstance(data, dict):
+            data = Table(data)
+        elif isinstance(data, Table):
+            data = data.copy()
+        else:
+            raise TypeError("Unsupported type for data table.")
+        n_images = len(data)
+
+        if constituent:
+            # Fill in the defaults for the original/constituent images.
+            for colname in ["data_loc", "ebd_wcs", "geocentric_distance", "original_wcs"]:
+                if colname not in data.colnames:
+                    data[colname] = np.full(n_images, None)
+        else:
+            # Fill in the defaults for the current image.
+            if "per_image_indices" not in data.colnames:
+                data["per_image_indices"] = [[i] for i in range(n_images)]
+            if "wcs" not in data.colnames:
+                data["wcs"] = np.full(n_images, None)
+        return data
 
     def get_constituent_meta(self, column):
         """Get the meta data values of a given column for all the constituent images.
@@ -218,55 +252,6 @@ class WorkUnit:
         """
         return list(self.org_img_meta[column].data)
 
-    def add_org_img_meta_data(self, column, data, default=None):
-        """Add a column of meta data for the constituent images. Adds a column of all
-        default values if data is None and the column does not already exist.
-
-        Parameters
-        ----------
-        column : `str`
-            The name of the meta data column.
-        data : list-like
-            The data for each constituent. If None then uses None for
-            each column.
-        dtype : type
-            The numpy dtype to use when storing this data. If None
-
-        """
-        if data is None:
-            if column not in self.org_img_meta.colnames:
-                self.org_img_meta[column] = np.array([default] * self.n_constituents)
-        elif len(data) == self.n_constituents:
-            self.org_img_meta[column] = np.array(data)
-        else:
-            raise ValueError(
-                f"Data mismatch size for WorkUnit metadata {column}. "
-                f"Expected {self.n_constituents} but found {len(data)}."
-            )
-
-    def has_common_wcs(self):
-        """Returns whether the WorkUnit has a common WCS for all images."""
-        return self.wcs is not None
-
-    def per_image_wcs_all_match(self, target=None):
-        """Check if all the per-image WCS are the same as a given target value.
-
-        Parameters
-        ----------
-        target : `astropy.wcs.WCS`, optional
-            The WCS to which to compare the per-image WCS. If None, checks that
-            all of the per-image WCS are None.
-
-        Returns
-        -------
-        result : `bool`
-            A Boolean indicating that all the per-images WCS match the target.
-        """
-        for current in self._per_image_wcs:
-            if not wcs_fits_equal(current, target):
-                return False
-        return True
-
     def get_wcs(self, img_num):
         """Return the WCS for the a given image. Alway prioritizes
         a global WCS if one exits.
@@ -280,26 +265,11 @@ class WorkUnit:
         -------
         wcs : `astropy.wcs.WCS`
             The image's WCS if one exists. Otherwise None.
-
-        Raises
-        ------
-        IndexError if an invalid index is given.
         """
-        if img_num < 0 or img_num >= len(self._per_image_wcs):
-            raise IndexError(f"Invalid image number {img_num}")
-
-        # Extract the per-image WCS if one exists.
-        if self._per_image_wcs is not None and img_num < len(self._per_image_wcs):
-            per_img = self._per_image_wcs[img_num]
-        else:
-            per_img = None
-
-        if self.wcs is not None:
-            if per_img is not None and not wcs_fits_equal(self.wcs, per_img):
-                warnings.warn("Both a global and per-image WCS given. Using global WCS.", Warning)
+        if self.wcs:
             return self.wcs
-
-        return per_img
+        else:
+            return self.img_meta["wcs"][img_num]
 
     def get_pixel_coordinates(self, ra, dec, times=None):
         """Get the pixel coordinates for pairs of (RA, dec) coordinates. Uses the global
@@ -346,7 +316,7 @@ class WorkUnit:
             for i, index in enumerate(inds):
                 if index == -1:
                     raise ValueError(f"Unmatched time {times[i]}.")
-                current_wcs = self._per_image_wcs[index]
+                current_wcs = self.img_meta["wcs"][index]
                 curr_x, curr_y = current_wcs.world_to_pixel(
                     SkyCoord(ra=ra[i] * u.degree, dec=dec[i] * u.degree)
                 )
@@ -390,9 +360,6 @@ class WorkUnit:
         unique_indices = [list(np.where(all_obstimes == time)[0]) for time in unique_obstimes]
         return unique_obstimes, unique_indices
 
-    def get_num_images(self):
-        return len(self._per_image_indices)
-
     @classmethod
     def from_fits(cls, filename, show_progress=None):
         """Create a WorkUnit from a single FITS file.
@@ -433,11 +400,23 @@ class WorkUnit:
             # Read in the search parameters from the 'kbmod_config' extension.
             config = SearchConfiguration.from_hdu(hdul["kbmod_config"])
 
-            # Read in the per-image metadata.
+            # Read the size and order information from the primary header.
+            num_images = hdul[0].header["NUMIMG"]
+            n_constituents = hdul[0].header["NCON"] if "NCON" in hdul[0].header else num_images
+            logger.info(f"Loading {num_images} images.")
+
+            # Read in the per-image metadata for the current images and the constituent images.
             if "IMG_META" in hdul:
+                logger.debug("Reading image metadata from IMG_META.")
                 per_image_meta = hdu_to_metadata_table(hdul["IMG_META"])
             else:
-                per_image_meta = None
+                per_image_meta = WorkUnit.create_meta(constituent=True, data=None, n_images=num_images)
+
+            if "ORG_META" in hdul:
+                logger.debug("Reading original image metadata from ORG_META.")
+                org_image_meta = hdu_to_metadata_table(hdul["ORG_META"])
+            else:
+                org_image_meta = WorkUnit.create_meta(constituent=True, data=None, n_images=n_constituents)
 
             # Read in the global WCS from extension 0 if the information exists.
             # We filter the warning that the image dimension does not match the WCS dimension
@@ -446,22 +425,16 @@ class WorkUnit:
                 warnings.simplefilter("ignore", AstropyWarning)
                 global_wcs = extract_wcs_from_hdu_header(hdul[0].header)
 
-            # Read the size and order information from the primary header.
-            num_images = hdul[0].header["NUMIMG"]
-            n_constituents = hdul[0].header["NCON"]
-            expected_num_images = (4 * num_images) + (2 * n_constituents) + 3
-            if len(hdul) != expected_num_images:
-                raise ValueError(f"WorkUnit wrong number of extensions. Expected " f"{expected_num_images}.")
-            logger.info(f"Loading {num_images} images and {expected_num_images} total layers.")
-
             # Misc. reprojection metadata
             reprojected = hdul[0].header["REPRJCTD"]
             heliocentric_distance = hdul[0].header["HELIO"]
-            geocentric_distances = []
-            for i in range(num_images):
-                geocentric_distances.append(hdul[0].header[f"GEO_{i}"])
+            if np.all(org_image_meta["geocentric_distance"] == None):
+                # If the metadata table does not have the geocentric_distance, try
+                # loading it from the primary header's GEO_i fields (legacy approach).
+                for i in range(n_constituents):
+                    if f"GEO_{i}" in hdul[0].header:
+                        org_image_meta["geocentric_distance"][i] = hdul[0].header[f"GEO_{i}"]
 
-            per_image_indices = []
             # Read in all the image files.
             for i in tqdm(
                 range(num_images),
@@ -483,38 +456,38 @@ class WorkUnit:
                 # force_move destroys img object, but avoids a copy.
                 im_stack.append_image(img, force_move=True)
 
-                n_indices = sci_hdu.header["NIND"]
-                sub_indices = []
-                for j in range(n_indices):
-                    sub_indices.append(sci_hdu.header[f"IND_{j}"])
-                per_image_indices.append(sub_indices)
+                # Check if we need to load the map of current images to constituent images
+                # from the (legacy) headers.
+                if "NIND" in sci_hdu.header:
+                    n_indices = sci_hdu.header["NIND"]
+                    sub_indices = []
+                    for j in range(n_indices):
+                        sub_indices.append(sci_hdu.header[f"IND_{j}"])
+                    per_image_meta["per_image_indices"][i] = sub_indices
 
-            per_image_wcs = []
-            per_image_ebd_wcs = []
-            constituent_images = []
+            # Extract the per-image data from header information if needed. This happens
+            # when the WorkUnit was saved before metadata tables were saved as layers and
+            # all the information is in header values.
             for i in tqdm(
                 range(n_constituents),
                 bar_format=_DEFAULT_WORKUNIT_TQDM_BAR,
                 desc="Loading WCS",
                 disable=not show_progress,
             ):
-                # Extract the per-image WCS if one exists.
-                per_image_wcs.append(extract_wcs_from_hdu_header(hdul[f"WCS_{i}"].header))
-                per_image_ebd_wcs.append(extract_wcs_from_hdu_header(hdul[f"EBD_{i}"].header))
-                constituent_images.append(hdul[f"WCS_{i}"].header["ILOC"])
+                if f"WCS_{i}" in hdul:
+                    org_image_meta["original_wcs"][i] = extract_wcs_from_hdu_header(hdul[f"WCS_{i}"].header)
+                    org_image_meta["data_loc"][i] = hdul[f"WCS_{i}"].header["ILOC"]
+                if f"EBD_{i}" in hdul:
+                    org_image_meta["original_wcs"][i] = extract_wcs_from_hdu_header(hdul[f"EBD_{i}"].header)
 
         result = WorkUnit(
             im_stack=im_stack,
             config=config,
             wcs=global_wcs,
-            constituent_images=constituent_images,
-            per_image_wcs=per_image_wcs,
-            per_image_ebd_wcs=per_image_ebd_wcs,
             heliocentric_distance=heliocentric_distance,
-            geocentric_distances=geocentric_distances,
             reprojected=reprojected,
-            per_image_indices=per_image_indices,
-            per_image_meta=per_image_meta,
+            image_meta=per_image_meta,
+            org_image_meta=org_image_meta,
         )
         return result
 
@@ -540,20 +513,17 @@ class WorkUnit:
         if Path(filename).is_file() and not overwrite:
             raise FileExistsError(f"WorkUnit file {filename} already exists.")
 
-        hdul = self.metadata_to_primary_header(include_wcs=False)
+        # Create an HDU list with the metadata layers.
+        hdul = self.metadata_to_hdul(include_wcs=False)
 
+        # Create each image layer.
         for i in range(self.im_stack.img_count()):
             layered = self.im_stack.get_single_image(i)
             obstime = layered.get_obstime()
-            c_indices = self._per_image_indices[i]
-            n_indices = len(c_indices)
 
             img_wcs = self.get_wcs(i)
             sci_hdu = raw_image_to_hdu(layered.get_science(), obstime, img_wcs)
             sci_hdu.name = f"SCI_{i}"
-            sci_hdu.header["NIND"] = n_indices
-            for j in range(n_indices):
-                sci_hdu.header[f"IND_{j}"] = c_indices[j]
             hdul.append(sci_hdu)
 
             var_hdu = raw_image_to_hdu(layered.get_variance(), obstime)
@@ -569,11 +539,6 @@ class WorkUnit:
             psf_hdu = fits.hdu.image.ImageHDU(psf_array)
             psf_hdu.name = f"PSF_{i}"
             hdul.append(psf_hdu)
-
-        # Format additional metadata.
-        meta_hdu = metadata_table_to_hdu(self.org_img_meta, "IMG_META")
-        hdul.append(meta_hdu)
-        self.append_all_wcs(hdul)
 
         hdul.writeto(filename, overwrite=overwrite)
 
@@ -623,16 +588,11 @@ class WorkUnit:
         for i in range(self.im_stack.img_count()):
             layered = self.im_stack.get_single_image(i)
             obstime = layered.get_obstime()
-            c_indices = self._per_image_indices[i]
-            n_indices = len(c_indices)
             sub_hdul = fits.HDUList()
 
             img_wcs = self.get_wcs(i)
             sci_hdu = raw_image_to_hdu(layered.get_science(), obstime, img_wcs)
             sci_hdu.name = f"SCI_{i}"
-            sci_hdu.header["NIND"] = n_indices
-            for j in range(n_indices):
-                sci_hdu.header[f"IND_{j}"] = c_indices[j]
             sub_hdul.append(sci_hdu)
 
             var_hdu = raw_image_to_hdu(layered.get_variance(), obstime)
@@ -650,12 +610,8 @@ class WorkUnit:
             sub_hdul.append(psf_hdu)
             sub_hdul.writeto(os.path.join(directory, f"{i}_{filename}"))
 
-        hdul = self.metadata_to_primary_header(include_wcs=True)
-
-        # Format additional metadata as a single HDU
-        meta_hdu = metadata_table_to_hdu(self.org_img_meta, "IMG_META")
-        hdul.append(meta_hdu)
-
+        # Create a primary file with all of the metadata
+        hdul = self.metadata_to_hdul(include_wcs=True)
         hdul.writeto(os.path.join(directory, filename), overwrite=overwrite)
 
     @classmethod
@@ -700,11 +656,23 @@ class WorkUnit:
         with fits.open(os.path.join(directory, filename)) as primary:
             config = SearchConfiguration.from_hdu(primary["kbmod_config"])
 
-            # Read in the per-image metadata.
+            # Read the size and order information from the primary header.
+            num_images = primary[0].header["NUMIMG"]
+            n_constituents = primary[0].header["NCON"] if "NCON" in primary[0].header else num_images
+            logger.info(f"Loading {num_images} images.")
+
+            # Read in the per-image metadata for the current images and the constituent images.
             if "IMG_META" in primary:
+                logger.debug("Reading image metadata from IMG_META.")
                 per_image_meta = hdu_to_metadata_table(primary["IMG_META"])
             else:
-                per_image_meta = None
+                per_image_meta = WorkUnit.create_meta(constituent=True, data=None, n_images=num_images)
+
+            if "ORG_META" in primary:
+                logger.debug("Reading original image metadata from ORG_META.")
+                org_image_meta = hdu_to_metadata_table(primary["ORG_META"])
+            else:
+                org_image_meta = WorkUnit.create_meta(constituent=True, data=None, n_images=n_constituents)
 
             # Read in the global WCS from extension 0 if the information exists.
             # We filter the warning that the image dimension does not match the WCS dimension
@@ -713,27 +681,27 @@ class WorkUnit:
                 warnings.simplefilter("ignore", AstropyWarning)
                 global_wcs = extract_wcs_from_hdu_header(primary[0].header)
 
-            # Read the size and order information from the primary header.
-            num_images = primary[0].header["NUMIMG"]
-            n_constituents = primary[0].header["NCON"]
-            expected_num_images = (4 * num_images) + (2 * n_constituents) + 3
-
             # Misc. reprojection metadata
             reprojected = primary[0].header["REPRJCTD"]
             heliocentric_distance = primary[0].header["HELIO"]
-            geocentric_distances = []
             for i in range(n_constituents):
-                geocentric_distances.append(primary[0].header[f"GEO_{i}"])
+                if f"GEO_{i}" in primary[0].header:
+                    org_image_meta["geocentric_distance"][i] = primary[0].header[f"GEO_{i}"]
 
-            per_image_wcs = []
-            per_image_ebd_wcs = []
-            constituent_images = []
+            # Extract the per-image data from header innformation if needed.
+            # This happens with when the WorkUnit was saved before metadata tables were
+            # saved as layers.that we will fill in from the headers.
             for i in range(n_constituents):
-                # Extract the per-image WCS if one exists.
-                per_image_wcs.append(extract_wcs_from_hdu_header(primary[f"WCS_{i}"].header))
-                per_image_ebd_wcs.append(extract_wcs_from_hdu_header(primary[f"EBD_{i}"].header))
-                constituent_images.append(primary[f"WCS_{i}"].header["ILOC"])
-        per_image_indices = []
+                if f"WCS_{i}" in primary:
+                    org_image_meta["original_wcs"][i] = extract_wcs_from_hdu_header(
+                        primary[f"WCS_{i}"].header
+                    )
+                    org_image_meta["data_loc"][i] = primary[f"WCS_{i}"].header["ILOC"]
+                if f"EBD_{i}" in primary:
+                    org_image_meta["original_wcs"][i] = extract_wcs_from_hdu_header(
+                        primary[f"EBD_{i}"].header
+                    )
+
         file_paths = []
         obstimes = []
         for i in range(num_images):
@@ -753,32 +721,28 @@ class WorkUnit:
                 else:
                     file_paths.append(shard_path)
 
-                n_indices = sci_hdu.header["NIND"]
-                sub_indices = []
-                for j in range(n_indices):
-                    sub_indices.append(sci_hdu.header[f"IND_{j}"])
-                per_image_indices.append(sub_indices)
+                if "NIND" in sci_hdu.header:
+                    n_indices = sci_hdu.header["NIND"]
+                    sub_indices = []
+                    for j in range(n_indices):
+                        sub_indices.append(sci_hdu.header[f"IND_{j}"])
+                    per_image_meta["per_image_indices"][i] = sub_indices
 
         file_paths = None if not lazy else file_paths
         result = WorkUnit(
             im_stack=im_stack,
             config=config,
             wcs=global_wcs,
-            constituent_images=constituent_images,
-            per_image_wcs=per_image_wcs,
-            per_image_ebd_wcs=per_image_ebd_wcs,
-            heliocentric_distance=heliocentric_distance,
-            geocentric_distances=geocentric_distances,
             reprojected=reprojected,
-            per_image_indices=per_image_indices,
-            lazy=lazy,
+            heliocentric_distance=heliocentric_distance,
             file_paths=file_paths,
-            obstimes=obstimes,
-            per_image_meta=per_image_meta,
+            lazy=lazy,
+            image_meta=per_image_meta,
+            org_image_meta=org_image_meta,
         )
         return result
 
-    def metadata_to_primary_header(self, include_wcs=True):
+    def metadata_to_hdul(self, include_wcs=True):
         """Creates the metadata fits headers.
 
         Parameters
@@ -797,56 +761,26 @@ class WorkUnit:
         # the metadata (empty), and the configuration.
         hdul = fits.HDUList()
         pri = fits.PrimaryHDU()
-        pri.header["NUMIMG"] = self.get_num_images()
+        pri.header["NUMIMG"] = self.n_images
         pri.header["NCON"] = self.n_constituents
         pri.header["REPRJCTD"] = self.reprojected
         pri.header["HELIO"] = self.heliocentric_distance
-        for i in range(self.n_constituents):
-            pri.header[f"GEO_{i}"] = self.org_img_meta["geocentric_distance"][i]
 
         # If the global WCS exists, append the corresponding keys.
         if self.wcs is not None:
             append_wcs_to_hdu_header(self.wcs, pri.header)
-
         hdul.append(pri)
 
-        meta_hdu = fits.BinTableHDU()
-        meta_hdu.name = "metadata"
-        hdul.append(meta_hdu)
-
+        # Add the configuration layer.
         config_hdu = self.config.to_hdu()
         config_hdu.name = "kbmod_config"
         hdul.append(config_hdu)
 
-        if include_wcs:
-            self.append_all_wcs(hdul)
+        # Save the additional metadata tables into HDUs
+        hdul.append(metadata_table_to_hdu(self.img_meta, "IMG_META"))
+        hdul.append(metadata_table_to_hdu(self.org_img_meta, "ORG_META"))
 
         return hdul
-
-    def append_all_wcs(self, hdul):
-        """Append all the original WCS and EBD WCS to a header.
-
-        Parameters
-        ----------
-        hdul : `astropy.io.fits.HDUList`
-            The HDU list.
-        """
-        all_ebd_wcs = self.get_constituent_meta("ebd_wcs")
-
-        for i in range(self.n_constituents):
-            img_location = self.org_img_meta["data_loc"][i]
-
-            orig_wcs = self._per_image_wcs[i]
-            wcs_hdu = fits.TableHDU()
-            append_wcs_to_hdu_header(orig_wcs, wcs_hdu.header)
-            wcs_hdu.name = f"WCS_{i}"
-            wcs_hdu.header["ILOC"] = img_location
-            hdul.append(wcs_hdu)
-
-            ebd_hdu = fits.TableHDU()
-            append_wcs_to_hdu_header(all_ebd_wcs[i], ebd_hdu.header)
-            ebd_hdu.name = f"EBD_{i}"
-            hdul.append(ebd_hdu)
 
     def image_positions_to_original_icrs(
         self, image_indices, positions, input_format="xy", output_format="xy", filter_in_frame=True
@@ -876,6 +810,7 @@ class WorkUnit:
             Whether or not to filter the output based on whether they fit within the
             original `constituent_image` frame. If `True`, only results that fall within
             the bounds of the original WCS will be returned.
+
         Returns
         -------
         positions : `list` of `astropy.coordinates.SkyCoord`s or `tuple`s
@@ -930,12 +865,12 @@ class WorkUnit:
 
         positions = []
         for i in image_indices:
-            inds = self._per_image_indices[i]
+            inds = self.img_meta["per_image_indices"][i]
             coord = inverted_coords[i]
             pos = []
             for j in inds:
                 con_image = self.org_img_meta["data_loc"][j]
-                con_wcs = self._per_image_wcs[j]
+                con_wcs = self.org_img_meta["original_wcs"][j]
                 height, width = con_wcs.array_shape
                 x, y = skycoord_to_pixel(coord, con_wcs)
                 x, y = float(x), float(y)
@@ -1053,7 +988,7 @@ def metadata_table_to_hdu(data, layer_name=None):
     num_rows = len(data)
     if num_rows == 0:
         # No data to encode. Just use the current table.
-        meta_hdu = fits.BinTableHDU(data)
+        save_table = data
     else:
         # Create a new table to save with the correct column
         # values/names for the serialized information.

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -46,9 +46,6 @@ class WorkUnit:
         The image data for the KBMOD run.
     config : `kbmod.configuration.SearchConfiguration`
         The configuration for the KBMOD run.
-    n_images : `int`
-        The number of images. This may differ from the length of the ImageStack due
-        to lazy loading.
     n_constituents : `int`
         The number of original images making up the data in this WorkUnit. This might be
         different from the number of images stored in memory if the WorkUnit has been
@@ -85,15 +82,13 @@ class WorkUnit:
         The image data for the KBMOD run.
     config : `kbmod.configuration.SearchConfiguration`
         The configuration for the KBMOD run.
-    num_images : `int`, optional
-        The number of images. This may differ from the length of the ImageStack due
-        to lazy loading.
     wcs : `astropy.wcs.WCS`, optional
         A global WCS for all images in the WorkUnit. Only exists
         if all images have been projected to same pixel space.
-    per_image_wcs : `list`
+    per_image_wcs : `list`, optional
         A list with one WCS for each image in the WorkUnit. Used for when
-        the images have *not* been standardized to the same pixel space.
+        the images have *not* been standardized to the same pixel space. If provided
+        this will the WCS values in org_image_meta
     reprojected : `bool`, optional
         Whether or not the WorkUnit image data has been reprojected.
     per_image_indices : `list` of `list`, optional
@@ -109,7 +104,7 @@ class WorkUnit:
         in lazy mode.
     obstimes : `list[float]`
         The MJD obstimes of the images.
-    org_image_meta : `dict` or `astropy.table.Table`, optional
+    org_image_meta : `astropy.table.Table`, optional
         A table of per-image data for the constituent images.
     """
 
@@ -143,10 +138,10 @@ class WorkUnit:
             self.n_constituents = im_stack.img_count()
 
         # Track the metadata for each constituent image in the WorkUnit. If no constituent
-        # data is provided, this will create an empty array the same size as the original.
+        # data is provided, this will create a table of default values the correct size.
         self.org_img_meta = create_image_metadata(self.n_constituents, data=org_image_meta)
 
-        # Handle WCS input. If per_image_wcs is provided on the command line use that.
+        # Handle WCS input. If per_image_wcs is provided as an argument, use that.
         # If no per_image_wcs values are provided, use the global one.
         self.wcs = wcs
         if per_image_wcs is not None:
@@ -1008,10 +1003,6 @@ def hdu_to_image_metadata_table(hdu):
     data : `astropy.table.Table`
         The table of loaded data.
     """
-    if hdu is None:
-        # Nothing to decode. Return an empty table.
-        return Table()
-
     data = Table(hdu.data)
     all_cols = set(data.colnames)
 

--- a/tests/test_imagecollection.py
+++ b/tests/test_imagecollection.py
@@ -69,6 +69,7 @@ class TestImageCollection(unittest.TestCase):
             "obs_elev",
             "FILTER",
             "IDNUM",
+            "visit",
             "OBSID",
             "DTNSANAM",
             "AIRMASS",
@@ -156,6 +157,14 @@ class TestImageCollection(unittest.TestCase):
         data = self.fitsFactory.get_n(3, spoof_data=True)
         ic = ImageCollection.fromTargets(data)
         wu = ic.toWorkUnit(search_config=SearchConfiguration())
+        self.assertEqual(len(wu), 3)
+
+        # We can retrieve the meta data from the WorkUnit.
+        filter_info = wu.get_constituent_meta("visit")
+        self.assertEqual(len(filter_info), 3)
+        self.assertIsNotNone(filter_info[0])
+
+        # We can write the whole work unit to a file.
         with tempfile.TemporaryDirectory() as dir_name:
             wu.to_fits(f"{dir_name}/test.fits")
 

--- a/tests/test_reprojection.py
+++ b/tests/test_reprojection.py
@@ -19,9 +19,6 @@ class test_reprojection(unittest.TestCase):
         self.test_wunit = WorkUnit.from_fits(self.data_path)
         self.common_wcs = self.test_wunit.get_wcs(0)
 
-        # self.tmp_dir = os.path(tempfile.TemporaryDirectory())
-        # self.test_wunit.to_sharded_fits("test_wunit.fits", self.tmp_dir)
-
     def test_reproject(self):
         # test exception conditions
         self.assertRaises(

--- a/tests/test_wcs_utils.py
+++ b/tests/test_wcs_utils.py
@@ -67,6 +67,13 @@ class test_wcs_conversion(unittest.TestCase):
         self.assertEqual(self.wcs.pixel_shape, wcs2.pixel_shape)
         self.assertTrue(wcs_fits_equal(self.wcs, wcs2))
 
+        # Test that we can serialize and deserialize None.
+        none_str = serialize_wcs(None)
+        self.assertEqual(none_str, "")
+        self.assertIsNone(deserialize_wcs(""))
+        self.assertIsNone(deserialize_wcs("none"))
+        self.assertIsNone(deserialize_wcs("None"))
+
     def test_append_wcs_to_hdu_header(self):
         for use_dictionary in [True, False]:
             if use_dictionary:

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -171,6 +171,32 @@ class test_work_unit(unittest.TestCase):
         for i in range(len(md_table2)):
             self.assertTrue(isinstance(md_table2["wcs"][i], WCS))
 
+    def test_create_image_meta(self):
+        # Empty constituent image data.
+        org_img_meta = WorkUnit.create_image_meta(n_images=3, data=None)
+        self.assertEqual(len(org_img_meta), 3)
+        self.assertTrue("data_loc" in org_img_meta.colnames)
+        self.assertTrue("ebd_wcs" in org_img_meta.colnames)
+        self.assertTrue("geocentric_distance" in org_img_meta.colnames)
+        self.assertTrue("original_wcs" in org_img_meta.colnames)
+
+        # We can create from a dictionary.  In this case we ignore n_images
+        data_dict = {
+            "uri": ["file1", "file2", "file3"],
+            "geocentric_distance": [1.0, 2.0, 3.0],
+        }
+        org_img_meta2 = WorkUnit.create_image_meta(n_images=5, data=data_dict)
+        self.assertEqual(len(org_img_meta2), 3)
+        self.assertTrue("data_loc" in org_img_meta2.colnames)
+        self.assertTrue("ebd_wcs" in org_img_meta2.colnames)
+        self.assertTrue("geocentric_distance" in org_img_meta2.colnames)
+        self.assertTrue("original_wcs" in org_img_meta2.colnames)
+        self.assertTrue("uri" in org_img_meta2.colnames)
+
+        # We need either data or a positive number of images.
+        self.assertRaises(ValueError, WorkUnit.create_image_meta, None, None)
+        self.assertRaises(ValueError, WorkUnit.create_image_meta, None, -1)
+
     def test_save_and_load_fits(self):
         with tempfile.TemporaryDirectory() as dir_name:
             file_path = os.path.join(dir_name, "test_workunit.fits")
@@ -480,7 +506,7 @@ class test_work_unit(unittest.TestCase):
 
         new_wcs = make_fake_wcs(190.0, -7.7888, 500, 700)
         work.org_img_meta["original_wcs"][-1] = new_wcs
-        work.img_meta["per_image_indices"] = [[0], [1], [2], [3, 4], [4]]
+        work._per_image_indices[3] = [3, 4]
 
         res = work.image_positions_to_original_icrs(
             self.indices,


### PR DESCRIPTION
Save the metadata table as its own HDU (instead of saving each individual item in fits headers). This should simplify the addition of new metadata or the removal of unused metadata. This PR does not remove the ability to read the previous fits headers as we want to preserve compatibility with any saved data.

This also incorporates the changes from #740 to pass metadata from an `ImageCollection` to a `WorkUnit`. It current passes the visit field (as requested in #656).

Closes #410 