### PR TITLE
Fix overwrite option in WorkUnit.to_sharded_fits

### DIFF
--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -584,7 +584,7 @@ class WorkUnit:
             psf_hdu = fits.hdu.image.ImageHDU(psf_array)
             psf_hdu.name = f"PSF_{i}"
             sub_hdul.append(psf_hdu)
-            sub_hdul.writeto(os.path.join(directory, f"{i}_{filename}"))
+            sub_hdul.writeto(os.path.join(directory, f"{i}_{filename}"), overwrite=overwrite)
 
         # Create a primary file with all of the metadata, including all the WCS info.
         hdul = self.metadata_to_hdul()

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -336,7 +336,7 @@ class test_work_unit(unittest.TestCase):
             self.assertRaises(FileExistsError, work.to_fits, file_path)
 
             # We succeed if overwrite=True
-            work.to_fits(file_path, overwrite=True)
+            work.to_sharded_fits("test_workunit.fits", dir_name, overwrite=True)
 
     def test_save_and_load_fits_shard_lazy(self):
         with tempfile.TemporaryDirectory() as dir_name:


### PR DESCRIPTION
In `WorkUnit.to_sharded_fits`, the `overwrite` argument was propagated when writing the primary layer but not when writing individual shards. Here we make a one line change to fix this.