### PR TITLE
Fix documentation

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -50,7 +50,7 @@ jobs:
           python -m pip install .[docs]
       - name: Build docs
         run: |
-          sphinx-build -aEj 12 -b html docs/source docs/build/
+          sphinx-build -aEj 12 -v -b html docs/source docs/build/
       # internet seems scary with messages about and/or conditions not actually working
       # for GH, so best to have a self-standing-step.
       - name: Cron deploy docs

--- a/docs/source/api_reference/analysis/create_stamps.rst
+++ b/docs/source/api_reference/analysis/create_stamps.rst
@@ -1,0 +1,5 @@
+Module: create_stamps
+=====================
+
+.. automodule:: kbmod.analysis.create_stamps
+   :members:

--- a/docs/source/api_reference/analysis/plotting.rst
+++ b/docs/source/api_reference/analysis/plotting.rst
@@ -1,0 +1,5 @@
+Module: plotting
+================
+
+.. automodule:: kbmod.analysis.plotting
+   :members:

--- a/docs/source/api_reference/analysis/visualizer.rst
+++ b/docs/source/api_reference/analysis/visualizer.rst
@@ -1,0 +1,5 @@
+Module: visualizer
+==================
+
+.. automodule:: kbmod.analysis.visualizer
+   :members:

--- a/docs/source/api_reference/analysis_utils.rst
+++ b/docs/source/api_reference/analysis_utils.rst
@@ -1,5 +1,0 @@
-Module: analysis_utils
-======================
-
-.. automodule:: kbmod.analysis_utils
-   :members:

--- a/docs/source/api_reference/fake_data/insert_fake_orbit.rst
+++ b/docs/source/api_reference/fake_data/insert_fake_orbit.rst
@@ -1,5 +1,0 @@
-Module: insert_fake_orbit
-=========================
-
-.. automodule:: kbmod.fake_data.insert_fake_orbit
-   :members:

--- a/docs/source/api_reference/file_utils.rst
+++ b/docs/source/api_reference/file_utils.rst
@@ -1,5 +1,0 @@
-Module: file_utils
-==================
-
-.. automodule:: kbmod.file_utils
-   :members:

--- a/docs/source/api_reference/filters/base_filter.rst
+++ b/docs/source/api_reference/filters/base_filter.rst
@@ -1,5 +1,0 @@
-Module: base_filter
-===================
-
-.. automodule:: kbmod.filters.base_filter
-   :members:

--- a/docs/source/api_reference/filters/basic_filter.rst
+++ b/docs/source/api_reference/filters/basic_filter.rst
@@ -1,0 +1,5 @@
+Module: basic_filters
+=====================
+
+.. automodule:: kbmod.filters.basic_filters
+   :members:

--- a/docs/source/api_reference/filters/clustering_filters.rst
+++ b/docs/source/api_reference/filters/clustering_filters.rst
@@ -1,0 +1,5 @@
+Module: clustering_filters
+==========================
+
+.. automodule:: kbmod.filters.clustering_filters
+   :members:

--- a/docs/source/api_reference/filters/known_object_filters.rst
+++ b/docs/source/api_reference/filters/known_object_filters.rst
@@ -1,0 +1,5 @@
+Module: known_object_filters
+============================
+
+.. automodule:: kbmod.filters.known_object_filters
+   :members:

--- a/docs/source/api_reference/filters/sigma_g_filter.rst
+++ b/docs/source/api_reference/filters/sigma_g_filter.rst
@@ -1,0 +1,5 @@
+Module: sigma_g_filter
+======================
+
+.. automodule:: kbmod.filters.sigma_g_filter
+   :members:

--- a/docs/source/api_reference/filters/stats_filters.rst
+++ b/docs/source/api_reference/filters/stats_filters.rst
@@ -1,5 +1,0 @@
-Module: stats_filters
-=====================
-
-.. automodule:: kbmod.filters.stats_filters
-   :members:

--- a/docs/source/api_reference/index.rst
+++ b/docs/source/api_reference/index.rst
@@ -10,7 +10,9 @@ Object Search
    configuration
    run_search_referenceapi
    search_referenceapi
+   results
    trajectory_explorer
+   trajectory_generator
    work_unit
 
 Preprocessing
@@ -20,7 +22,13 @@ Preprocessing
    :maxdepth: 1
 
    image_collection
-   masking
+   standardizers/butler_standardizer
+   standardizers/fits_standardizer
+   standardizers/kbmodv1
+   standardizers/kbmodv05
+   standardizers/multi_extension_fits
+   standardizers/single_extension_fits
+   standardizers/standardizer
    reprojection
 
 Filtering Results
