### PR TITLE
Add a neighborhood search to the TrajectoryExplorer

### DIFF
--- a/notebooks/TrajectoryExplorer.ipynb
+++ b/notebooks/TrajectoryExplorer.ipynb
@@ -244,6 +244,30 @@
     "for i in range(len(fake_times)):\n",
     "    print(f\"Time {i} is valid = {result['obs_valid'][0][i]}.\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Neighborhood Searches\n",
+    "\n",
+    "The `TrajectoryExplorer` can also be used to perform a hyper-localized search.  This search effectively uses a small neighborhood around a given trajectory (both in terms of starting pixel and velocities) and returns all results from this neighborhood. This localized set can be used to:\n",
+    "1) refine trajectories by searching a finer parameter space around the best results found by the initial search, or\n",
+    "2) collect a distribution of trajectories and their likelihoods around a single result.\n",
+    "For this search, the `TrajectoryExplorer` does not perform any filtering, so it will return all trajectories and their likelihoods (even one <= -1.0)\n",
+    "\n",
+    "Only basic statistics, such as likelihood and flux, are returned from the search. Stamps and lightcurves are not computed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "samples = explorer.evaluate_around_linear_trajectory(50, 60, 5.0, -2.0, pixel_radius=5)\n",
+    "print(samples[0:10])"
+   ]
   }
  ],
  "metadata": {

--- a/src/kbmod/configuration.py
+++ b/src/kbmod/configuration.py
@@ -1,3 +1,4 @@
+import copy
 import math
 
 from astropy.io import fits
@@ -83,6 +84,10 @@ class SearchConfiguration:
         for key, value in self._params.items():
             result += f"{key}: {value}\n"
         return result
+
+    def copy(self):
+        """Create a new deep copy of the configuration."""
+        return copy.deepcopy(self)
 
     def set(self, param, value, warn_on_unknown=False):
         """Sets the value of a specific parameter.

--- a/src/kbmod/search/kernels/kernels.cu
+++ b/src/kbmod/search/kernels/kernels.cu
@@ -251,7 +251,7 @@ __global__ void searchFilterImages(PsiPhiArrayMeta psi_phi_meta, void *psi_phi_v
     for (int r = 0; r < params.results_per_pixel; ++r) {
         results[base_index + r].x = x;
         results[base_index + r].y = y;
-        results[base_index + r].lh = -1.0;
+        results[base_index + r].lh = -FLT_MAX;
     }
 
     // For each trajectory we'd like to search
@@ -274,10 +274,9 @@ __global__ void searchFilterImages(PsiPhiArrayMeta psi_phi_meta, void *psi_phi_v
             continue;
 
         // Insert the new trajectory into the sorted list of final results.
-        // Only sort the values with valid likelihoods.
         Trajectory temp;
         for (unsigned int r = 0; r < params.results_per_pixel; ++r) {
-            if (curr_trj.lh > results[base_index + r].lh && curr_trj.lh > -1.0) {
+            if (curr_trj.lh > results[base_index + r].lh) {
                 temp = results[base_index + r];
                 results[base_index + r] = curr_trj;
                 curr_trj = temp;

--- a/src/kbmod/search/pydocs/stack_search_docs.h
+++ b/src/kbmod/search/pydocs/stack_search_docs.h
@@ -30,6 +30,10 @@ static const auto DOC_StackSearch_set_min_lh = R"doc(
       The minimum likelihood value for a trajectory to be returned.
   )doc";
 
+static const auto DOC_StackSearch_disable_gpu_sigmag_filter = R"doc(
+  Turns off the on-GPU sigma-G filtering.
+  )doc";
+          
 static const auto DOC_StackSearch_enable_gpu_sigmag_filter = R"doc(
   Enable on-GPU sigma-G filtering.
 

--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -66,6 +66,10 @@ void StackSearch::enable_gpu_sigmag_filter(std::vector<float> percentiles, float
     params.sigmag_coeff = sigmag_coeff;
     params.min_lh = min_lh;
 }
+    
+void StackSearch::disable_gpu_sigmag_filter() {
+    params.do_sigmag_filter = false;
+}
 
 void StackSearch::enable_gpu_encoding(int encode_num_bytes) {
     // If changing a setting that would impact the search data encoding, clear the cached values.
@@ -310,6 +314,8 @@ static void stack_search_bindings(py::module& m) {
             .def("set_min_lh", &ks::set_min_lh, pydocs::DOC_StackSearch_set_min_lh)
             .def("set_results_per_pixel", &ks::set_results_per_pixel,
                  pydocs::DOC_StackSearch_set_results_per_pixel)
+            .def("disable_gpu_sigmag_filter", &ks::disable_gpu_sigmag_filter,
+                 pydocs::DOC_StackSearch_disable_gpu_sigmag_filter)
             .def("enable_gpu_sigmag_filter", &ks::enable_gpu_sigmag_filter,
                  pydocs::DOC_StackSearch_enable_gpu_sigmag_filter)
             .def("enable_gpu_encoding", &ks::enable_gpu_encoding, pydocs::DOC_StackSearch_enable_gpu_encoding)

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -40,6 +40,7 @@ public:
     // Parameter setters used to control the searches.
     void set_min_obs(int new_value);
     void set_min_lh(float new_value);
+    void disable_gpu_sigmag_filter();
     void enable_gpu_sigmag_filter(std::vector<float> percentiles, float sigmag_coeff, float min_lh);
     void enable_gpu_encoding(int num_bytes);
     void set_start_bounds_x(int x_min, int x_max);

--- a/src/kbmod/trajectory_explorer.py
+++ b/src/kbmod/trajectory_explorer.py
@@ -3,8 +3,10 @@ import numpy as np
 from kbmod.configuration import SearchConfiguration
 from kbmod.filters.sigma_g_filter import apply_clipped_sigma_g, SigmaGClipping
 from kbmod.results import Results
-from kbmod.search import StackSearch, StampCreator, Logging
+from kbmod.run_search import configure_kb_search_stack
+from kbmod.search import DebugTimer, StackSearch, StampCreator, Logging
 from kbmod.filters.stamp_filters import append_all_stamps, append_coadds
+from kbmod.trajectory_generator import PencilSearch
 from kbmod.trajectory_utils import make_trajectory_from_ra_dec
 
 
@@ -42,9 +44,24 @@ class TrajectoryExplorer:
         # Allocate and configure the StackSearch object.
         self.search = None
 
-    def initialize_data(self):
-        """Perform any needed initialization and preprocessing on the images."""
+    def initialize_data(self, config=None):
+        """Initialize the data, including applying the configuration parameters.
+
+        Parameters
+        ----------
+        config : `SearchConfiguration`, optional
+            Any custom configuration parameters to use for this run.
+            If ``None`` uses the default configuration parameters.
+        """
+        if config is None:
+            config = self.config
+
         if self._data_initalized:
+            # Always reapply the configuration parameters if in case we used custom
+            # ones on a previous search.
+            configure_kb_search_stack(self.search, config)
+
+            # Nothing else to do
             return
 
         # If we are using an encoded image representation on GPU, enable it and
@@ -55,6 +72,7 @@ class TrajectoryExplorer:
 
         # Allocate the search structure.
         self.search = StackSearch(self.im_stack)
+        configure_kb_search_stack(self.search, config)
 
         self._data_initalized = True
 
@@ -120,6 +138,82 @@ class TrajectoryExplorer:
         """
         trj = make_trajectory_from_ra_dec(ra, dec, v_ra, v_dec, wcs)
         return self.evaluate_linear_trajectory(trj.x, trj.y, trj.vx, trj.vy)
+
+    def evaluate_around_linear_trajectory(
+        self,
+        x,
+        y,
+        vx,
+        vy,
+        pixel_radius=5,
+        max_ang_offset=0.2618,
+        ang_step=0.035,
+        max_vel_offset=10.0,
+        vel_step=0.5,
+    ):
+        """Evaluate all the trajectories within a local neighborhood of the given trajectory.
+        No filtering is done at all.
+
+        Parameters
+        ----------
+        x : `int`
+            The starting x pixel of the trajectory.
+        y : `int`
+            The starting y pixel of the trajectory.
+        vx : `float`
+            The x velocity of the trajectory in pixels per day.
+        vy : `float`
+            The y velocity of the trajectory in pixels per day.
+        pixel_radius : `int`
+            The number of pixels to evaluate to each side of the Trajectory's starting pixel.
+        max_ang_offset : `float`
+            The maximum offset of a candidate trajectory from the original (in radians)
+        ang_step : `float`
+            The step size to explore for each angle (in radians)
+        max_vel_offset : `float`
+            The maximum offset of the velocity's magnitude from the original (in pixels per day)
+        vel_step : `float`
+            The step size to explore for each velocity magnitude (in pixels per day)
+
+        Returns
+        -------
+        result : `Results`
+            The results table with a single row and all the columns filled out.
+        """
+        if pixel_radius < 0:
+            raise ValueError(f"Pixel radius must be >= 0. Got {pixel_radius}")
+        num_pixels = (2 * pixel_radius + 1) * (2 * pixel_radius + 1)
+        logger.debug(f"Testing {num_pixels} starting pixels.")
+
+        # Create a pencil search around the given trajectory.
+        trj_generator = PencilSearch(vx, vy, max_ang_offset, ang_step, max_vel_offset, vel_step)
+        num_trj = len(trj_generator)
+        logger.debug(f"Exploring {num_trj} trajectories per starting pixel.")
+
+        # Set the search bounds to right around the trajectory's starting position and
+        # turn off all filtering.
+        reduced_config = self.config.copy()
+        reduced_config.set("x_pixel_bounds", [x - pixel_radius, x + pixel_radius + 1])
+        reduced_config.set("y_pixel_bounds", [y - pixel_radius, y + pixel_radius + 1])
+        reduced_config.set("results_per_pixel", min(num_trj, 10_000))
+        reduced_config.set("gpu_filter", False)
+        reduced_config.set("num_obs", 1)
+        reduced_config.set("max_lh", 1e25)
+        reduced_config.set("lh_level", -1e25)
+        self.initialize_data(config=reduced_config)
+
+        # Do the actual search.
+        search_timer = DebugTimer("grid search", logger)
+        candidates = [trj for trj in trj_generator]
+        self.search.search_all(candidates, int(reduced_config["num_obs"]))
+        search_timer.stop()
+
+        # Load all of the results without any filtering.
+        logger.debug(f"Loading {num_pixels * num_trj} results.")
+        trjs = self.search.get_results(0, num_pixels * num_trj)
+        results = Results.from_trajectories(trjs)
+
+        return results
 
     def apply_sigma_g(self, result):
         """Apply sigma G clipping to a single ResultRow. Modifies the row in-place.

--- a/src/kbmod/trajectory_generator.py
+++ b/src/kbmod/trajectory_generator.py
@@ -157,6 +157,9 @@ class SingleVelocitySearch(TrajectoryGenerator):
     def __str__(self):
         return f"SingleVelocitySearch: vx={self.vx}, vy={self.vy}"
 
+    def __len__(self):
+        return 1
+
     def generate(self, *args, **kwargs):
         """Produces a single candidate trajectory to test.
 
@@ -220,6 +223,9 @@ class VelocityGridSearch(TrajectoryGenerator):
             f"    Vel Y: [{self.min_vy}, {self.max_vy}] in {self.vy_steps} steps."
         )
 
