### PR TITLE
Pass more metadata through results

### DIFF
--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -187,7 +187,7 @@ class SearchRunner:
         keep = self.load_and_filter_results(search, config)
         return keep
 
-    def run_search(self, config, stack, trj_generator=None, wcs=None):
+    def run_search(self, config, stack, trj_generator=None, wcs=None, extra_meta=None):
         """This function serves as the highest-level python interface for starting
         a KBMOD search given an ImageStack and SearchConfiguration.
 
@@ -202,6 +202,8 @@ class SearchRunner:
             If None uses the default EclipticCenteredSearch
         wcs : `astropy.wcs.WCS`, optional
             A global WCS for all images in the search.
+        extra_meta : `dict`, optional
+            Any additional metadata to save as part of the results file.
 
         Returns
         -------
@@ -256,11 +258,11 @@ class SearchRunner:
 
         # Create and save any additional meta data that should be saved with the results.
         num_img = stack.img_count()
-        meta = {
-            "num_img": num_img,
-            "dims": (stack.get_width(), stack.get_height()),
-            "mjd_mid": [stack.get_obstime(i) for i in range(num_img)],
-        }
+
+        meta_to_save = extra_meta.copy()
+        meta_to_save["num_img"] = num_img
+        meta_to_save["dims"] = stack.get_width(), stack.get_height()
+        meta_to_save["mjd_mid"] = [stack.get_obstime(i) for i in range(num_img)]
 
         # Save the results in as an ecsv file and/or a legacy text file.
         if config["legacy_filename"] is not None:
@@ -270,9 +272,11 @@ class SearchRunner:
         if config["result_filename"] is not None:
             logger.info(f"Saving results table to {config['result_filename']}")
             if not config["save_all_stamps"]:
-                keep.write_table(config["result_filename"], cols_to_drop=["all_stamps"], extra_meta=meta)
+                keep.write_table(
+                    config["result_filename"], cols_to_drop=["all_stamps"], extra_meta=meta_to_save
+                )
             else:
-                keep.write_table(config["result_filename"], extra_meta=meta)
+                keep.write_table(config["result_filename"], extra_meta=meta_to_save)
         full_timer.stop()
 
         return keep
@@ -292,5 +296,16 @@ class SearchRunner:
         """
         trj_generator = create_trajectory_generator(work.config, work_unit=work)
 
+        # Extract extra metadata. We do not use the full org_image_meta table from the WorkUnit
+        # because this can be very large and varies with the source. Instead we only save a
+        # few pre-defined fields to the results data.
+        extra_meta = work.get_constituent_meta(["visit", "filter"])
+
         # Run the search.
-        return self.run_search(work.config, work.im_stack, trj_generator=trj_generator, wcs=work.wcs)
+        return self.run_search(
+            work.config,
+            work.im_stack,
+            trj_generator=trj_generator,
+            wcs=work.wcs,
+            extra_meta=extra_meta,
+        )

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 import os
 import warnings
 from pathlib import Path
@@ -182,19 +183,31 @@ class WorkUnit:
         return len(self._per_image_indices)
 
     def get_constituent_meta(self, column):
-        """Get the meta data values of a given column for all the constituent images.
+        """Get the metadata values of a given column or a list of columns
+        for all the constituent images.
 
         Parameters
         ----------
-        column : `str`
-            The column name to fetch.
+        column : `str`, or Iterable
+            The column name(s) to fetch.
 
         Returns
         -------
-        data : `list`
-            A list of the meta-data for each constituent image.
+        data : `list` or `dict`
+            If a single string column name is provided, the function returns the
+            values in a list. Otherwise it returns a dictionary, mapping
+            each column name to its values.
         """
-        return list(self.org_img_meta[column].data)
+        if isinstance(column, str):
+            return self.org_img_meta[column].data.tolist()
+        elif isinstance(column, Iterable):
+            results = {}
+            for col in column:
+                if col in self.org_img_meta.colnames:
+                    results[col] = self.org_img_meta[col].data.tolist()
+            return results
+        else:
+            raise TypeError(f"Unsupported column type {type(column)}")
 
     def get_wcs(self, img_num):
         """Return the WCS for the a given image. Alway prioritizes

--- a/tests/test_regression_test.py
+++ b/tests/test_regression_test.py
@@ -266,7 +266,10 @@ def perform_search(im_stack, res_filename, default_psf):
     }
     config = SearchConfiguration.from_dict(input_parameters)
 
-    wu = WorkUnit(im_stack=im_stack, config=config)  # , wcs=fake_wcs)
+    # Create fake visit metadata to confirm we pass it along.
+    wu = WorkUnit(im_stack=im_stack, config=config)
+    wu.org_img_meta["visit"] = [f"img_{i}" for i in range(im_stack.img_count())]
+
     rs = SearchRunner()
     rs.run_search_from_work_unit(wu)
 
@@ -340,6 +343,10 @@ def run_full_test():
         assert loaded_data.table.meta["num_img"] == num_times
         assert loaded_data.table.meta["dims"] == (stack.get_width(), stack.get_height())
         assert np.allclose(loaded_data.table.meta["mjd_mid"], times)
+        assert np.array_equal(
+            loaded_data.table.meta["visit"],
+            [f"img_{i}" for i in range(stack.img_count())],
+        )
 
         # Determine which trajectories we did not recover.
         overlap = find_unique_overlap(trjs, found, 3.0, [0.0, 2.0])

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -270,6 +270,13 @@ class test_work_unit(unittest.TestCase):
             npt.assert_array_equal(work2.get_constituent_meta("int_index"), extra_meta["int_index"])
             npt.assert_array_equal(work2.get_constituent_meta("data_loc"), self.constituent_images)
 
+            # Check that we can retrieve the extra metadata in a single request.
+            meta2 = work2.get_constituent_meta(["uri", "int_index", "nonexistent_column"])
+            self.assertEqual(len(meta2), 2)
+            npt.assert_array_equal(meta2["uri"], extra_meta["uri"])
+            npt.assert_array_equal(meta2["int_index"], extra_meta["int_index"])
+            self.assertFalse("nonexistent_column" in extra_meta)
+
             # We throw an error if we try to overwrite a file with overwrite=False
             self.assertRaises(FileExistsError, work.to_fits, file_path)
 


### PR DESCRIPTION
Closes #656 

Pass the metadata that is being saved in the `WorkUnit` (PR #742) through to the results data structure and write it to the results.