### PR TITLE
fix extra memory usage in ImageCollection

### DIFF
--- a/src/kbmod/image_collection.py
+++ b/src/kbmod/image_collection.py
@@ -898,7 +898,9 @@ class ImageCollection:
             metadata["per_image_wcs"] = list(self.wcs)
 
         # Create the basic WorkUnit from the ImageStack.
-        imgstack = ImageStack(layeredImages)
+        imgstack = ImageStack()
+        for layimg in layeredImages:
+            imgstack.append_image(layimg, force_move=True)
         work = WorkUnit(imgstack, search_config, org_image_meta=metadata)
 
         return work


### PR DESCRIPTION
uses the `force_move` option for `ImageStack.append_image` to get rid of memory duplication.

## Before

![icmem1](https://github.com/user-attachments/assets/99ba2957-8985-46fe-ac4d-19e83f415ca0)


## After

![icmem2](https://github.com/user-attachments/assets/f45233e2-dfde-42de-a950-b9ebbdc684c2)