+    def __len__(self):
+        return self.vy_steps * self.vx_steps
+
     def generate(self, *args, **kwargs):
         """Produces a single candidate trajectory to test.
 
@@ -280,11 +286,13 @@ class PencilSearch(TrajectoryGenerator):
         self.min_ang = self.center_ang - max_ang_offset
         self.max_ang = self.center_ang + max_ang_offset
         self.ang_step = ang_step
+        self.ang_array = np.arange(self.min_ang, self.max_ang + 1e-8, self.ang_step)
 
         self.center_vel = np.sqrt(vx * vx + vy * vy)
         self.min_vel = np.max([self.center_vel - max_vel_offset, 0.0])
         self.max_vel = self.center_vel + max_vel_offset
         self.vel_step = vel_step
+        self.vel_array = np.arange(self.min_vel, self.max_vel + 1e-8, self.vel_step)
 
     def __repr__(self):
         return (
@@ -300,6 +308,9 @@ class PencilSearch(TrajectoryGenerator):
             f"    Ang: [{self.min_ang}, {self.max_ang}) in {self.ang_step} sized steps."
         )
 
+    def __len__(self):
+        return len(self.ang_array) * len(self.vel_array)
+
     def generate(self, *args, **kwargs):
         """Produces a single candidate trajectory to test.
 
