### PR TITLE
Add a wrapper for displaying the cuda stats

### DIFF
--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -221,6 +221,7 @@ class SearchRunner:
         """
         if config["debug"]:
             logging.basicConfig(level=logging.DEBUG)
+            kb.print_cuda_stats()
 
         if not kb.HAS_GPU:
             logger.warning("Code was compiled without GPU.")

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -55,4 +55,5 @@ PYBIND11_MODULE(search, m) {
     m.def("create_mean_image", &search::create_mean_image);
     // Functions from kernel_testing_helpers.cpp
     m.def("sigmag_filtered_indices", &search::sigmaGFilteredIndices);
+    m.def("print_cuda_stats", &search::print_cuda_stats);
 }

--- a/src/kbmod/search/kernel_testing_helpers.cpp
+++ b/src/kbmod/search/kernel_testing_helpers.cpp
@@ -2,12 +2,25 @@
 
 #include <vector>
 
+#include "logging.h"
+
 namespace search {
 #ifdef HAVE_CUDA
+void cuda_print_stats();
+    
 /* The filter_kenerls.cu functions. */
 extern "C" void SigmaGFilteredIndicesCU(float *values, int num_values, float sgl0, float sgl1, float sg_coeff,
                                         float width, int *idx_array, int *min_keep_idx, int *max_keep_idx);
 #endif
+
+void print_cuda_stats() {
+#ifdef HAVE_CUDA
+    cuda_print_stats();
+#else
+    std::cout << "\n----- CUDA Debugging Log -----\n";
+    std::cout << "CUDA not enabled.\n";
+#endif
+}
 
 /* Used for testing SigmaGFilteredIndicesCU for python
  *


### PR DESCRIPTION
Add a wrapper for displaying the cuda stats from Python and output these at the start of a search if "debug" is set to True.