### PR TITLE
Cleanup unused code in LayeredImage

### DIFF
--- a/src/kbmod/search/layered_image.cpp
+++ b/src/kbmod/search/layered_image.cpp
@@ -196,19 +196,6 @@ RawImage LayeredImage::generate_phi_image() {
     return result;
 }
 
-double LayeredImage::compute_fraction_masked() const {
-    double masked_count = 0.0;
-    double total_count = 0.0;
-
-    for (int j = 0; j < height; ++j) {
-        for (int i = 0; i < width; ++i) {
-            if (!science_pixel_has_data({j, i})) masked_count += 1.0;
-            total_count++;
-        }
-    }
-    return masked_count / total_count;
-}
-
 #ifdef Py_PYTHON_H
 static void layered_image_bindings(py::module& m) {
     using li = search::LayeredImage;
@@ -268,8 +255,6 @@ static void layered_image_bindings(py::module& m) {
             .def("get_npixels", &li::get_npixels, pydocs::DOC_LayeredImage_get_npixels)
             .def("get_obstime", &li::get_obstime, pydocs::DOC_LayeredImage_get_obstime)
             .def("set_obstime", &li::set_obstime, pydocs::DOC_LayeredImage_set_obstime)
-            .def("compute_fraction_masked", &li::compute_fraction_masked,
-                 pydocs::DOC_LayeredImage_compute_fraction_masked)
             .def("generate_psi_image", &li::generate_psi_image, pydocs::DOC_LayeredImage_generate_psi_image)
             .def("generate_phi_image", &li::generate_phi_image, pydocs::DOC_LayeredImage_generate_phi_image);
 }

--- a/src/kbmod/search/layered_image.cpp
+++ b/src/kbmod/search/layered_image.cpp
@@ -119,22 +119,6 @@ void LayeredImage::apply_mask(int flags) {
     variance.apply_mask(flags, mask);
 }
 
-void LayeredImage::subtract_template(RawImage& sub_template) {
-    assert_sizes_equal(sub_template.get_width(), width, "template width");
-    assert_sizes_equal(sub_template.get_height(), height, "template height");
-    const uint64_t num_pixels = get_npixels();
-
-    logging::getLogger("kbmod.search.layered_image")->debug("Subtracting template image.");
-
-    float* sci_pixels = science.data();
-    float* tem_pixels = sub_template.data();
-    for (uint64_t i = 0; i < num_pixels; ++i) {
-        if (pixel_value_valid(sci_pixels[i]) && pixel_value_valid(tem_pixels[i])) {
-            sci_pixels[i] -= tem_pixels[i];
-        }
-    }
-}
-
 void LayeredImage::set_science(RawImage& im) {
     assert_sizes_equal(im.get_width(), width, "science layer width");
     assert_sizes_equal(im.get_height(), height, "science layer height");
@@ -268,7 +252,6 @@ static void layered_image_bindings(py::module& m) {
                  })
             .def("binarize_mask", &li::binarize_mask, pydocs::DOC_LayeredImage_binarize_mask)
             .def("apply_mask", &li::apply_mask, pydocs::DOC_LayeredImage_apply_mask)
-            .def("sub_template", &li::subtract_template, pydocs::DOC_LayeredImage_sub_template)
             .def("get_science", &li::get_science, py::return_value_policy::reference_internal,
                  pydocs::DOC_LayeredImage_get_science)
             .def("get_mask", &li::get_mask, py::return_value_policy::reference_internal,

--- a/src/kbmod/search/layered_image.h
+++ b/src/kbmod/search/layered_image.h
@@ -68,9 +68,6 @@ public:
     void binarize_mask(int flags_to_keep);
     void apply_mask(int flags);
 
-    // Subtracts a template image from the science layer.
-    void subtract_template(RawImage& sub_template);
-
     // Setter functions for the individual layers.
     void set_science(RawImage& im);
     void set_mask(RawImage& im);

--- a/src/kbmod/search/layered_image.h
+++ b/src/kbmod/search/layered_image.h
@@ -83,9 +83,6 @@ public:
     RawImage generate_psi_image();
     RawImage generate_phi_image();
 
-    // Debugging and statistics functions.
-    double compute_fraction_masked() const;
-
 private:
     unsigned width;
     unsigned height;

--- a/src/kbmod/search/pydocs/layered_image_docs.h
+++ b/src/kbmod/search/pydocs/layered_image_docs.h
@@ -218,16 +218,6 @@ static const auto DOC_LayeredImage_generate_phi_image = R"doc(
       A ``RawImage`` of the same dimensions as the ``LayeredImage``.
   )doc";
 
-static const auto DOC_LayeredImage_compute_fraction_masked = R"doc(
-  Computes the fraction of pixels in the layered image that are masked.
-  This can be used for debugging purposes.
-
-  Returns
-  -------
-  value : `double`
-      The fraction of pixels in the science image that are masked.
-  )doc";
-
 }  // namespace pydocs
 
 #endif /* LAYEREDIMAGE_DOCS  */