@@ -29,9 +37,11 @@ Filtering Results
 .. toctree::
    :maxdepth: 1
 
-   filters/base_filter
+   filters/basic_filter
+   filters/clustering_filters
+   filters/known_object_filters
+   filters/sigma_g_filter
    filters/stamp_filters
-   filters/stats_filters
 
 Analyzing Results
 -----------------
@@ -39,9 +49,10 @@ Analyzing Results
 .. toctree::
    :maxdepth: 1
 
-   analysis_utils
+   analysis/create_stamps
+   analysis/plotting
+   analysis/visualizer
    jointfit_functions
-   result_list
 
 Miscelaneous utilities
 ----------------------
@@ -53,4 +64,5 @@ Miscelaneous utilities
    fake_data/insert_fake_orbit
    file_utils
    trajectory_utils
+   util_functions
    wcs_utils

--- a/docs/source/api_reference/masking.rst
+++ b/docs/source/api_reference/masking.rst
@@ -1,5 +1,0 @@
-Module: masking
-===============
-
-.. automodule:: kbmod.masking
-   :members:

--- a/docs/source/api_reference/result_list.rst
+++ b/docs/source/api_reference/result_list.rst
@@ -1,5 +1,0 @@
-Module: result_list
-===================
-
-.. automodule:: kbmod.result_list
-   :members:

--- a/docs/source/api_reference/results.rst
+++ b/docs/source/api_reference/results.rst
@@ -1,0 +1,5 @@
+Module: results
+===============
+
+.. automodule:: kbmod.results
+   :members:

--- a/docs/source/api_reference/standardizers/butler_standardizer.rst
+++ b/docs/source/api_reference/standardizers/butler_standardizer.rst
@@ -1,0 +1,5 @@
+Module: butler_standardizer
+===========================
+
+.. automodule:: kbmod.standardizers.butler_standardizer
+   :members:

--- a/docs/source/api_reference/standardizers/fits_standardizer.rst
+++ b/docs/source/api_reference/standardizers/fits_standardizer.rst
@@ -1,0 +1,5 @@
+Module: fits_standardizer
+=========================
+
+.. automodule:: kbmod.standardizers.fits_standardizers.fits_standardizer
+   :members:

--- a/docs/source/api_reference/standardizers/kbmodv05.rst
+++ b/docs/source/api_reference/standardizers/kbmodv05.rst
@@ -1,0 +1,5 @@
+Module: kbmodv05
+================
+
+.. automodule:: kbmod.standardizers.fits_standardizers.kbmodv05
+   :members:

--- a/docs/source/api_reference/standardizers/kbmodv1.rst
+++ b/docs/source/api_reference/standardizers/kbmodv1.rst
@@ -1,0 +1,5 @@
+Module: kbmodv1
+===============
+
+.. automodule:: kbmod.standardizers.fits_standardizers.kbmodv1
+   :members:

--- a/docs/source/api_reference/standardizers/multi_extension_fits.rst
+++ b/docs/source/api_reference/standardizers/multi_extension_fits.rst
@@ -1,0 +1,5 @@
+Module: multi_extension_fits
+============================
+
+.. automodule:: kbmod.standardizers.fits_standardizers.multi_extension_fits
+   :members:

--- a/docs/source/api_reference/standardizers/single_extension_fits.rst
+++ b/docs/source/api_reference/standardizers/single_extension_fits.rst
@@ -1,0 +1,5 @@
+Module: single_extension_fits
+=============================
+
+.. automodule:: kbmod.standardizers.fits_standardizers.single_extension_fits
+   :members:

--- a/docs/source/api_reference/standardizers/standardizer.rst
+++ b/docs/source/api_reference/standardizers/standardizer.rst
@@ -1,0 +1,5 @@
+Module: standardizer
+=====================
+
+.. automodule:: kbmod.standardizers.standardizer
+   :members:

--- a/docs/source/api_reference/trajectory_generator.rst
+++ b/docs/source/api_reference/trajectory_generator.rst
@@ -1,0 +1,5 @@
+Module: trajectory_generator
+============================
+
+.. automodule:: kbmod.trajectory_generator
+   :members:

--- a/notebooks/reprojection/heliocentric_reproject_algo_comparison.ipynb
+++ b/notebooks/reprojection/heliocentric_reproject_algo_comparison.ipynb
@@ -191,7 +191,6 @@
     "    per_distance_earth_dist_diff_geom = []\n",
     "\n",
     "    for ra in range(min_ra, max_ra, ra_step):\n",
