### PR TITLE
black formatting to fix nightly tests

### DIFF
--- a/src/kbmod/standardizers/fits_standardizers/fits_standardizer.py
+++ b/src/kbmod/standardizers/fits_standardizers/fits_standardizer.py
@@ -1,4 +1,4 @@
-""" `FitsStandardizer` standardize local file-system FITS files.
+"""`FitsStandardizer` standardize local file-system FITS files.
 
 Prefer to use specific FITS standardizers that specify the type of the FITS
 file, such as `SingleExtensionFits` or `MultiExtensionFits`, whenever possible.


### PR DESCRIPTION
new `black` update changed the formatting requirements and caused our nightlies to fail.