--- a/src/kbmod/search/pydocs/layered_image_docs.h
+++ b/src/kbmod/search/pydocs/layered_image_docs.h
@@ -66,10 +66,6 @@ static const auto DOC_LayeredImage_apply_mask = R"doc(
   call binarize_mask() first.
   )doc";
 
-static const auto DOC_LayeredImage_sub_template = R"doc(
-  Subtract given image template
-  )doc";
-
 static const auto DOC_LayeredImage_get_science = R"doc(
   Returns the science layer raw_image.
   )doc";

--- a/tests/test_layered_image.py
+++ b/tests/test_layered_image.py
@@ -181,20 +181,6 @@ class test_LayeredImage(unittest.TestCase):
                 self.assertEqual(pixel_value_valid(pix_val), expected)
                 self.assertEqual(self.image.science_pixel_has_data(y, x), expected)
 
-    def test_compute_fraction_masked(self):
-        total_pixels = self.width * self.height
-
-        # Mask 50 pixels
-        for y in range(0, 10):
-            for x in range(0, 5):
-                self.image.mask_pixel(y, x)
-        self.assertAlmostEqual(self.image.compute_fraction_masked(), 50.0 / total_pixels)
-
-        # Mask another 25 pixels.
-        for x in range(3, 28):
-            self.image.mask_pixel(12, x)
-        self.assertAlmostEqual(self.image.compute_fraction_masked(), 75.0 / total_pixels)
-
     def test_binarize_mask(self):
         # Mask out a range of pixels.
         mask = self.image.get_mask()

--- a/tests/test_layered_image.py
+++ b/tests/test_layered_image.py
@@ -284,39 +284,6 @@ class test_LayeredImage(unittest.TestCase):
                 else:
                     self.assertFalse(pixel_value_valid(phi.get_pixel(y, x)))
 
-    def test_subtract_template(self):
-        sci = self.image.get_science()
-        sci.mask_pixel(7, 10)
-        sci.mask_pixel(7, 11)
-        sci.set_pixel(7, 12, math.nan)
-        sci.set_pixel(7, 13, np.nan)
-        old_sci = RawImage(sci.image.copy())  # Make a copy.
-
-        template = RawImage(self.image.get_width(), self.image.get_height())
-        template.set_all(0.0)
-        for h in range(sci.height):
-            for w in range(4, sci.width):
-                template.set_pixel(h, w, 0.01 * h)
-        self.image.sub_template(template)
-
-        for y in range(sci.height):
-            for x in range(sci.width):
-                if y == 7 and (x >= 10 and x <= 13):
-                    self.assertFalse(sci.pixel_has_data(y, x))
-                elif x < 4:
-                    val1 = old_sci.get_pixel(y, x)
-                    val2 = sci.get_pixel(y, x)
-                    self.assertEqual(val1, val2)
-                else:
-                    val1 = old_sci.get_pixel(y, x) - 0.01 * y
-                    val2 = sci.get_pixel(y, x)
-                    self.assertAlmostEqual(val1, val2, delta=1e-5)
-
-        # Test that we fail when the template size does not match.
-        template2 = RawImage(self.image.get_width(), self.image.get_height() + 1)
-        template2.set_all(0.0)
-        self.assertRaises(RuntimeError, self.image.sub_template, template2)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Remove two unused functions from `LayeredImage`:
- `subtract_template()` is from when image differencing was done in KBMOD (before version 0.5)
- `compute_fraction_masked()` is a debugging function that was not very useful.