### PR TITLE
Clean up scipy dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
     "scipy>=1.9.2",
     "scikit_learn>=1.0.0",
     "tensorflow",
-    "koffi>=0.1.1",
     "PyYAML>=6.0"
 ]
 

--- a/src/kbmod/reprojection_utils.py
+++ b/src/kbmod/reprojection_utils.py
@@ -4,7 +4,6 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord, GCRS, ICRS, solar_system_ephemeris, get_body_barycentric
 from astropy.time import Time
 from astropy.wcs.utils import fit_wcs_from_points
-from scipy.optimize import minimize
 
 
 __all__ = [
@@ -121,6 +120,9 @@ def correct_parallax_with_minimizer(
     los_earth_obj = coord.transform_to(GCRS(obstime=obstime, obsgeoloc=loc))
 
     if geocentric_distance is None:
+        # Only import the scipy module if we are going to use it.
+        from scipy.optimize import minimize
+
         cost = lambda geocentric_distance: np.abs(
             heliocentric_distance
             - GCRS(

--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -6,7 +6,6 @@ import copy
 import csv
 import logging
 import numpy as np
-import os.path as ospath
 from pathlib import Path
 
 from astropy.table import Table, vstack

--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -10,7 +10,6 @@ from astropy.wcs import WCS
 import astropy.units as u
 
 import numpy as np
-from scipy.signal import convolve2d
 
 from .standardizer import Standardizer, StandardizerConfig
 from kbmod.search import LayeredImage, PSF
@@ -470,6 +469,9 @@ class ButlerStandardizer(Standardizer):
             mask = mask | bmask
 
         if self.config["grow_mask"]:
+            # Only import the scipy module if we actually need it.
+            from scipy.signal import convolve2d
+
             grow_kernel = np.ones(self.config["grow_kernel_shape"])
             mask = convolve2d(mask, grow_kernel, mode="same").astype(bool)
 

--- a/src/kbmod/standardizers/fits_standardizers/kbmodv05.py
+++ b/src/kbmod/standardizers/fits_standardizers/kbmodv05.py
@@ -7,7 +7,6 @@ from astropy.nddata import bitmask
 
 import logging
 import numpy as np
-from scipy.signal import convolve2d
 
 from .multi_extension_fits import MultiExtensionFits, FitsStandardizerConfig
 
@@ -193,6 +192,9 @@ class KBMODV0_5(MultiExtensionFits):
             mask = mask | bmask
 
         if self.config["grow_mask"]:
+            # Only import the scipy module if we actually need it.
+            from scipy.signal import convolve2d
+
             grow_kernel = np.ones(self.config["grow_kernel_shape"])
             mask = convolve2d(mask, grow_kernel, mode="same").astype(bool)
 

--- a/src/kbmod/standardizers/fits_standardizers/kbmodv1.py
+++ b/src/kbmod/standardizers/fits_standardizers/kbmodv1.py
@@ -10,7 +10,6 @@ from astropy.time import Time
 from astropy.nddata import bitmask
 
 import numpy as np
-from scipy.signal import convolve2d
 
 from .multi_extension_fits import MultiExtensionFits, FitsStandardizerConfig
 
@@ -199,6 +198,9 @@ class KBMODV1(MultiExtensionFits):
             mask = mask | bmask
 
         if self.config["grow_mask"]:
+            # Only import the scipy module if we actually need it.
+            from scipy.signal import convolve2d
+
             grow_kernel = np.ones(self.config["grow_kernel_shape"])
             mask = convolve2d(mask, grow_kernel, mode="same").astype(bool)
 


### PR DESCRIPTION
Move a few of the scipy imports until where they are used so we don't import them if that path is not used.

Also remove koffi from pyproject.toml since we don't call it from within core KBMOD anymore.