@@ -308,8 +319,8 @@ class PencilSearch(TrajectoryGenerator):
         candidate : `Trajectory`
             A ``Trajectory`` to test at each pixel.
         """
-        for ang in np.arange(self.min_ang, self.max_ang + 1e-8, self.ang_step):
-            for vel in np.arange(self.min_vel, self.max_vel + 1e-8, self.vel_step):
+        for ang in self.ang_array:
+            for vel in self.vel_array:
                 vx = np.cos(ang) * vel
                 vy = np.sin(ang) * vel
 
@@ -367,6 +378,9 @@ class KBMODV1Search(TrajectoryGenerator):
             f"    Vel: [{self.min_vel}, {self.max_vel}) in {self.vel_steps} steps.\n"
             f"    Ang: [{self.min_ang}, {self.max_ang}) in {self.ang_steps} steps."
         )
+
+    def __len__(self):
+        return self.ang_steps * self.vel_steps
 
     def generate(self, *args, **kwargs):
         """Produces a single candidate trajectory to test.
@@ -532,6 +546,9 @@ class EclipticCenteredSearch(TrajectoryGenerator):
                    Offsets = {self.angles[0]} to {self.angles[1]}
                    [{self.min_ang}, {self.max_ang}] in {self.angles[2]} steps."""
 
+    def __len__(self):
+        return self.angles[2] * self.velocities[2]
+
     def generate(self, *args, **kwargs):
         """Produces a single candidate trajectory to test.
 