-    "\n",
     "        icrs_ra1 = ra  # range of 0-360\n",
     "        icrs_dec1 = 10.0  # perhaps set this to 10.\n",
     "        icrs_time1 = Time(\"2023-03-20T16:00:00\", format=\"isot\", scale=\"utc\")\n",

--- a/src/kbmod/analysis/plotting.py
+++ b/src/kbmod/analysis/plotting.py
@@ -574,6 +574,7 @@ def compute_lightcurve_histogram(row, min_val=0.0, max_val=1000.0, bins=20):
         Default: 1000.0
     bins : `int`
         The number of bins.
+        Default: 20
 
     Returns
     -------

--- a/src/kbmod/analysis/plotting.py
+++ b/src/kbmod/analysis/plotting.py
@@ -39,12 +39,12 @@ def iter_over_obj(objects):
     iterates over them sorted by date-time stamp.
 
     Parameters
-    -----------
+    ----------
     objects : `astropy.table.Table`
         Table of objects.
 
     Returns
-    --------
+    -------
     obj : `iterator`
         Iterator over individual object observations.
     """
@@ -316,7 +316,7 @@ def plot_cutouts(axes, cutouts, remove_extra_axes=True):
          left empty are removed from the plot.
 
     Raises
-    -------
+    ------
     ValueError - When number of given axes is less than
     the number of given cutouts.
     """
@@ -560,6 +560,26 @@ def plot_result_row(row, times=None, figure=None):
 
 
 def compute_lightcurve_histogram(row, min_val=0.0, max_val=1000.0, bins=20):
+    """Compute a historgram from a light curve.
+
+    Parameters
+    ----------
+    row : astropy Table row
+        The row for this results.
+    min_val : `float`
+        The minimum bin edge for the historgram.
+        Default: 0.0
+    max_val : `float`
+        The maximum bin edge for the historgram.
+        Default: 1000.0
+    bins : `int`
+        The number of bins.
+
+    Returns
+    -------
+    numpy histogram object
+        The histogram.
+    """
     psi = row["psi_curve"]
     phi = row["phi_curve"]
     valid = (phi != 0) & np.isfinite(psi) & np.isfinite(phi)

--- a/src/kbmod/analysis/visualizer.py
+++ b/src/kbmod/analysis/visualizer.py
@@ -59,8 +59,7 @@ class Visualizer:
         self.results.table["num_days"] = num_days
 
     def plot_daily_coadds(self, result_idx, filename=None):
-        """Plots a coadded stamp for each day of valid observations for a
-        given result.
+        """Plots a coadded stamp for each day of valid observations for a given result.
 
         Parameters
         ----------
@@ -71,7 +70,7 @@ class Visualizer:
             image file.
 
         Raises
-        ----------
+        ------
         `RuntimeError` if `num_days` or `all_stamps` are not in the
         results table (i.e. not been generated with `count_num_days` or
         `generate_all_stamps`).

--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -481,8 +481,8 @@ class Results:
         is an 'empty' value (None or anything of length 0). Used to mark or
         filter missing values.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         colname : str
             The name of the column to check.
 
@@ -590,8 +590,8 @@ class Results:
     def revert_filter(self, label=None, add_column=None):
         """Revert the filtering by re-adding filtered ResultRows.
 
-        Note
-        ----
+        Notes
+        -----
         Filtered rows are appended to the end of the list. Does not return
         the results to the original ordering.
 
@@ -647,8 +647,8 @@ class Results:
     def write_table(self, filename, overwrite=True, cols_to_drop=(), extra_meta=None):
         """Write the unfiltered results to a single (ecsv) file.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         filename : `str`
             The name of the result file.
         overwrite : `bool`

