### PR TITLE
Fix trajectory_predict_skypos mutating input array

### DIFF
--- a/src/kbmod/filters/known_object_filters.py
+++ b/src/kbmod/filters/known_object_filters.py
@@ -44,8 +44,8 @@ class KnownObjsMatcher:
         ----------
         table : astropy.table.Table
             A table containing our catalog of observations of known objects.
-        obstimes : list(float)
-            The MJD times of each observation within KBMOD results we want to match to
+        obstimes : np.array(float)
+            A numpy array of MJD times of each observation within KBMOD results we want to match to
             the known objects.
         matcher_name : str
             The name of the filter to apply to the results. This both determines

--- a/src/kbmod/trajectory_utils.py
+++ b/src/kbmod/trajectory_utils.py
@@ -124,7 +124,9 @@ def trajectory_predict_skypos(trj, wcs, times):
         A SkyCoord with the transformed locations.
     """
     dt = np.asarray(times)
-    dt -= dt[0]
+    # Note that we do a reassignment to avoid modifying the input, which may
+    # happen if `times` is already an array and `np.asarray` is a no-op.
+    dt = dt - dt[0]
 
     # Predict locations in pixel space.
     x_vals = trj.x + trj.vx * dt

--- a/src/kbmod/trajectory_utils.py
+++ b/src/kbmod/trajectory_utils.py
@@ -126,11 +126,11 @@ def trajectory_predict_skypos(trj, wcs, times):
     dt = np.asarray(times)
     # Note that we do a reassignment to avoid modifying the input, which may
     # happen if `times` is already an array and `np.asarray` is a no-op.
-    dt = dt - dt[0]
+    zeroed_dt = dt - dt[0]
 
     # Predict locations in pixel space.
-    x_vals = trj.x + trj.vx * dt
-    y_vals = trj.y + trj.vy * dt
+    x_vals = trj.x + trj.vx * zeroed_dt
+    y_vals = trj.y + trj.vy * zeroed_dt
 
     result = wcs.pixel_to_world(x_vals, y_vals)
     return result

--- a/tests/test_known_object_filters.py
+++ b/tests/test_known_object_filters.py
@@ -26,7 +26,10 @@ class TestKnownObjMatcher(unittest.TestCase):
 
         # Create a fake dataset with 15 x 10 images and 25 obstimes.
         num_images = 25
-        self.obstimes = np.array(create_fake_times(num_images))
+        start_time = 58922.1
+        self.obstimes = np.array(create_fake_times(num_images, t0=start_time))
+        # Check that all obstimes are greater or equal to the start time
+        self.assertTrue(np.all(self.obstimes >= start_time))
         ds = FakeDataSet(15, 10, self.obstimes, use_seed=True)
         self.wcs = make_fake_wcs(10.0, 15.0, 15, 10)
         ds.set_wcs(self.wcs)
@@ -106,6 +109,9 @@ class TestKnownObjMatcher(unittest.TestCase):
             spatial_offset=0.0001,
             time_offset=time_offset_mjd_close,
         )
+
+        # check that the obstimes have been unmodified and are still not zero-offset
+        self.assertTrue(np.all(self.obstimes >= start_time))
 
     def test_known_objs_matcher_init(
         self,

--- a/tests/test_known_object_filters.py
+++ b/tests/test_known_object_filters.py
@@ -28,6 +28,7 @@ class TestKnownObjMatcher(unittest.TestCase):
         num_images = 25
         start_time = 58922.1
         self.obstimes = np.array(create_fake_times(num_images, t0=start_time))
+        orig_obstimes = self.obstimes.copy()
         # Check that all obstimes are greater or equal to the start time
         self.assertTrue(np.all(self.obstimes >= start_time))
         ds = FakeDataSet(15, 10, self.obstimes, use_seed=True)
@@ -112,6 +113,7 @@ class TestKnownObjMatcher(unittest.TestCase):
 
         # check that the obstimes have been unmodified and are still not zero-offset
         self.assertTrue(np.all(self.obstimes >= start_time))
+        self.assertTrue(np.all(self.obstimes == orig_obstimes))
 
     def test_known_objs_matcher_init(
         self,

--- a/tests/test_trajectory_utils.py
+++ b/tests/test_trajectory_utils.py
@@ -62,12 +62,19 @@ class test_trajectory_utils(unittest.TestCase):
         # Create a trajectory starting at the middle and traveling +2 pixels a day in x and -5 in y.
         trj = Trajectory(x=9, y=9, vx=2.0, vy=-5.0)
 
-        # Predict locations at times 0.0 and 1.0
-        my_sky = trajectory_predict_skypos(trj, my_wcs, [0.0, 1.0])
-        self.assertAlmostEqual(my_sky.ra[0].deg, 45.0)
-        self.assertAlmostEqual(my_sky.dec[0].deg, -15.0)
-        self.assertAlmostEqual(my_sky.ra[1].deg, 45.2, delta=0.01)
-        self.assertAlmostEqual(my_sky.dec[1].deg, -15.5, delta=0.01)
+        # Predict locations at times 57921.0 and 57922.0, both as a list and as a numpy array.
+        obstimes = [57921.0, 57922.0]
+        for curr_obstimes in [obstimes, np.array(obstimes)]:
+            my_sky = trajectory_predict_skypos(trj, my_wcs, curr_obstimes)
+            # Verify that the obstimes were not mutated
+            self.assertEqual(curr_obstimes[0], 57921.0)
+            self.assertEqual(curr_obstimes[1], 57922.0)
+
+            # Verify that the predicted sky positions are correct.
+            self.assertAlmostEqual(my_sky.ra[0].deg, 45.0)
+            self.assertAlmostEqual(my_sky.dec[0].deg, -15.0)
+            self.assertAlmostEqual(my_sky.ra[1].deg, 45.2, delta=0.01)
+            self.assertAlmostEqual(my_sky.dec[1].deg, -15.5, delta=0.01)
 
     def test_trajectory_from_np_object(self):
         np_obj = np.array(


### PR DESCRIPTION
`trajectory_predict_skypos` is meant to predict the positions of a KBMOD trajectory along a list or array of observation times, however it mutates the observation times if they are provided as a numpy array rather than a list.

It calls `dt = np.asarray(times)` which creates a new numpy array if `times` is a list or is a no-op if it is an array. We then subtract out the starting timestamp so all times are offset from 0, and we use the in-place operation of `dt -= dt[0]` to preserve memory. However if `times` is an array, the original object passed to the array has been mutated to now be offset by 0.

As quickly illustrated in a python repl:

```
>>> import numpy as np
>>> def modify_me(n):
...     new_n = np.asarray(n)
...     new_n -= new_n[0]
... 
>>> a = list(range(10, 20))
>>> modify_me(a)
>>> a
[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
>>> b = np.asarray(a)
>>> modify_me(b)
>>> b
array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) 
```
This PR fixes this by choosing not to do the in-place subtraction.

To add better testing for this, we a) use tests with non-zero observation times to actually test the subtraction and b) test both lists and numpy arrays as inputs.

Note that this was showing up as an issue with the `KnownObjMatcher` having its numpy array of observation times mutated by the call to `trajectory_predict_skypos`. Then when it tries to compare the observation times against times from an ephemeris, a match cannot be made due to the temporal subtraction.