### PR TITLE
Add times attributes to Results

### DIFF
--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -32,6 +32,9 @@ class Results:
     wcs : `astropy.wcs.WCS`
         A global WCS for all the results. This is optional and primarily used when saving
         the results to a file so as to preserve the WCS for future analysis.
+    times : `np.ndarray`
+        An array of the times for each observation. This is optional and primarily used
+        when saving the results to a file so as to preserve the times for future analysis.
     track_filtered : `bool`
         Whether to track (save) the filtered trajectories. This will use
         more memory and is recommended only for analysis.
@@ -57,7 +60,7 @@ class Results:
     ]
     _required_col_names = set([rq_col[0] for rq_col in required_cols])
 
-    def __init__(self, data=None, track_filtered=False, wcs=None):
+    def __init__(self, data=None, track_filtered=False, wcs=None, times=None):
         """Create a ResultTable class.
 
         Parameters
@@ -68,9 +71,12 @@ class Results:
             Whether to track (save) the filtered trajectories. This will use
             more memory and is recommended only for analysis.
         wcs : `astropy.wcs.WCS`, optional
-            A gloabl WCS for the results.
+            A global WCS for the results.
+        times : `np.ndarray`, optional
+            A list of times.
         """
         self.wcs = wcs
+        self.times = times
 
         # Set up information to track which row is filtered at which round.
         self.track_filtered = track_filtered
@@ -124,6 +130,8 @@ class Results:
         result : `int`
             The number of time steps. Returns 0 if there is no such information.
         """
+        if self.times is not None:
+            return len(self.times)
         if "psi_curve" in self.table.colnames:
             return self.table["psi_curve"].shape[1]
         if "phi_curve" in self.table.colnames:
@@ -187,7 +195,13 @@ class Results:
         else:
             wcs = None
 
-        return Results(data, track_filtered=track_filtered, wcs=wcs)
+        # Check if we have a list of observed times.
+        if "times" in data.meta:
+            times = np.array(data.meta["times"])
+        else:
+            times = None
+
+        return Results(data, track_filtered=track_filtered, wcs=wcs, times=times)
 
     def remove_column(self, colname):
         """Remove a column from the results table.
@@ -674,6 +688,8 @@ class Results:
         if self.wcs is not None:
             logger.debug("Saving WCS to Results table meta data.")
             write_table.meta["wcs"] = serialize_wcs(self.wcs)
+        if self.times is not None:
+            write_table.meta["times"] = self.times
         if extra_meta is not None:
             for key, val in extra_meta.items():
                 logger.debug(f"Saving {key} to Results table meta data.")

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -297,6 +297,10 @@ class SearchRunner:
         meta_to_save["dims"] = stack.get_width(), stack.get_height()
         meta_to_save["mjd_mid"] = [stack.get_obstime(i) for i in range(num_img)]
 
+        # We also save the times to the attribute. This technical writes them twice
+        # but maintains compatibility with analysis scripts that need 'mjd_mid'.
+        keep.times = np.array([stack.get_obstime(i) for i in range(num_img)])
+
         if config["result_filename"] is not None:
             logger.info(f"Saving results table to {config['result_filename']}")
             if not config["save_all_stamps"]:

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -52,6 +52,8 @@ class test_results(unittest.TestCase):
         self.assertEqual(len(table), 0)
         self.assertEqual(len(table.colnames), 7)
         self.assertEqual(table.get_num_times(), 0)
+        self.assertIsNone(table.wcs)
+        self.assertIsNone(table.times)
 
         # Check that we don't crash on updating the likelihoods.
         table._update_likelihood()
@@ -60,6 +62,8 @@ class test_results(unittest.TestCase):
         table = Results.from_trajectories(self.trj_list)
         self.assertEqual(len(table), self.num_entries)
         self.assertEqual(len(table.colnames), 7)
+        self.assertIsNone(table.wcs)
+        self.assertIsNone(table.times)
         self._assert_results_match_dict(table, self.input_dict)
 
     def test_from_dict(self):
@@ -432,6 +436,9 @@ class test_results(unittest.TestCase):
         fake_wcs = make_fake_wcs(25.0, -7.5, 800, 600, deg_per_pixel=0.01)
         table.wcs = fake_wcs
 
+        # Add fake times.
+        table.times = np.array([1, 2, 3, 4, 5])
+
         # Test read/write to file.
         with tempfile.TemporaryDirectory() as dir_name:
             file_path = os.path.join(dir_name, "results.ecsv")
@@ -460,7 +467,7 @@ class test_results(unittest.TestCase):
                 file_path,
                 overwrite=True,
                 cols_to_drop=["other"],
-                extra_meta={"times": [1, 2, 3, 4, 5], "other": 100.0},
+                extra_meta={"other": 100.0},
             )
 
             table3 = Results.read_table(file_path)


### PR DESCRIPTION
Add an optional times attribute to the `Results` object. This makes analysis easier by being able to refer to `results.times`. It can add some overhead in cases where the results object was already storing the times in the "mjd_mid" meta data column. We need to preserve that for compatibility with Dino's analysis scripts. But using the "time" meta data column will be clearer in the future.