### PR TITLE
Allow debug logging to be set by the config

### DIFF
--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import time
 
@@ -218,6 +219,9 @@ class SearchRunner:
         keep : `Results`
             The results.
         """
+        if config["debug"]:
+            logging.basicConfig(level=logging.DEBUG)
+
         if not kb.HAS_GPU:
             logger.warning("Code was compiled without GPU.")
 

--- a/tests/test_regression_test.py
+++ b/tests/test_regression_test.py
@@ -131,7 +131,7 @@ def perform_search(im_stack, res_filename, default_psf):
         "clip_negative": True,
         "x_pixel_buffer": 10,
         "y_pixel_buffer": 10,
-        "debug": True,
+        "debug": False,
     }
     config = SearchConfiguration.from_dict(input_parameters)
 


### PR DESCRIPTION
Adds a path to turn on debug logging when the config's "debug" parameter is set to True.