### PR TITLE
Cnn filter redux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ Changelog = "https://epyc.astro.washington.edu/~kbmod/project_details/release_no
 
 [project.optional-dependencies]
 analysis = [
-    "tensorflow>=2.9",
+    "tensorflow<=2.15",
     "matplotlib>=3.6.1",
     "ipywidgets>=8.0",
     "ephem>=4.1"

--- a/src/kbmod/filters/stamp_filters.py
+++ b/src/kbmod/filters/stamp_filters.py
@@ -286,13 +286,13 @@ def filter_stamps_by_cnn(result_data, model_path, coadd_type="mean", stamp_radiu
     verbose : `bool`
         Verbosity option the CNN predicition. Off by default.
     """
-    import tensorflow as tf
+    from tensorflow.keras.models import load_model
 
     coadd_column = f"coadd_{coadd_type}"
     if coadd_column not in result_data.colnames:
         raise ValueError("result_data does not have provided coadd type as a column.")
 
-    cnn = tf.keras.models.load_model(model_path)
+    cnn = load_model(model_path)
 
     stamps = result_data.table[coadd_column].data
     normalized_stamps = _normalize_stamps(stamps)
@@ -308,6 +308,6 @@ def filter_stamps_by_cnn(result_data, model_path, coadd_type="mean", stamp_radiu
     for p in predictions:
         classsifications.append(np.argmax(p))
 
-    # TODO: maybe cast as a bool?
-    result_data.table["cnn_class"] = np.array(classsifications)
+    bool_arr = np.array(classsifications) != 0
+    result_data.table["cnn_class"] = bool_arr
 

--- a/src/kbmod/filters/stamp_filters.py
+++ b/src/kbmod/filters/stamp_filters.py
@@ -249,23 +249,25 @@ def append_all_stamps(result_data, im_stack, stamp_radius):
     result_data.table["all_stamps"] = np.array(all_stamps)
     stamp_timer.stop()
 
+
 def _normalize_stamps(stamps):
     """Normalize a list of stamps. Used for `filter_stamps_by_cnn`."""
     normed_stamps = []
-    sigma_g_coeff =  0.7413
+    sigma_g_coeff = 0.7413
     for stamp in stamps:
         stamp = np.copy(stamp)
         stamp[np.isnan(stamp)] = 0
 
-        per25, per50, per75 = np.percentile(stamp, [25,50,75])
+        per25, per50, per75 = np.percentile(stamp, [25, 50, 75])
         sigmaG = sigma_g_coeff * (per75 - per25)
-        stamp[stamp<(per50-2*sigmaG)] = per50-2*sigmaG
+        stamp[stamp < (per50 - 2 * sigmaG)] = per50 - 2 * sigmaG
 
         stamp -= np.min(stamp)
         stamp /= np.sum(stamp)
         stamp[np.isnan(stamp)] = 0
-        normed_stamps.append(stamp.reshape(21,21))
+        normed_stamps.append(stamp.reshape(21, 21))
     return np.array(normed_stamps)
+
 
 def filter_stamps_by_cnn(result_data, model_path, coadd_type="mean", stamp_radius=10, verbose=False):
     """Given a set of results data, run the the requested coadded stamps through a
@@ -310,4 +312,3 @@ def filter_stamps_by_cnn(result_data, model_path, coadd_type="mean", stamp_radiu
 
     bool_arr = np.array(classsifications) != 0
     result_data.table["cnn_class"] = bool_arr
-

--- a/src/kbmod/filters/stamp_filters.py
+++ b/src/kbmod/filters/stamp_filters.py
@@ -272,7 +272,7 @@ def _normalize_stamps(stamps):
 def filter_stamps_by_cnn(result_data, model_path, coadd_type="mean", stamp_radius=10, verbose=False):
     """Given a set of results data, run the the requested coadded stamps through a
     provided convolutional neural network and assign a new column that contains the
-    stamp classification, i.e. whehter or not the result passed the CNN filter.
+    stamp classification, i.e. whether or not the result passed the CNN filter.
 
     Parameters
     ----------
@@ -282,11 +282,12 @@ def filter_stamps_by_cnn(result_data, model_path, coadd_type="mean", stamp_radiu
         Path to the the tensorflow model and weights file.
     coadd_type : `str`
         Which coadd type to use in the filtering. Depends on how the model was trained.
+        Default is 'mean', will grab stamps from the 'coadd_mean' column.
     stamp_radius : `int`
-        The radius used to generate the stamps. The dimmension of the stamps should be
+        The radius used to generate the stamps. The dimension of the stamps should be
         (stamp_radius * 2) + 1.
     verbose : `bool`
-        Verbosity option the CNN predicition. Off by default.
+        Verbosity option for the CNN predicition. Off by default.
     """
     from tensorflow.keras.models import load_model
 
@@ -306,9 +307,9 @@ def filter_stamps_by_cnn(result_data, model_path, coadd_type="mean", stamp_radiu
 
     predictions = cnn.predict(resized_stamps, verbose=verbose)
 
-    classsifications = []
+    classifications = []
     for p in predictions:
-        classsifications.append(np.argmax(p))
+        classifications.append(np.argmax(p))
 
-    bool_arr = np.array(classsifications) != 0
+    bool_arr = np.array(classifications) != 0
     result_data.table["cnn_class"] = bool_arr


### PR DESCRIPTION
adds in a new `filter_stamps_by_cnn` which creates a pass/fail mask for the requested coadd stamp using a provided cnn.

cnn classifications are added as a new column to the `Results.table` as a boolean. You can get the filtered list of just results that passed the cnn filter with
```python
filter_stamps_by_cnn(results, "example_cnn.keras")
filtered_results = results.table[results.table["cnn_class"]]
```