### PR TITLE
Implement SigmaG filtering in JAX

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dynamic = ["version"]
 dependencies = [
     "astropy>=5.1",
     "astroquery>=0.4.6",
+    "jax",
     "joblib>=1.4",
     "matplotlib>=3.5",
     "numpy<2.0",

--- a/src/kbmod/filters/sigma_g_filter.py
+++ b/src/kbmod/filters/sigma_g_filter.py
@@ -182,7 +182,7 @@ class SigmaGClipping:
             A N x T matrix of Booleans indicating if each point is valid (True)
             or has been filtered (False).
         """
-        inds_valid = self.sigma_g_jax_fn(jnp.asarray(lh))
+        inds_valid = self.sigma_g_jax_fn(jnp.asarray(lh)).block_until_ready()
         return inds_valid
 
 


### PR DESCRIPTION
Change the numpy vectorized implementation of sigma G filtering to use JAX and vmap. This produced roughly a 2000x speedup on sigma-G filtering on timing tests on Baldur.

Also makes one behavior change. Previously sigma-G filtering with clipped_negative=True would filter out zero values of LH (but NOT all negative values). This does not make sense with the goal of sigma-G, so I have removed it.