--- a/src/kbmod/search/image_stack.cpp
+++ b/src/kbmod/search/image_stack.cpp
@@ -155,7 +155,8 @@ static void image_stack_bindings(py::module& m) {
             .def(py::init<std::vector<li>>())
             .def_property_readonly("on_gpu", &is::on_gpu, pydocs::DOC_ImageStack_on_gpu)
             .def("__len__", &is::img_count)
-            .def("get_images", &is::get_images, pydocs::DOC_ImageStack_get_images)
+            .def("get_images", &is::get_images, py::return_value_policy::reference_internal,
+                 pydocs::DOC_ImageStack_get_images)
             .def("get_single_image", &is::get_single_image, py::return_value_policy::reference_internal,
                  pydocs::DOC_ImageStack_get_single_image)
             .def("set_single_image", &is::set_single_image, py::arg("index"), py::arg("img"),

--- a/src/kbmod/search/pydocs/image_stack_docs.h
+++ b/src/kbmod/search/pydocs/image_stack_docs.h
@@ -14,14 +14,29 @@ static const auto DOC_ImageStack = R"doc(
 
 static const auto DOC_ImageStack_on_gpu = R"doc(
   Indicates whether a copy of the images are stored on GPU.
+   
+  Returns
+  -------
+  on_gpu : `bool`
+      Indicates whether a copy of the images are stored on GPU.
   )doc";
 
 static const auto DOC_ImageStack_get_images = R"doc(
   Returns a reference to the vector of images.
+   
+  Returns
+  -------
+  images : `list`
+      The reference to the vector of images.
   )doc";
 
 static const auto DOC_ImageStack_img_count = R"doc(
   Returns the number of images in the stack.
+   
+  Returns
+  -------
+  img_count : `int`
+      The number of images in the stack.
   )doc";
 
 static const auto DOC_ImageStack_get_single_image = R"doc(
@@ -120,6 +135,11 @@ static const auto DOC_ImageStack_build_zeroed_times = R"doc(
   Construct an array of time differentials between each image
   in the stack and the first image. This can return negative times
   if the images are not sorted by time.
+   
+  Returns
+  -------
+  zeroed_times : `list`
+      A list of times starting at 0.0.
   )doc";
 
 static const auto DOC_ImageStack_sort_by_time = R"doc(
@@ -137,18 +157,38 @@ static const auto DOC_ImageStack_convolve_psf = R"doc(
 
 static const auto DOC_ImageStack_get_width = R"doc(
   Returns the width of the images in pixels.
+   
+  Returns
+  -------
+  npixels : `int`
+      The width of each image in pixels.
   )doc";
 
 static const auto DOC_ImageStack_get_height = R"doc(
   Returns the height of the images in pixels.
+   
+  Returns
+  -------
+  npixels : `int`
+      The height of each image in pixels.
   )doc";
 
 static const auto DOC_ImageStack_get_npixels = R"doc(
   Returns the number of pixels per image.
+   
+  Returns
+  -------
+  npixels : `int`
+      The number of pixels per image.
   )doc";
 
 static const auto DOC_ImageStack_get_total_pixels = R"doc(
   Returns the total number of pixels in all the images.
+   
+  Returns
+  -------
+  npixels : `int`
+      The total number of pixels over all images.
   )doc";
 
 static const auto DOC_ImageStack_copy_to_gpu = R"doc(

--- a/src/kbmod/standardizers/fits_standardizers/fits_standardizer.py
+++ b/src/kbmod/standardizers/fits_standardizers/fits_standardizer.py
@@ -99,7 +99,7 @@ class FitsStandardizer(Standardizer):
             `"hdulist"`` key contains the constructed `~fits.HDUList` object.
 
         Raises
-        -----
+        ------
         FileNotFoundError - when file doesn't exist
         """
         resources = {}
@@ -146,7 +146,7 @@ class FitsStandardizer(Standardizer):
             containing `~fits.HDUList` when ``canStandardize`` is `True`.
 
         Raises
-        -----
+        ------
         FileNotFoundError - when target is path to file that doesn't exist
         TypeError - when target is not HDUList or a filepath.
         """

--- a/src/kbmod/trajectory_utils.py
+++ b/src/kbmod/trajectory_utils.py
@@ -355,8 +355,8 @@ def match_trajectory_sets(traj_query, traj_base, threshold, times=[0.0]):
     query trajectories and base trajectories such that each trajectory is used in
     at most one pair.
 
-    Note
-    ----
+    Notes
+    -----
     This function is designed to evaluate the performance of searches by determining
     which true trajectories (traj_query) were found in the result set (traj_base).
 

--- a/src/kbmod/util_functions.py
+++ b/src/kbmod/util_functions.py
@@ -57,7 +57,7 @@ def mjd_to_day(mjd):
         mjd format date.
 
     Returns
-    ----------
+    -------
     A `str` with a calendar date, in the format YYYY-MM-DD.
     e.g., mjd=60000 -> '2023-02-25'
     """


### PR DESCRIPTION
The file structure for the KBMOD API documentation has gotten very out of data, including references to files that no longer exist and not including many of recent files. This PR brings it more up to date.

It also fixes some docstring formatting that was causing warnings.