@@ -592,6 +609,9 @@ class RandomVelocitySearch(TrajectoryGenerator):
 
     def __str__(self):
         return self.__repr__()
+
+    def __len__(self):
+        return self.samples_left
 
     def reset_sample_count(self, max_samples):
         """Reset the counter of samples left.

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -46,6 +46,21 @@ class test_configuration(unittest.TestCase):
         self.assertEqual(config["im_filepath"], "Here2")
         self.assertEqual(config["num_obs"], 5)
 
+    def test_copy(self):
+        d = {"im_filepath": "Here2", "encode_num_bytes": -1}
+        config = SearchConfiguration.from_dict(d)
+
+        # Create a copy and change values.
+        config2 = config.copy()
+        config2.set("im_filepath", "who knows?")
+        config2.set("encode_num_bytes", 2000)
+        self.assertEqual(config2["im_filepath"], "who knows?")
+        self.assertEqual(config2["encode_num_bytes"], 2000)
+
+        # Confirm the original configuration is unchanged.
+        self.assertEqual(config["im_filepath"], "Here2")
+        self.assertEqual(config["encode_num_bytes"], -1)
+
     def test_from_hdu(self):
         t = Table(
             [

--- a/tests/test_trajectory_generator.py
+++ b/tests/test_trajectory_generator.py
@@ -25,11 +25,13 @@ class test_trajectory_generator(unittest.TestCase):
         self.assertEqual(len(trjs), 1)
         self.assertEqual(trjs[0].vx, 10.0)
         self.assertEqual(trjs[0].vy, 5.0)
+        self.assertEqual(len(gen), 1)
 
     def test_VelocityGridSearch(self):
         gen = VelocityGridSearch(3, 0.0, 2.0, 3, -0.25, 0.25)
         expected_x = [0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 0.0, 1.0, 2.0]
         expected_y = [-0.25, -0.25, -0.25, 0.0, 0.0, 0.0, 0.25, 0.25, 0.25]
+        self.assertEqual(len(gen), 9)
 
         trjs = [trj for trj in gen]
         self.assertEqual(len(trjs), 9)
@@ -59,6 +61,7 @@ class test_trajectory_generator(unittest.TestCase):
             max_vel_offset=5.0,
             vel_step=2.5,
         )
+        self.assertEqual(len(gen), 25)
 
         trjs = [trj for trj in gen]
         self.assertEqual(len(trjs), 25)
@@ -78,6 +81,7 @@ class test_trajectory_generator(unittest.TestCase):
         gen = KBMODV1Search(3, 0.0, 3.0, 2, -0.25, 0.25)
         expected_x = [0.0, 0.9689, 1.9378, 0.0, 1.0, 2.0]
         expected_y = [0.0, -0.247, -0.4948, 0.0, 0.0, 0.0]
+        self.assertEqual(len(gen), 6)
 
         trjs = [trj for trj in gen]
         self.assertEqual(len(trjs), 6)
@@ -102,6 +106,7 @@ class test_trajectory_generator(unittest.TestCase):
         gen = EclipticCenteredSearch(
             [0.0, 2.0, 3], [-45.0, 45.0, 3], angle_units="degree", given_ecliptic=0.0
         )
+        self.assertEqual(len(gen), 9)
         expected_x = [0.0, 0.707107, 1.41421, 0.0, 1.0, 2.0, 0.0, 0.707107, 1.41421]
         expected_y = [0.0, -0.707107, -1.41421, 0.0, 0.0, 0.0, 0.0, 0.707107, 1.41421]
 


### PR DESCRIPTION
Add a search that will perform a hyper-localized search.  This search effectively uses a small neighborhood around a given trajectory (both in terms of starting pixel and velocities) and returns all results from this neighborhood. This localized set can be used to:
- refine trajectories by searching a finer parameter space around the best results found by the initial search, or
- collect a distribution of trajectories and their likelihoods around a single result.

As part of this change we remove a small optimization from the core search (which did not bother to sort trajectories with LH <= -1.0 since we knew they would be filtered eventually). This removes that optimization so we can get the full grid of nearby trajectories.