### PR TITLE
ButlerStandardizer should allow optional metadata headers to be missing

### DIFF
--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -377,14 +377,14 @@ class ButlerStandardizer(Standardizer):
             # is middleware so complicated! Best-effort attempt,
             # 90% cases?
             self._metadata["OBSID"] = meta["OBSID"]
-            
+
             # Note that the following metadata keys may not be present in all
             # Rubin butlers, and we only extract them if available.
             if "DTNSANAM" in meta:
                 self._metadata["DTNSANAM"] = meta["DTNSANAM"]
             if "AIRMASS" in meta:
                 self._metadata["AIRMASS"] = meta["AIRMASS"]
-            d2s = 0.0 
+            d2s = 0.0
             if "DIMM2SEE" in meta and meta["DIMM2SEE"] != "NaN":
                 self._metadata["DIMM2SEE"] = d2s
             if "GAINA" in meta:

--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -378,20 +378,18 @@ class ButlerStandardizer(Standardizer):
             # 90% cases?
             self._metadata["OBSID"] = meta["OBSID"]
             
-            # Note that the following metadata keys, may not be present in all
-            # Rubin data products, and we only extract them if available.
-            if "DTNSANAM" in self._metadata:
+            # Note that the following metadata keys may not be present in all
+            # Rubin butlers, and we only extract them if available.
+            if "DTNSANAM" in meta:
                 self._metadata["DTNSANAM"] = meta["DTNSANAM"]
-            # TODO
-            if "AIRMASS" in self._metadata:
+            if "AIRMASS" in meta:
                 self._metadata["AIRMASS"] = meta["AIRMASS"]
             d2s = 0.0 
             if "DIMM2SEE" in meta and meta["DIMM2SEE"] != "NaN":
-                d2s = float(meta["DIMM2SEE"])
-            self._metadata["DIMM2SEE"] = d2s
-            if "GAINA" in self._metadata:
+                self._metadata["DIMM2SEE"] = d2s
+            if "GAINA" in meta:
                 self._metadata["GAINA"] = meta["GAINA"]
-            if "GAINB" in self._metadata:
+            if "GAINB" in meta:
                 self._metadata["GAINB"] = meta["GAINB"]
 
         # Will be nan for VR filter so it's optional

--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -377,12 +377,22 @@ class ButlerStandardizer(Standardizer):
             # is middleware so complicated! Best-effort attempt,
             # 90% cases?
             self._metadata["OBSID"] = meta["OBSID"]
-            self._metadata["DTNSANAM"] = meta["DTNSANAM"]
-            self._metadata["AIRMASS"] = meta["AIRMASS"]
-            d2s = 0.0 if meta["DIMM2SEE"] == "NaN" else float(meta["DIMM2SEE"])
+            
+            # Note that the following metadata keys, may not be present in all
+            # Rubin data products, and we only extract them if available.
+            if "DTNSANAM" in self._metadata:
+                self._metadata["DTNSANAM"] = meta["DTNSANAM"]
+            # TODO
+            if "AIRMASS" in self._metadata:
+                self._metadata["AIRMASS"] = meta["AIRMASS"]
+            d2s = 0.0 
+            if "DIMM2SEE" in meta and meta["DIMM2SEE"] != "NaN":
+                d2s = float(meta["DIMM2SEE"])
             self._metadata["DIMM2SEE"] = d2s
-            self._metadata["GAINA"] = meta["GAINA"]
-            self._metadata["GAINB"] = meta["GAINB"]
+            if "GAINA" in self._metadata:
+                self._metadata["GAINA"] = meta["GAINA"]
+            if "GAINB" in self._metadata:
+                self._metadata["GAINB"] = meta["GAINB"]
 
         # Will be nan for VR filter so it's optional
         if self.config.standardize_effective_summary_stats:

--- a/tests/utils/mock_butler.py
+++ b/tests/utils/mock_butler.py
@@ -126,6 +126,12 @@ class PropertyList:
 
     def __getitem__(self, key):
         return self.valdict[key]
+    
+    def __contains__(self, key):
+        return key in self.valdict
+    
+    def __delitem__(self, key):
+        del self.valdict[key]
 
 
 class DatasetQueryResults:
@@ -243,12 +249,17 @@ class MockButler:
     * mocked.variance.array
     * mocked.mask.array
     attributes can be used to customize the returned arrays.
+
+    The mocked metadata will be a copy of the header of the first file in the
+    FitsFactory, but with the option to remove some header keys by providing a
+    list of keys in `missing_headers`.
     """
 
-    def __init__(self, root, ref=None, mock_images_f=None, registry=None):
+    def __init__(self, root, ref=None, mock_images_f=None, registry=None, missing_headers=[]):
         self.datastore = Datastore(root)
         self.registry = Registry() if registry is None else registry
         self.mockImages = mock_images_f
+        self.missing_headers = missing_headers
 
     def getURI(self, ref, dataId=None, collections=None):
         mocked = mock.Mock(name="ButlerURI")
@@ -309,7 +320,12 @@ class MockButler:
     def mock_metadata(self, ref):
         hdul = FitsFactory.get_fits(ref % FitsFactory.n_files)
         prim = hdul["PRIMARY"].header
-        return PropertyList(dict(prim))
+        meta = PropertyList(dict(prim))
+        if self.missing_headers:
+            # remove some keys from the metadata to simulate different environments
+            for key in self.missing_headers:
+                del meta[key]
+        return meta
 
     def mock_visitinfo(self, ref):
         hdul = FitsFactory.get_fits(ref % FitsFactory.n_files)

--- a/tests/utils/mock_butler.py
+++ b/tests/utils/mock_butler.py
@@ -126,10 +126,10 @@ class PropertyList:
 
     def __getitem__(self, key):
         return self.valdict[key]
-    
+
     def __contains__(self, key):
         return key in self.valdict
-    
+
     def __delitem__(self, key):
         del self.valdict[key]
 


### PR DESCRIPTION
On the USDF embargo butler, certain optional metadata headers are missing, and by default we will fail if they are not provided (DTNSANAM, AIRMASS, DIMM2SEE, GAINA, GAINB). Since these are already considered "optional", here we only populate them in an ImageCollection/WorkUnit if present.

The `mock_butler` has been modified to allow for certain headers to be specified as "missing" from the metadata for testing purposes.

