### PR TITLE
Adjust stamp creator CPU fallback

### DIFF
--- a/src/kbmod/search/stamp_creator.cpp
+++ b/src/kbmod/search/stamp_creator.cpp
@@ -65,7 +65,7 @@ std::vector<RawImage> get_coadded_stamps(ImageStack& stack, std::vector<Trajecto
     DebugTimer timer = DebugTimer("coadd generating", rs_logger);
 
     // If the stamps are larger than the GPU can handle, fall back to CPU.
-    if (use_gpu && (2 * params.radius + 1 > MAX_STAMP_EDGE)) {
+    if (use_gpu && params.radius >= 15) {
         rs_logger->info("Stamp size too large for GPU. Performing co-adds on the CPU.");
         use_gpu = false;
     }


### PR DESCRIPTION
GPU stamp generation is not working for radius >= 15, so force a CPU fallback at these settings.