### PR TITLE
Breaking out helper functions

### DIFF
--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -2,6 +2,7 @@
 and helper functions for filtering and maintaining consistency between different attributes in each row.
 """
 
+import copy
 import csv
 import logging
 import numpy as np
@@ -131,6 +132,10 @@ class Results:
         if "obs_valid" in self.table.colnames:
             return self.table["obs_valid"].shape[1]
         return 0
+
+    def copy(self):
+        """Return a deep copy of the current Results object."""
+        return copy.deepcopy(self)
 
     @classmethod
     def from_trajectories(cls, trajectories, track_filtered=False):

--- a/tests/test_regression_test.py
+++ b/tests/test_regression_test.py
@@ -20,142 +20,11 @@ from kbmod.fake_data.fake_data_creator import add_fake_object, make_fake_layered
 from kbmod.results import Results
 from kbmod.run_search import SearchRunner
 from kbmod.search import *
+from kbmod.trajectory_utils import match_trajectory_sets
 from kbmod.wcs_utils import make_fake_wcs_info
 from kbmod.work_unit import WorkUnit
 
 logger = logging.getLogger(__name__)
-
-
-def ave_trajectory_distance(trjA, trjB, times=[0.0]):
-    """Evaluate the average distance between two trajectories (in pixels)
-    at different times.
-
-    Parameters
-    ----------
-    trjA : `kbmod.search.Trajectory`
-        The first Trajectory to evaluate.
-    trjB : `kbmod.search.Trajectory`
-        The second Trajectory to evaluate.
-    times : `list`
-        The list of zero-shifted times at which to evaluate the
-        matches. The average of the distances at these times
-        are used.
-
-    Returns
-    -------
-    ave_dist : `float`
-        The average distance in pixels.
-    """
-    total = 0.0
-    for t in times:
-        dx = (trjA.x + t * trjA.vx) - (trjB.x + t * trjB.vx)
-        dy = (trjA.y + t * trjA.vy) - (trjB.y + t * trjB.vy)
-        total += math.sqrt(dx * dx + dy * dy)
-
-    ave_dist = total / len(times)
-    return ave_dist
-
-
-def find_unique_overlap(traj_query, traj_base, threshold, times=[0.0]):
-    """Finds the set of trajectories in traj_query that are 'close' to
-    trajectories in traj_base such that each Trajectory in traj_base
-    is used at most once.
-
-    Used to evaluate the performance of algorithms.
-
-    Parameters
-    ----------
-    traj1 : `list`
-        A list of trajectories to compare.
-    traj2 : `list`
-        The second list of trajectories to compare.
-    threshold : float
-        The distance threshold between two observations to count a
-        match (in pixels).
-    times : `list`
-        The list of zero-shifted times at which to evaluate the matches.
-        The average of the distances at these times are used.
-
-    Returns
-    -------
-    results : `list`
-        The list of trajectories that appear in both traj1 and traj2
-        where each Trajectory in each set is only used once.
-    """
-    num_times = len(times)
-    size_base = len(traj_base)
-    used = [False] * size_base
-
-    results = []
-    for query in traj_query:
-        best_dist = 10.0 * threshold
-        best_ind = -1
-
-        # Check the current query against all unused base trajectories.
-        for j in range(size_base):
-            if not used[j]:
-                dist = ave_trajectory_distance(query, traj_base[j], times)
-                if dist < best_dist:
-                    best_dist = dist
-                    best_ind = j
-
-        # If we found a good match, save it.
-        if best_dist <= threshold:
-            results.append(query)
-            used[best_ind] = True
-    return results
-
-
-def find_set_difference(traj_query, traj_base, threshold, times=[0.0]):
-    """Finds the set of trajectories in traj_query that are NOT 'close' to
-    any trajectories in traj_base such that each Trajectory in traj_base
-    is used at most once.
-
-    Used to evaluate the performance of algorithms.
-
-    Parameters
-    ----------
-    traj_query : `list`
-        A list of trajectories to compare.
-    traj_base : `list`
-        The second list of trajectories to compare.
-    threshold : `float`
-        The distance threshold between two observations
-        to count a match (in pixels).
-    times : `list`
-        The list of zero-shifted times at which to evaluate the matches.
-        The average of the distances at these times are used.
-
-    Returns
-    -------
-    results : `list`
-        A list of trajectories that appear in traj_query but not
-        in traj_base where each Trajectory in each set is only
-        used once.
-    """
-    num_times = len(times)
-    size_base = len(traj_base)
-    used = [False] * size_base
-
-    results = []
-    for query in traj_query:
-        best_dist = 10.0 * threshold
-        best_ind = -1
-
-        # Check the current query against all unused base trajectories.
-        for j in range(size_base):
-            if not used[j]:
-                dist = ave_trajectory_distance(query, traj_base[j], times)
-                if dist < best_dist:
-                    best_dist = dist
-                    best_ind = j
-
-        # If we found a good match, save it.
-        if best_dist <= threshold:
-            used[best_ind] = True
-        else:
-            results.append(query)
-    return results
 
 
 def make_fake_ImageStack(times, trjs, psf_vals):
@@ -356,12 +225,13 @@ def run_full_test():
         )
 
         # Determine which trajectories we did not recover.
-        overlap = find_unique_overlap(trjs, found, 3.0, [0.0, 2.0])
-        missing = find_set_difference(trjs, found, 3.0, [0.0, 2.0])
+        matches = match_trajectory_sets(trjs, found, 3.0, [0.0, 2.0])
+        overlap = np.where(matches > -1)[0]
+        missing = np.where(matches == -1)[0]
 
         logger.debug("\nRecovered %i matching trajectories:" % len(overlap))
         for x in overlap:
-            logger.debug(x)
+            logger.debug(trjs[x])
 
         if len(missing) == 0:
             logger.debug("*** PASSED ***")
@@ -369,7 +239,7 @@ def run_full_test():
         else:
             logger.debug("\nFailed to recover %i trajectories:" % len(missing))
             for x in missing:
-                logger.debug(x)
+                logger.debug(trjs[x])
             logger.debug("*** FAILED ***")
             return False
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -88,6 +88,16 @@ class test_results(unittest.TestCase):
         table = Results(Table(self.input_dict))
         self._assert_results_match_dict(table, self.input_dict)
 
+    def test_copy(self):
+        table1 = Results(self.input_dict)
+        table2 = table1.copy()
+
+        # Add a new column to table2 and check that it is not in table1
+        # (i.e. we have done a deep copy).
+        table2.table["something_added"] = [i for i in range(self.num_entries)]
+        self.assertTrue("something_added" in table2.colnames)
+        self.assertFalse("something_added" in table1.colnames)
+
     def test_make_trajectory_list(self):
         self.input_dict["something_added"] = [i for i in range(self.num_entries)]
         table = Results(self.input_dict)


### PR DESCRIPTION
Break out some helper functions from the regression test so I can reuse them in some notebooks for testing speedups to filtering and clustering. 

Also adds a `copy()` method to `Results` to enable easier testing.