### PR TITLE
Remove unused legacy file format

### DIFF
--- a/docs/source/user_manual/search_params.rst
+++ b/docs/source/user_manual/search_params.rst
@@ -76,10 +76,6 @@ This document serves to provide a quick overview of the existing parameters and 
 |                        |                             | directory with multiple FITS files     |
 |                        |                             | (one for each exposure).               |
 +------------------------+-----------------------------+----------------------------------------+
-| ``legacy_filename` `   | None                        | The full path and file name for the    |
-|                        |                             | legacy text file of results. If        |
-|                        |                             | ``None`` does not output this file.    |
-+------------------------+-----------------------------+----------------------------------------+
 | ``lh_level``           | 10.0                        | The minimum computed likelihood for an |
 |                        |                             | object to be accepted.                 |
 +------------------------+-----------------------------+----------------------------------------+

--- a/src/kbmod/configuration.py
+++ b/src/kbmod/configuration.py
@@ -41,7 +41,6 @@ class SearchConfiguration:
             },
             "gpu_filter": False,
             "im_filepath": None,
-            "legacy_filename": None,
             "lh_level": 10.0,
             "max_lh": 1000.0,
             "mom_lims": [35.5, 35.5, 2.0, 0.3, 0.3],

--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -683,52 +683,6 @@ class Results:
         # Write out the table.
         write_table.write(filename, overwrite=overwrite)
 
-    def write_trajectory_file(self, filename, overwrite=True):
-        """Save the trajectories to a numpy file.
-
-        Parameters
-        ----------
-        filename : `str`
-            The file name for the ouput file.
-        overwrite : `bool`
-            Whether to overwrite an existing file.
-
-        Raises
-        ------
-        Raises a FileExistsError is the file already exists and
-        ``overwrite`` is set to ``False``.
-        """
-        logger.info(f"Saving result trajectories to {filename}")
-
-        if not overwrite and Path(filename).is_file():
-            raise FileExistsError(f"{filename} already exists")
-
-        trj_list = self.make_trajectory_list()
-        np.savetxt(filename, trj_list, fmt="%s")
-
-    @staticmethod
-    def load_trajectory_file(filename):
-        """Load the trajectories from a numpy file.
-
-        Parameters
-        ----------
-        filename : str
-            The full path and filename of the results.
-
-        Returns
-        -------
-        results : list
-            A list of trajectory objects.
-        """
-        np_results = np.genfromtxt(
-            filename,
-            usecols=(1, 3, 5, 7, 9, 11, 13),
-            names=["lh", "flux", "x", "y", "vx", "vy", "num_obs"],
-            ndmin=2,
-        )
-        results = [trajectory_from_np_object(x) for x in np_results]
-        return results
-
     def write_column(self, colname, filename):
         """Save a single column's data as a numpy data file.
 

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -275,11 +275,6 @@ class SearchRunner:
         meta_to_save["dims"] = stack.get_width(), stack.get_height()
         meta_to_save["mjd_mid"] = [stack.get_obstime(i) for i in range(num_img)]
 
-        # Save the results in as an ecsv file and/or a legacy text file.
-        if config["legacy_filename"] is not None:
-            logger.info(f"Saving legacy results to {config['legacy_filename']}")
-            keep.write_trajectory_file(config["legacy_filename"])
-
         if config["result_filename"] is not None:
             logger.info(f"Saving results table to {config['result_filename']}")
             if not config["save_all_stamps"]:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -74,7 +74,6 @@ class test_configuration(unittest.TestCase):
             "num_obs": 5,
             "cluster_type": None,
             "do_clustering": False,
-            "legacy_filename": "There",
             "res_filepath": "There",
             "generator_config": {"name": "test_gen", "p1": [1.0, 2.0], "p2": 2.0},
             "basic_array": [1.0, 2.0, 3.0],
@@ -85,7 +84,6 @@ class test_configuration(unittest.TestCase):
         self.assertEqual(hdu.data["im_filepath"][0], "Here2\n...")
         self.assertEqual(hdu.data["num_obs"][0], "5\n...")
         self.assertEqual(hdu.data["cluster_type"][0], "null\n...")
-        self.assertEqual(hdu.data["legacy_filename"][0], "There\n...")
         self.assertEqual(hdu.data["res_filepath"][0], "There\n...")
         self.assertEqual(hdu.data["generator_config"][0], "{name: test_gen, p1: [1.0, 2.0], p2: 2.0}")
         self.assertEqual(hdu.data["basic_array"][0], "[1.0, 2.0, 3.0]")
@@ -96,7 +94,6 @@ class test_configuration(unittest.TestCase):
             "num_obs": 5,
             "cluster_type": None,
             "do_clustering": False,
-            "legacy_filename": "There",
             "generator_config": {"name": "test_gen", "p1": [1.0, 2.0], "p2": 2.0},
         }
         config = SearchConfiguration.from_dict(d)
@@ -106,7 +103,6 @@ class test_configuration(unittest.TestCase):
         self.assertEqual(yaml_dict["im_filepath"], "Here2")
         self.assertEqual(yaml_dict["num_obs"], 5)
         self.assertEqual(yaml_dict["cluster_type"], None)
-        self.assertEqual(yaml_dict["legacy_filename"], "There")
         self.assertEqual(yaml_dict["generator_config"]["name"], "test_gen")
         self.assertEqual(yaml_dict["generator_config"]["p1"], [1.0, 2.0])
         self.assertEqual(yaml_dict["generator_config"]["p2"], 2.0)
@@ -171,7 +167,7 @@ class test_configuration(unittest.TestCase):
             self.assertEqual(config2["lh_level"], 25.0)
 
             # Check that we correctly parse Nones.
-            self.assertIsNone(config2["legacy_filename"])
+            self.assertIsNone(config2["result_filename"])
 
 
 if __name__ == "__main__":

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -476,34 +476,6 @@ class test_results(unittest.TestCase):
             self.assertIsNotNone(table3.wcs)
             self.assertTrue(wcs_fits_equal(table3.wcs, fake_wcs))
 
-    def test_save_and_load_trajectories(self):
-        table = Results.from_trajectories(self.trj_list)
-
-        # Try outputting the ResultList
-        with tempfile.TemporaryDirectory() as dir_name:
-            file_path = os.path.join(dir_name, "results.txt")
-            self.assertFalse(Path(file_path).is_file())
-
-            # Can't load if the file is not there.
-            with self.assertRaises(FileNotFoundError):
-                _ = Results.from_trajectory_file(file_path)
-
-            table.write_trajectory_file(file_path)
-            self.assertTrue(Path(file_path).is_file())
-
-            # Load the results into a new data structure and confirm they match.
-            table2 = Results.from_trajectory_file(file_path)
-            self._assert_results_match_dict(table2, self.input_dict)
-
-            # We can also load them into a list.
-            trj_list = Results.load_trajectory_file(file_path)
-            self.assertEqual(len(trj_list), self.num_entries)
-
-            # Can't overwrite when it is set to False, but can with True.
-            with self.assertRaises(FileExistsError):
-                table2.write_trajectory_file(file_path, overwrite=False)
-            table2.write_trajectory_file(file_path, overwrite=True)
-
     def test_write_and_load_column(self):
         table = Results.from_trajectories(self.trj_list)
         self.assertFalse("all_stamps" in table.colnames)


### PR DESCRIPTION
Since we have switched to the `Results` table output, we do not use the legacy file formats anymore. This removes them to reduce code complexity.