### PR TITLE
Add a flag to turn of sigma G filtering

### DIFF
--- a/src/kbmod/configuration.py
+++ b/src/kbmod/configuration.py
@@ -44,6 +44,7 @@ class SearchConfiguration:
             "result_filename": None,
             "results_per_pixel": 8,
             "save_all_stamps": False,
+            "sigmaG_filter": True,
             "sigmaG_lims": [25, 75],
             "stamp_radius": 10,
             "stamp_type": "sum",

--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -354,7 +354,7 @@ class Results:
         else:
             phi_sum = self.table["phi_curve"].sum(axis=1)
             psi_sum = self.table["psi_curve"].sum(axis=1)
-            num_obs = np.full((num_rows, 1), num_times)
+            num_obs = np.full(num_rows, num_times)
 
         non_zero = phi_sum != 0
         self.table["likelihood"] = np.zeros((num_rows))

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -49,7 +49,7 @@ def configure_kb_search_stack(search, config):
     search.set_results_per_pixel(config["results_per_pixel"])
 
     # If we are using gpu_filtering, enable it and set the parameters.
-    if config["gpu_filter"]:
+    if config["sigmaG_filter"] and config["gpu_filter"]:
         logger.debug("Using in-line GPU sigmaG filtering methods")
         coeff = SigmaGClipping.find_sigma_g_coeff(
             config["sigmaG_lims"][0],
@@ -154,7 +154,8 @@ class SearchRunner:
                 result_batch.add_psi_phi_data(psi_batch, phi_batch)
 
                 # Do the sigma-G filtering and subsequent stats filtering.
-                apply_clipped_sigma_g(clipper, result_batch)
+                if config["sigmaG_filter"]:
+                    apply_clipped_sigma_g(clipper, result_batch)
                 obs_row_mask = result_batch["obs_count"] >= num_obs
                 result_batch.filter_rows(obs_row_mask, "obs_count")
                 logger.debug(f"After obs_count >= {num_obs}. Batch size = {len(result_batch)}")

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -174,7 +174,16 @@ class test_results(unittest.TestCase):
         exp_flux = [1.15, 1.1666667, 0.0]
         exp_obs = [4, 3, 0]
 
-        # Check the the data has been inserted and the statistics have been updated.
+        # Without obs_valid: Check the the data has been inserted and the
+        # statistics have been updated.
+        table.add_psi_phi_data(psi_array, phi_array)
+        for i in range(num_to_use):
+            self.assertEqual(len(table["psi_curve"][i]), 4)
+            self.assertEqual(len(table["phi_curve"][i]), 4)
+            self.assertEqual(table["obs_count"][i], 4)
+
+        # With obs_valid: Check the the data has been inserted and the
+        # statistics have been updated.
         table.add_psi_phi_data(psi_array, phi_array, obs_valid)
         for i in range(num_to_use):
             self.assertEqual(len(table["psi_curve"][i]), 4)


### PR DESCRIPTION
Closes #861 

The bulk of this PR is adding a new test for for `load_and_filter_results()` which was previously untested. In the process, I found a small bug with `Results._update_likelihood()` where it was producing a 2-d array instead of a 1-d array.  This fixes that and adds a test.