### PR TITLE
Add another missing dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "astropy>=5.1",
     "jax",
     "joblib>=1.4",
+    "jplephem",
     "matplotlib>=3.5",
     "numpy<2.0",
     "reproject",


### PR DESCRIPTION
Another PR to fix the failing canary test. I believe this should be installed transitively (via astropy), but it is not being installed for the canary.