### PR TITLE
Only run test_core_search_exact with GPUs

### DIFF
--- a/tests/test_core_search_exact.py
+++ b/tests/test_core_search_exact.py
@@ -11,6 +11,7 @@ from kbmod.search import *
 from kbmod.trajectory_generator import VelocityGridSearch
 
 
+@unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
 class test_search_exact(unittest.TestCase):
     def test_core_search_exact(self):
         # image properties


### PR DESCRIPTION
`test_core_search_exact` presumes GPU availability, so only run it with GPU access.