### PR TITLE
recenter stamp center lines

### DIFF
--- a/src/kbmod/analysis/plotting.py
+++ b/src/kbmod/analysis/plotting.py
@@ -335,8 +335,10 @@ def plot_cutouts(axes, cutouts, remove_extra_axes=True):
         norm = ImageNormalize(img, interval=ZScaleInterval(), stretch=AsinhStretch())
         im = ax.imshow(cutout.data, norm=norm)
         ax.set_aspect("equal")
-        ax.axvline(cutout.shape[0] / 2, c="red", lw=0.25)
-        ax.axhline(cutout.shape[1] / 2, c="red", lw=0.25)
+        hline_pos = (cutout.shape[0] - 1) / 2
+        vline_pos = (cutout.shape[1] - 1) / 2
+        ax.axvline(hline_pos, c="red", lw=0.25)
+        ax.axhline(vline_pos, c="red", lw=0.25)
 
     if remove_extra_axes and naxes > nplots:
         for ax in axs[nplots - naxes :]:
@@ -419,8 +421,12 @@ def plot_image(img, ax=None, figure=None, norm=True, title=None, show_counts=Tru
         vmin, vmax = clim[0], clim[1]
         im.set_clim(vmin, vmax)
 
-    ax.axhline(img.shape[0] / 2, c="red", lw=0.5)
-    ax.axvline(img.shape[1] / 2, c="red", lw=0.5)
+    # ensure that the vertical line will be placed in the center of the image
+    # plt.imshow is -0.5 indexed so this works for both odd and even length axes.
+    hline_pos = (img.shape[0] - 1) / 2
+    vline_pos = (img.shape[1] - 1) / 2
+    ax.axhline(hline_pos, c="red", lw=0.5)
+    ax.axvline(vline_pos, c="red", lw=0.5)
     ax.set_title(title)
     if show_counts:
         figure.colorbar(im, label="Counts")


### PR DESCRIPTION
fixed the red center lines of the stamp plot to either go through the center pixel when the axis is odd (like in our 21 x 21 stamps) or inbetween the center pixels when the axis is odd.

# Odd Axis 

![Screenshot 2025-02-14 at 12 08 06 PM](https://github.com/user-attachments/assets/ba0bbabf-6b72-48e2-ab3d-f2e61636c84a)

# Even Axis

![Screenshot 2025-02-14 at 12 07 53 PM](https://github.com/user-attachments/assets/5c2b75b1-e972-4730-96ef-c05acf969b2e)
