### PR TITLE
Fix encoding crash when an image is empty

### DIFF
--- a/src/kbmod/search/psi_phi_array.cpp
+++ b/src/kbmod/search/psi_phi_array.cpp
@@ -209,7 +209,14 @@ std::array<float, 3> compute_scale_params_from_image_vect(const std::vector<RawI
     float min_val = FLT_MAX;
     float max_val = -FLT_MAX;
     for (int i = 0; i < num_images; ++i) {
-        std::array<float, 2> bnds = imgs[i].compute_bounds();
+        std::array<float, 2> bnds = imgs[i].compute_bounds(false);
+
+        // Check if we have hit a case where the image is effectively empty (all zero).
+        if ((bnds[0] == 0.0) && (bnds[1] == 0.0)) {
+            logging::getLogger("kbmod.search.psi_phi_array")
+                ->debug("Image " + std::to_string(i) + " has no data.\n");
+        }
+
         if (bnds[0] < min_val) min_val = bnds[0];
         if (bnds[1] > max_val) max_val = bnds[1];
     }

--- a/src/kbmod/search/pydocs/raw_image_docs.h
+++ b/src/kbmod/search/pydocs/raw_image_docs.h
@@ -193,6 +193,12 @@ static const auto DOC_RawImage_l2_allclose = R"doc(
 static const auto DOC_RawImage_compute_bounds = R"doc(
   Returns min and max pixel values, ignoring the masked pixels.
 
+  Parameters
+  ----------
+  strict_checks : `bool`
+      If True and none of the pixels contain data, then raises an RuntimeError.
+      If False and none of the pixels contain data, returns (0.0, 0.0).
+
   Returns
   -------
   bounds : `tuple`

--- a/src/kbmod/search/raw_image.h
+++ b/src/kbmod/search/raw_image.h
@@ -84,7 +84,7 @@ public:
     RawImage create_stamp(const Point& p, const int radius, const bool keep_no_data) const;
 
     // Compute the min and max bounds of values in the image.
-    std::array<float, 2> compute_bounds() const;
+    std::array<float, 2> compute_bounds(bool strict_checks=true) const;
 
     // Convolve the image with a point spread function.
     void convolve(PSF& psf);

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -20,8 +20,6 @@ class test_RawImage(unittest.TestCase):
     def setUp(self, width=10, height=12):
         self.width = width
         self.height = height
-
-        # self.const_arr =  10.0 * np.ones(height, width, dtype=np.single)
         self.array = np.arange(0, width * height, dtype=np.single).reshape(height, width)
 
         self.masked_array = 10.0 * np.ones((height, width), dtype=np.single)
@@ -154,6 +152,16 @@ class test_RawImage(unittest.TestCase):
         lower, upper = img.compute_bounds()
         self.assertAlmostEqual(lower, 0.1, delta=1e-6)
         self.assertAlmostEqual(upper, 100.0, delta=1e-6)
+
+        # If the entire image is NaN the function should raise an error by default.
+        bad_arr = np.full((2, 2), KB_NO_DATA, dtype=np.single)
+        bad_img = RawImage(bad_arr)
+        self.assertRaises(RuntimeError, bad_img.compute_bounds)
+
+        # The function does not raise an error when strict_checks=False.
+        lower, upper = bad_img.compute_bounds(strict_checks=False)
+        self.assertEqual(lower, 0.0)
+        self.assertEqual(upper, 0.0)
 
     def test_replace_masked_values(self):
         img2 = RawImage(np.copy(self.masked_array))


### PR DESCRIPTION
The code was throwing a RuntimeError if any of the images in the ImageStack were empty (all NO_DATA). This might happen due to a combination of masking and reprojection. This PR fixes the code so it logs a warning that one of the images is empty, but otherwise proceeds.