### PR TITLE
Add predicted (x, y) values to Results

### DIFF
--- a/docs/source/user_manual/output_files.rst
+++ b/docs/source/user_manual/output_files.rst
@@ -38,6 +38,10 @@ The mapped RA, dec information consists of up to four columns. The columns `glob
 
 The columns `img_ra` and `img_dec` indicate the positions in the original images. These could be the same or different from the global (RA, dec) even for reprojected images. If the reprojection consists of aligning the images, such as correcting for rotation, the coordinates will be the same. In that case, the RA and dec are not actually changing, just the mappping from RA, dec to pixels. However if the reprojection includes a shift of the viewing location, such as with the barycentric reprojection, we would expect the RA and dec to also change.
 
+**Predicted x, y Information**
+
+KBMOD will also listed the predicted (x, y) pixel coordinates of the object for each time step. The columns `pred_x` and `pred_y` list the predicted x and y positions in the common WCS frame that KBMOD used for the search.  The columns `img_x` and `img_y` list the predicted x and y positions in each image's original WCS frame. The `img_` columns may be identical to the `pred_` columns if the images were not reprojected.
+
 **Metadata**
 
 The table also includes some basic metadata about the set of images, including the number of images (`num_img`), the image dimensions (`dims`), and the midpoint times of the observations (`mid_mjd`).

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -89,7 +89,7 @@ class WorkUnit:
     per_image_wcs : `list`, optional
         A list with one WCS for each image in the WorkUnit. Used for when
         the images have *not* been standardized to the same pixel space. If provided
-        this will the WCS values in org_image_meta
+        this will overwrite the WCS values in org_image_meta
     reprojected : `bool`, optional
         Whether or not the WorkUnit image data has been reprojected.
     reprojection_frame : `str`, optional

--- a/tests/test_run_search.py
+++ b/tests/test_run_search.py
@@ -1,45 +1,74 @@
 """Test some of the functions needed for running the search."""
 
+from astropy.coordinates import EarthLocation, SkyCoord
+from astropy.table import Table
+from astropy.time import Time
+
 import unittest
 
 import numpy as np
 
 from kbmod.configuration import SearchConfiguration
 from kbmod.fake_data.fake_data_creator import create_fake_times, FakeDataSet
+from kbmod.reprojection_utils import fit_barycentric_wcs
 from kbmod.results import Results
-from kbmod.run_search import append_ra_dec_to_results
+from kbmod.run_search import append_positions_to_results
 from kbmod.search import *
 from kbmod.wcs_utils import make_fake_wcs
 from kbmod.work_unit import WorkUnit
 
 
 class test_run_search(unittest.TestCase):
-    def test_append_ra_dec_global(self):
+    def test_append_positions_to_results_global(self):
         # Create a fake WorkUnit with 20 times, a completely random ImageStack,
         # and no trajectories.
         num_times = 20
-        fake_times = create_fake_times(num_times, t0=60676.0)
-        fake_ds = FakeDataSet(800, 600, fake_times)
+        width = 800
+        height = 600
+        t0 = 60676.0
+        helio_dist = 500.0
 
-        # Append a global fake WCS and one for each time.
+        fake_times = create_fake_times(num_times, t0=t0)
+        fake_ds = FakeDataSet(width, height, fake_times)
+
+        # Create a global fake WCS,  one for each time (slightly shifted), and the EBD information.
         global_wcs = make_fake_wcs(20.0, 0.0, 800, 600, deg_per_pixel=0.5 / 3600.0)
-        all_wcs = []
-        for idx in range(num_times):
-            curr = make_fake_wcs(
-                20.01 + idx / 100.0, 0.01 + idx / 100.0, 800, 600, deg_per_pixel=0.5 / 3600.0
-            )
-            all_wcs.append(curr)
 
+        per_image_wcs = []
+        for idx in range(num_times):
+            # Each WCS is slight shifted from the global one.
+            curr = make_fake_wcs(
+                20.001 + idx / 1000.0, 0.001 + idx / 1000.0, 800, 600, deg_per_pixel=0.5 / 3600.0
+            )
+            per_image_wcs.append(curr)
+
+        ebd_wcs, geo_dist = fit_barycentric_wcs(
+            global_wcs,
+            width,
+            height,
+            helio_dist,
+            Time(t0, format="mjd"),
+            EarthLocation.of_site("ctio"),
+        )
+
+        # Create the fake WorkUnit with this information.
+        org_image_meta = Table(
+            {
+                "ebd_wcs": np.array([ebd_wcs] * num_times),
+                "geocentric_distance": np.array([geo_dist] * num_times),
+                "per_image_wcs": np.array(per_image_wcs),
+            }
+        )
         fake_wu = WorkUnit(
             im_stack=fake_ds.stack,
             config=SearchConfiguration(),
-            wcs=global_wcs,
-            per_image_wcs=all_wcs,
+            wcs=ebd_wcs,
             reprojected=True,
             reprojection_frame="ebd",
             per_image_indices=[i for i in range(num_times)],
-            heliocentric_distance=np.full(num_times, 100.0),
+            heliocentric_distance=helio_dist,
             obstimes=fake_times,
+            org_image_meta=org_image_meta,
         )
 
         # Create three fake trajectories in the bounds of the images. We don't
@@ -52,7 +81,7 @@ class test_run_search(unittest.TestCase):
         results = Results.from_trajectories(trjs)
         self.assertEqual(len(results), 3)
 
-        append_ra_dec_to_results(fake_wu, results)
+        append_positions_to_results(fake_wu, results)
 
         # The global RA should exist and be close to 20.0 for all observations.
         self.assertEqual(len(results["global_ra"]), 3)
@@ -68,24 +97,45 @@ class test_run_search(unittest.TestCase):
             self.assertTrue(np.all(results["global_dec"][i] > -1.0))
             self.assertTrue(np.all(results["global_dec"][i] < 1.0))
 
-        # The per-image RA should exist, be close to 20.0 for all observations,
-        # and be different from the global RA
+        # The per-image RA should exist, be close to (but not the same as)
+        # the global RA for all observations.
         self.assertEqual(len(results["img_ra"]), 3)
         for i in range(3):
             self.assertEqual(len(results["img_ra"][i]), num_times)
-            self.assertTrue(np.all(results["img_ra"][i] > 19.0))
-            self.assertTrue(np.all(results["img_ra"][i] < 21.0))
-            self.assertFalse(np.any(results["img_ra"][i] == results["global_ra"][i]))
+            ra_diffs = np.abs(results["img_ra"][i] - results["global_ra"][i])
+            self.assertTrue(np.all(ra_diffs > 0.0))
+            self.assertTrue(np.all(ra_diffs < 1.0))
 
-        # The global Dec should exist and be close to 0.0 for all observations.
+        # The per-image dec should exist, be close to (but not the same as)
+        # the global dec for all observations.
         self.assertEqual(len(results["img_dec"]), 3)
         for i in range(3):
             self.assertEqual(len(results["img_dec"][i]), num_times)
-            self.assertTrue(np.all(results["img_dec"][i] > -1.0))
-            self.assertTrue(np.all(results["img_dec"][i] < 1.0))
-            self.assertFalse(np.any(results["img_dec"][i] == results["global_dec"][i]))
+            dec_diffs = np.abs(results["img_dec"][i] - results["global_dec"][i])
+            self.assertTrue(np.all(dec_diffs > 0.0))
+            self.assertTrue(np.all(dec_diffs < 1.0))
 
-    def test_append_ra_dec_no_global(self):
+        # The per-image x should exist and be within some delta of the global predicted x.
+        self.assertEqual(len(results["pred_x"]), 3)
+        self.assertEqual(len(results["img_x"]), 3)
+        for i in range(3):
+            self.assertEqual(len(results["img_x"][i]), num_times)
+            self.assertEqual(len(results["pred_x"][i]), num_times)
+            x_diffs = np.abs(results["img_x"][i] - results["pred_x"][i])
+            self.assertTrue(np.all(x_diffs > 0.0))
+            self.assertTrue(np.all(x_diffs < 1000.0))
+
+        # The per-image y should exist and be within some delta of the global predicted y.
+        self.assertEqual(len(results["pred_y"]), 3)
+        self.assertEqual(len(results["img_y"]), 3)
+        for i in range(3):
+            self.assertEqual(len(results["img_y"][i]), num_times)
+            self.assertEqual(len(results["pred_y"][i]), num_times)
+            y_diffs = np.abs(results["img_y"][i] - results["pred_y"][i])
+            self.assertTrue(np.all(y_diffs > 0.0))
+            self.assertTrue(np.all(y_diffs < 1000.0))
+
+    def test_append_positions_to_results_no_global(self):
         # Create a fake WorkUnit with 20 times, a completely random ImageStack,
         # and no trajectories.
         num_times = 20
@@ -120,7 +170,7 @@ class test_run_search(unittest.TestCase):
         results = Results.from_trajectories(trjs)
         self.assertEqual(len(results), 3)
 
-        append_ra_dec_to_results(fake_wu, results)
+        append_positions_to_results(fake_wu, results)
 
         # The global RA and global dec should not exist.
         self.assertFalse("global_ra" in results.colnames)
@@ -139,6 +189,22 @@ class test_run_search(unittest.TestCase):
             self.assertEqual(len(results["img_dec"][i]), num_times)
             self.assertTrue(np.all(results["img_dec"][i] > -1.0))
             self.assertTrue(np.all(results["img_dec"][i] < 1.0))
+
+        # The per-image x should exist and the same as global predicted x.
+        self.assertEqual(len(results["pred_x"]), 3)
+        self.assertEqual(len(results["img_x"]), 3)
+        for i in range(3):
+            self.assertEqual(len(results["img_x"][i]), num_times)
+            self.assertEqual(len(results["pred_x"][i]), num_times)
+            self.assertTrue(np.allclose(results["img_x"][i], results["pred_x"][i]))
+
+        # The per-image y should exist and the same as global predicted y.
+        self.assertEqual(len(results["pred_y"]), 3)
+        self.assertEqual(len(results["img_y"]), 3)
+        for i in range(3):
+            self.assertEqual(len(results["img_y"][i]), num_times)
+            self.assertEqual(len(results["pred_y"][i]), num_times)
+            self.assertTrue(np.allclose(results["img_y"][i], results["pred_y"][i]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add the predicted (x, y) values in both the common WCS and the per-image WCS to the Results table. These might be the same for non-reprojected images.

This PR also fixes errors with the predicted RA, dec (passing in a vector of heliocentric distances produced incorrect results).