### PR TITLE
Switch from JAX to PyTorch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "astropy>=5.1",
-    "jax",
     "joblib>=1.4",
     "jplephem",
     "matplotlib>=3.5",
@@ -42,6 +41,7 @@ dependencies = [
     "scipy>=1.9.2",
     "scikit_learn>=1.0.0",
     "tensorflow",
+    "torch",
     "tqdm",
     "PyYAML>=6.0"
 ]


### PR DESCRIPTION
Switch SigmaG filtering from JAX to PyTorch. The main advantage is better usability and control of PyTorch. An additional advantage is the PyTorch implementation is faster (1.7ms for 10,000 rows instead of 2.6ms on Baldur).