### PR TITLE
Extend the tools for analyzing fakes

### DIFF
--- a/notebooks/analysis/FakeAnalysis.ipynb
+++ b/notebooks/analysis/FakeAnalysis.ipynb
@@ -21,7 +21,10 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "from kbmod.analysis.analyze_fakes import FakeInfo, load_fake_info_from_ecsv\n",
-    "from kbmod.analysis.plotting import plot_image\n",
+    "from kbmod.analysis.plotting import plot_image, plot_multiple_images, plot_time_series\n",
+    "from kbmod.results import Results\n",
+    "from kbmod.trajectory_explorer import TrajectoryExplorer\n",
+    "from kbmod.trajectory_utils import match_trajectory_sets\n",
     "from kbmod.work_unit import WorkUnit\n",
     "\n",
     "import logging\n",
@@ -34,7 +37,7 @@
    "id": "3eaee439-d70d-494a-a160-1e215367d39b",
    "metadata": {},
    "source": [
-    "Load the test WorkUnit and extract some metadata (t0)."
+    "Load the test `WorkUnit` and extract some metadata (t0 and configuration).  Also extract the configuration and set up a `TrajectoryExplorer` object that we can later use to run simulated searches on the `WorkUnit`."
    ]
   },
   {
@@ -46,8 +49,14 @@
    "source": [
     "wu_file = \"/epyc/projects/kbmod/data/20210908_B1h_047_test_data/20210908_B1h_047.wu\"\n",
     "wu = WorkUnit.from_fits(wu_file)\n",
+    "\n",
     "times = wu.get_all_obstimes()\n",
     "t0 = times[0]\n",
+    "zeroed_times = np.array(times) - t0\n",
+    "\n",
+    "config = wu.config\n",
+    "explorer = TrajectoryExplorer(wu.im_stack, wu.config)\n",
+    "explorer.initialize_data()\n",
     "\n",
     "print(f\"Loaded {len(wu)} images starting at time {t0}\")"
    ]
@@ -130,6 +139,173 @@
    "source": [
     "fakes_list[0].compare_stamps([0, 1, 2, 3])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4c77fae-bc99-4652-8251-a007a087b4b6",
+   "metadata": {},
+   "source": [
+    "## Loading the Results\n",
+    "\n",
+    "We load in the results of the actual KBMOD run for comparison."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "613317cd-9398-4b29-986b-d3254ebb380e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_file = \"/epyc/projects/kbmod/data/20210908_B1h_047_test_data/20210908_B1h_047.results.ecsv\"\n",
+    "results = Results.read_table(results_file)\n",
+    "print(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f39c4e3-0d89-43de-a501-bef19701e0b8",
+   "metadata": {},
+   "source": [
+    "Match the known fakes against the result set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e143598-1f0a-4b0a-90dc-63a4b8755035",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "known_list = [fake.trj for fake in fakes_list]\n",
+    "found_list = results.make_trajectory_list()\n",
+    "\n",
+    "matches = match_trajectory_sets(known_list, found_list, 200.0, times=[0.0, zeroed_times[-1]])\n",
+    "\n",
+    "for idx, trj in enumerate(known_list):\n",
+    "    m_idx = matches[idx]\n",
+    "    print(f\"Fake {idx}: Match={m_idx}\")\n",
+    "    print(f\"  Fake TRJ: x={trj.x:5d}, y={trj.y:5d}, vx={trj.vx:8.3f}, vy={trj.vy:8.3f}\")\n",
+    "    if m_idx != -1:\n",
+    "        m_trj = found_list[m_idx]\n",
+    "        print(f\"  Res  TRJ: x={m_trj.x:5d}, y={m_trj.y:5d}, vx={m_trj.vx:8.3f}, vy={m_trj.vy:8.3f}\")\n",
+    "        print(f\"  Score: lh={m_trj.lh}, obs_count={m_trj.obs_count}\")\n",
+    "    print(\"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a16c3abd-dfda-4d62-aa2b-df6fda07843c",
+   "metadata": {},
+   "source": [
+    "# Per Fake Investigation\n",
+    "\n",
+    "Now let's go deep on understanding what happened with a single fake.  The first unmatched fake was 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a7a432a-9d60-45f0-a82c-b354576b4573",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fake_num = 2\n",
+    "\n",
+    "trj = fakes_list[fake_num].trj\n",
+    "single_res = explorer.evaluate_linear_trajectory(trj.x, trj.y, trj.vx, trj.vy)[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb60724d-1f92-4945-8b95-817cc31ef753",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"TRJ: x={trj.x:5d}, y={trj.y:5d}, vx={trj.vx:8.3f}, vy={trj.vy:8.3f}\")\n",
+    "print(f\"GPU LH {single_res['likelihood']}\")\n",
+    "\n",
+    "# Plot some summary data.\n",
+    "fig, ax = plt.subplots(2, 3, figsize=(12.0, 8.0))\n",
+    "plot_image(single_res[\"coadd_sum\"], ax=ax[0][0], figure=fig, norm=True, title=\"Sum Stamp\")\n",
+    "plot_image(single_res[\"coadd_mean\"], ax=ax[0][1], figure=fig, norm=True, title=\"Mean Stamp\")\n",
+    "plot_image(single_res[\"coadd_median\"], ax=ax[0][2], figure=fig, norm=True, title=\"Median Stamp\")\n",
+    "\n",
+    "psi = single_res[\"psi_curve\"]\n",
+    "phi = single_res[\"phi_curve\"]\n",
+    "valid = (phi != 0) & np.isfinite(psi) & np.isfinite(phi)\n",
+    "\n",
+    "psi[~valid] = 0.0\n",
+    "phi[~valid] = 1e-28\n",
+    "lh = psi / np.sqrt(phi)\n",
+    "\n",
+    "plot_time_series(psi, zeroed_times, indices=valid, ax=ax[1][0], figure=fig, title=\"PSI\")\n",
+    "plot_time_series(phi, zeroed_times, indices=valid, ax=ax[1][1], figure=fig, title=\"PHI\")\n",
+    "plot_time_series(lh, zeroed_times, indices=valid, ax=ax[1][2], figure=fig, title=\"LH\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2a4f9eb-1ae3-431e-9401-3a7390a52f41",
+   "metadata": {},
+   "source": [
+    "The plots above do not account for the sigma-G filtering performed on the GPU or afterwards. So let's add that into i"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30fa45b4-20ae-452a-95dc-62c23138fe0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot some summary data.\n",
+    "fig, ax = plt.subplots(1, 3, figsize=(12.0, 4.0))\n",
+    "\n",
+    "sigma_g = single_res[\"sigma_g_res\"]\n",
+    "valid2 = (phi != 0) & np.isfinite(psi) & np.isfinite(phi) & sigma_g\n",
+    "\n",
+    "plot_time_series(psi, zeroed_times, indices=valid2, ax=ax[0], figure=fig, title=\"PSI\")\n",
+    "plot_time_series(phi, zeroed_times, indices=valid2, ax=ax[1], figure=fig, title=\"PHI\")\n",
+    "plot_time_series(lh, zeroed_times, indices=valid2, ax=ax[2], figure=fig, title=\"LH\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c333260f-02a8-45c1-a62c-80fdebc88cf6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_stamps = len(single_res[\"all_stamps\"])\n",
+    "\n",
+    "num_cols = 4\n",
+    "num_rows = np.ceil(num_stamps / num_cols)\n",
+    "img_width = 2.0\n",
+    "\n",
+    "labels = []\n",
+    "for idx, t in enumerate(zeroed_times):\n",
+    "    label = f\"{idx}={t:.4f}\\n\"\n",
+    "    if not valid[idx]:\n",
+    "        label += \"MASKED\"\n",
+    "    elif not sigma_g[idx]:\n",
+    "        label += \"SIGMA G\"\n",
+    "    else:\n",
+    "        label += \"VALID\"\n",
+    "    labels.append(label)\n",
+    "\n",
+    "fig = plt.figure(layout=\"tight\", figsize=(img_width * num_cols, img_width * num_rows))\n",
+    "plot_multiple_images(single_res[\"all_stamps\"], fig, columns=num_cols, labels=labels, norm=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8ed2c27-7455-43ac-bc4d-9bb234cea6bd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/analysis/FakeAnalysis.ipynb
+++ b/notebooks/analysis/FakeAnalysis.ipynb
@@ -25,11 +25,7 @@
     "from kbmod.results import Results\n",
     "from kbmod.trajectory_explorer import TrajectoryExplorer\n",
     "from kbmod.trajectory_utils import match_trajectory_sets\n",
-    "from kbmod.work_unit import WorkUnit\n",
-    "\n",
-    "import logging\n",
-    "\n",
-    "logging.basicConfig(level=logging.INFO)"
+    "from kbmod.work_unit import WorkUnit"
    ]
   },
   {
@@ -37,7 +33,9 @@
    "id": "3eaee439-d70d-494a-a160-1e215367d39b",
    "metadata": {},
    "source": [
-    "Load the test `WorkUnit` and extract some metadata (t0 and configuration).  Also extract the configuration and set up a `TrajectoryExplorer` object that we can later use to run simulated searches on the `WorkUnit`."
+    "## Load the WorkUnit\n",
+    "\n",
+    "Load the test `WorkUnit` for this run and extract some metadata (t0 and configuration).  Also extract the configuration and set up a `TrajectoryExplorer` object that we can later use to run simulated searches on the `WorkUnit`."
    ]
   },
   {
@@ -84,6 +82,8 @@
    "id": "4b493346-e0ea-44e3-88d9-70dae946c6df",
    "metadata": {},
    "source": [
+    "## Load the Inserted Fakes\n",
+    "\n",
     "Load the fakes data from the ecsv file. For each object (unique orbitid), build a trajectory with from those observations.  We use the `load_fake_info_from_ecsv()` helper function."
    ]
   },
@@ -115,9 +115,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for fake in fakes_list:\n",
+    "for idx, fake in enumerate(fakes_list):\n",
     "    fake.join_with_workunit(wu, 10)\n",
-    "    print(f\"{fake.name}:\\n  Fit:{fake.trj}\\n  MSE={fake.compute_fit_mse()}\")"
+    "    print(f\"{idx}, {fake.name}:\\n  {fake.trj}\\n  MSE={fake.compute_fit_mse()}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ea61f20-6922-4d78-8647-1328c26d1238",
+   "metadata": {},
+   "source": [
+    "We can also plot some summary information.  Here we plot three aspects:\n",
+    "  * RA vs time to show how linear the trajectory is in that dimension.\n",
+    "  * Dec vs time to show how linear the trajectory is in that dimension.\n",
+    "  * Magnitude vs time to show how the signal is changing over time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d30b82d-e1dd-4884-900b-04f470c84f97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for idx, fake in enumerate(fakes_list):\n",
+    "    fake.plot_summary(title=f\"\\n---------------\\n({idx}) {fake.name}\")"
    ]
   },
   {
@@ -125,7 +147,7 @@
    "id": "5dacebfa-a101-468f-9376-a8aab60369fa",
    "metadata": {},
    "source": [
-    "# Examining Stamps\n",
+    "## Examining Stamps\n",
     "\n",
     "We can plot the stamps at the raw (x, y) that we computed from the (RA, dec) position and the image WCS. We can also look at the positions predicted by the fitted, linear trajectory.  Below we look at the stamps at the first 4 time steps."
    ]
@@ -180,11 +202,13 @@
     "known_list = [fake.trj for fake in fakes_list]\n",
     "found_list = results.make_trajectory_list()\n",
     "\n",
-    "matches = match_trajectory_sets(known_list, found_list, 200.0, times=[0.0, zeroed_times[-1]])\n",
+    "# Match the known fakes and the found trajectories. To match the mean error at t_0 and t_last\n",
+    "# must be <= 10.0 pixels.\n",
+    "matches = match_trajectory_sets(known_list, found_list, 10.0, times=[0.0, zeroed_times[-1]])\n",
     "\n",
     "for idx, trj in enumerate(known_list):\n",
     "    m_idx = matches[idx]\n",
-    "    print(f\"Fake {idx}: Match={m_idx}\")\n",
+    "    print(f\"Fake {idx} ({fakes_list[idx].name}): Match={m_idx}\")\n",
     "    print(f\"  Fake TRJ: x={trj.x:5d}, y={trj.y:5d}, vx={trj.vx:8.3f}, vy={trj.vy:8.3f}\")\n",
     "    if m_idx != -1:\n",
     "        m_trj = found_list[m_idx]\n",
@@ -200,7 +224,10 @@
    "source": [
     "# Per Fake Investigation\n",
     "\n",
-    "Now let's go deep on understanding what happened with a single fake.  The first unmatched fake was 2."
+    "Now let's go deep on understanding what happened with each fake by trying a search on exactly the fit parameters. For each fake we are going to display:\n",
+    "  * The coadded stamps from the fitted trajectory. The red dots indicate masked points.\n",
+    "  * The psi, phi, and lh curves as computed after sigma-G filtering. The red dots indicate pointed that are either masked or filtered by sigma-G filtering. Masked points are also assigned values of 0.0.\n",
+    "  * The individual stamp at each time. We also indicate whether the stamp was a valid time step, a masked time step (e.g. bad pixel), or filtered by sigma-G filtering."
    ]
   },
   {
@@ -210,99 +237,90 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fake_num = 2\n",
+    "subplot_size = 3.0\n",
     "\n",
-    "trj = fakes_list[fake_num].trj\n",
-    "single_res = explorer.evaluate_linear_trajectory(trj.x, trj.y, trj.vx, trj.vy)[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bb60724d-1f92-4945-8b95-817cc31ef753",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(f\"TRJ: x={trj.x:5d}, y={trj.y:5d}, vx={trj.vx:8.3f}, vy={trj.vy:8.3f}\")\n",
-    "print(f\"GPU LH {single_res['likelihood']}\")\n",
+    "for idx, fake in enumerate(fakes_list):\n",
+    "    trj = fake.trj\n",
+    "    single_res = explorer.evaluate_linear_trajectory(trj.x, trj.y, trj.vx, trj.vy)[0]\n",
     "\n",
-    "# Plot some summary data.\n",
-    "fig, ax = plt.subplots(2, 3, figsize=(12.0, 8.0))\n",
-    "plot_image(single_res[\"coadd_sum\"], ax=ax[0][0], figure=fig, norm=True, title=\"Sum Stamp\")\n",
-    "plot_image(single_res[\"coadd_mean\"], ax=ax[0][1], figure=fig, norm=True, title=\"Mean Stamp\")\n",
-    "plot_image(single_res[\"coadd_median\"], ax=ax[0][2], figure=fig, norm=True, title=\"Median Stamp\")\n",
-    "\n",
-    "psi = single_res[\"psi_curve\"]\n",
-    "phi = single_res[\"phi_curve\"]\n",
-    "valid = (phi != 0) & np.isfinite(psi) & np.isfinite(phi)\n",
-    "\n",
-    "psi[~valid] = 0.0\n",
-    "phi[~valid] = 1e-28\n",
-    "lh = psi / np.sqrt(phi)\n",
-    "\n",
-    "plot_time_series(psi, zeroed_times, indices=valid, ax=ax[1][0], figure=fig, title=\"PSI\")\n",
-    "plot_time_series(phi, zeroed_times, indices=valid, ax=ax[1][1], figure=fig, title=\"PHI\")\n",
-    "plot_time_series(lh, zeroed_times, indices=valid, ax=ax[1][2], figure=fig, title=\"LH\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f2a4f9eb-1ae3-431e-9401-3a7390a52f41",
-   "metadata": {},
-   "source": [
-    "The plots above do not account for the sigma-G filtering performed on the GPU or afterwards. So let's add that into i"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "30fa45b4-20ae-452a-95dc-62c23138fe0e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Plot some summary data.\n",
-    "fig, ax = plt.subplots(1, 3, figsize=(12.0, 4.0))\n",
-    "\n",
-    "sigma_g = single_res[\"sigma_g_res\"]\n",
-    "valid2 = (phi != 0) & np.isfinite(psi) & np.isfinite(phi) & sigma_g\n",
-    "\n",
-    "plot_time_series(psi, zeroed_times, indices=valid2, ax=ax[0], figure=fig, title=\"PSI\")\n",
-    "plot_time_series(phi, zeroed_times, indices=valid2, ax=ax[1], figure=fig, title=\"PHI\")\n",
-    "plot_time_series(lh, zeroed_times, indices=valid2, ax=ax[2], figure=fig, title=\"LH\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c333260f-02a8-45c1-a62c-80fdebc88cf6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "num_stamps = len(single_res[\"all_stamps\"])\n",
-    "\n",
-    "num_cols = 4\n",
-    "num_rows = np.ceil(num_stamps / num_cols)\n",
-    "img_width = 2.0\n",
-    "\n",
-    "labels = []\n",
-    "for idx, t in enumerate(zeroed_times):\n",
-    "    label = f\"{idx}={t:.4f}\\n\"\n",
-    "    if not valid[idx]:\n",
-    "        label += \"MASKED\"\n",
-    "    elif not sigma_g[idx]:\n",
-    "        label += \"SIGMA G\"\n",
+    "    # Extract the basic information to use in the title string.\n",
+    "    data_str = f\"\\n---------------------------\\n{idx}: Orbit ID={fake.name}\\n\"\n",
+    "    if matches[idx] == -1:\n",
+    "        data_str += \"  Status: NOT FOUND\\n\"\n",
+    "        data_str += f\"  FAKE TRJ: x={trj.x:5d}, y={trj.y:5d}, vx={trj.vx:8.3f}, vy={trj.vy:8.3f}\\n\"\n",
     "    else:\n",
-    "        label += \"VALID\"\n",
-    "    labels.append(label)\n",
+    "        data_str += f\"  Status: RECOVERED (result={matches[idx]})\\n\"\n",
+    "        data_str += f\"   FAKE TRJ: x={trj.x:5d}, y={trj.y:5d}, vx={trj.vx:8.3f}, vy={trj.vy:8.3f}\\n\"\n",
+    "        data_str += f\"  FOUND TRJ: x={m_trj.x:5d}, y={m_trj.y:5d}, vx={m_trj.vx:8.3f}, vy={m_trj.vy:8.3f}\\n\"\n",
+    "        data_str += f\"  Score: lh={m_trj.lh}, obs_count={m_trj.obs_count}\\n\"\n",
+    "    data_str += f\"  FAKE GPU LH: {single_res['likelihood']}\\n\"\n",
     "\n",
-    "fig = plt.figure(layout=\"tight\", figsize=(img_width * num_cols, img_width * num_rows))\n",
-    "plot_multiple_images(single_res[\"all_stamps\"], fig, columns=num_cols, labels=labels, norm=True)"
+    "    # Plot some summary data.\n",
+    "    fig = plt.figure(layout=\"tight\", figsize=(3 * subplot_size, 2 * subplot_size))\n",
+    "    ax = fig.subplots(2, 3)\n",
+    "    fig.suptitle(data_str)\n",
+    "\n",
+    "    plot_image(\n",
+    "        single_res[\"coadd_sum\"], ax=ax[0][0], figure=fig, norm=True, title=\"Sum Stamp\", show_counts=False\n",
+    "    )\n",
+    "    plot_image(\n",
+    "        single_res[\"coadd_mean\"], ax=ax[0][1], figure=fig, norm=True, title=\"Mean Stamp\", show_counts=False\n",
+    "    )\n",
+    "    plot_image(\n",
+    "        single_res[\"coadd_median\"],\n",
+    "        ax=ax[0][2],\n",
+    "        figure=fig,\n",
+    "        norm=True,\n",
+    "        title=\"Median Stamp\",\n",
+    "        show_counts=False,\n",
+    "    )\n",
+    "\n",
+    "    # Compute the psi, phi, and LH curves without sigma-G filtering. Only\n",
+    "    # account for the masked points (valid array).\n",
+    "    psi = single_res[\"psi_curve\"]\n",
+    "    phi = single_res[\"phi_curve\"]\n",
+    "    valid = (phi != 0) & np.isfinite(psi) & np.isfinite(phi)\n",
+    "\n",
+    "    psi[~valid] = 0.0\n",
+    "    phi[~valid] = 1e-28\n",
+    "    lh = psi / np.sqrt(phi)\n",
+    "\n",
+    "    # Run sigma-G filtering on the curves and mark any points that\n",
+    "    # are either masked or subject to sigma-G filtering.\n",
+    "    sigma_g = single_res[\"sigma_g_res\"]\n",
+    "    valid2 = (phi != 0) & np.isfinite(psi) & np.isfinite(phi) & sigma_g\n",
+    "\n",
+    "    plot_time_series(psi, zeroed_times, indices=valid2, ax=ax[1][0], figure=fig, title=\"Sigma G PSI\")\n",
+    "    plot_time_series(phi, zeroed_times, indices=valid2, ax=ax[1][1], figure=fig, title=\"Sigma G PHI\")\n",
+    "    plot_time_series(lh, zeroed_times, indices=valid2, ax=ax[1][2], figure=fig, title=\"Sigma G LH\")\n",
+    "\n",
+    "    # Plot the stamps as their own figure.\n",
+    "    num_stamps = len(single_res[\"all_stamps\"])\n",
+    "    num_cols = 5\n",
+    "    num_rows = np.ceil(num_stamps / num_cols)\n",
+    "    img_width = 2.0\n",
+    "\n",
+    "    labels = []\n",
+    "    for idx, t in enumerate(zeroed_times):\n",
+    "        label = f\"{idx}={t:.4f}\\n\"\n",
+    "        if not valid[idx]:\n",
+    "            label += \"MASKED\"\n",
+    "        elif not sigma_g[idx]:\n",
+    "            label += \"SIGMA G\"\n",
+    "        else:\n",
+    "            label += \"VALID\"\n",
+    "        labels.append(label)\n",
+    "\n",
+    "    fig = plt.figure(layout=\"tight\", figsize=(img_width * num_cols, img_width * num_rows))\n",
+    "    plot_multiple_images(single_res[\"all_stamps\"], fig, columns=num_cols, labels=labels, norm=True)\n",
+    "\n",
+    "plt.show()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b8ed2c27-7455-43ac-bc4d-9bb234cea6bd",
+   "id": "39bec561-46cf-4153-8140-80ec9058533c",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/kbmod/analysis/plotting.py
+++ b/src/kbmod/analysis/plotting.py
@@ -532,7 +532,7 @@ def plot_time_series(values, times=None, indices=None, ax=None, figure=None, tit
         ax.set_title(title)
 
 
-def plot_result_row(row, times=None, figure=None):
+def plot_result_row(row, times=None, coadd_col="stamp", figure=None):
     """Plot a single row of the results table.
 
     Parameters
@@ -542,6 +542,8 @@ def plot_result_row(row, times=None, figure=None):
     times : a `list` or `numpy.ndarray` of floats
         The array of the time stamps. If ``None`` then uses equally
         spaced points. `None` by default.
+    coadd_col : `str`
+        The name of the coadd to display.
     figure : `matplotlib.pyplot.Figure` or `None`
         Figure, `None` by default.
     """
@@ -554,8 +556,8 @@ def plot_result_row(row, times=None, figure=None):
     # In the top subfigure plot the coadded stamp on the left and
     # the light curve on the right.
     (ax_stamp, ax_lc) = fig_top.subplots(1, 2)
-    if "stamp" in row and row["stamp"] is not None:
-        plot_image(row["stamp"], ax=ax_stamp, figure=fig_top, norm=True, title="Coadded Stamp")
+    if coadd_col in row.colnames and row[coadd_col] is not None:
+        plot_image(row[coadd_col], ax=ax_stamp, figure=fig_top, norm=True, title="Coadded Stamp")
     else:
         ax_stamp.text(0.5, 0.5, "No Stamp")
 


### PR DESCRIPTION
Extend the notebook (and libraries) for analyzing fakes to:
- Output plots of the fakes' (RA, dec) and magnitude over time.
- Match against the results table to see which fakes were found.
- Run `TrajectoryExplorer` to see what the GPU saw during the search.
- Plot the coadds, psi/phi/lh curves, and stamps found by the core search.
- Add the ability to run sigma-g filtering without applying it (just getting the mask)
