### PR TITLE
remove python 3.8 support

### DIFF
--- a/.github/workflows/canary_builds.yaml
+++ b/.github/workflows/canary_builds.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash -leo pipefail {0}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [{name="KBMOD Developers"}, ]
 description = "Moving object detection library implemented on GPUs"
 license = {file="LICENSE"}
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["astronomy", "astrophysics", "image_processing", "gpu"]
 classifiers = [
     "Development Status :: 3 - Beta",
@@ -84,7 +84,7 @@ tests = [
 # formatting configuration as specified at developer.lsst.io
 [tool.black]
 line-length = 110
-target-version = ["py38"]
+target-version = ["py39", "py310", "py311"]
 extend-exclude = "data/|docs/|include/|lib/|setup.py"
 
 [tool.isort]


### PR DESCRIPTION
#767 

also changed our `black` target-version to include all of our supported versions (best practice per the [docs](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#t-target-version)).

