### PR TITLE
Remove verification step for standardizer test

### DIFF
--- a/tests/test_imagecollection.py
+++ b/tests/test_imagecollection.py
@@ -117,7 +117,7 @@ class TestImageCollection(unittest.TestCase):
         tmpdir = tempfile.mkdtemp()
         for i, hdul in enumerate(hduls):
             fname = os.path.join(tmpdir, f"{i:0>3}.fits")
-            hdul.writeto(fname)
+            hdul.writeto(fname, output_verify="ignore")
             hdul.close()
         ic2 = ImageCollection.fromDir(tmpdir)
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -278,7 +278,6 @@ class test_results(unittest.TestCase):
         self.assertFalse(np.any(nums_is_empty))
 
         pairs_is_empty = table.is_empty_value("pairs")
-        print(pairs_is_empty)
         self.assertTrue(np.array_equal(pairs_is_empty, expected))
 
     def test_filter_by_index(self):

--- a/tests/test_standardizer.py
+++ b/tests/test_standardizer.py
@@ -129,7 +129,7 @@ class TestStandardizer(unittest.TestCase):
         # Test from path
         hdul = FitsFactory.mock_fits(spoof_data=True)
         tmpf = tempfile.NamedTemporaryFile(suffix=".fits", delete=False)
-        hdul.writeto(tmpf.file, overwrite=True)
+        hdul.writeto(tmpf.file, output_verify="ignore", overwrite=True)
         hdul.close()
         tmpf.close()
 
@@ -176,7 +176,7 @@ class TestKBMODV1(unittest.TestCase):
         # Test from path
         hdul = FitsFactory.mock_fits(spoof_data=True)
         fits_file = tempfile.NamedTemporaryFile(suffix=".fits", delete=False)
-        hdul.writeto(fits_file.file, overwrite=True)
+        hdul.writeto(fits_file.file, output_verify="ignore", overwrite=True)
         hdul.close()
         fits_file.close()
 


### PR DESCRIPTION
The verification step is failing for this specific mocked data for the standardizer tests with astropy 7.0.