### PR TITLE
Make UTC standard throughout KBMOD

### DIFF
--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -9,6 +9,7 @@ import numpy as np
 from pathlib import Path
 
 from astropy.table import Table, vstack
+from astropy.time import Time
 
 from kbmod.trajectory_utils import trajectories_to_dict
 from kbmod.search import Trajectory
@@ -33,8 +34,9 @@ class Results:
         A global WCS for all the results. This is optional and primarily used when saving
         the results to a file so as to preserve the WCS for future analysis.
     mjd_mid : `np.ndarray`
-        An array of the times (mid-MJD) for each observation. This is optional and primarily
-        used when saving the results to a file so as to preserve the times for future analysis.
+        An array of the times (mid-MJD) for each observation in UTC. This is optional
+        and primarily used when saving the results to a file so as to preserve the times
+        for future analysis.
     track_filtered : `bool`
         Whether to track (save) the filtered trajectories. This will use
         more memory and is recommended only for analysis.
@@ -60,7 +62,7 @@ class Results:
     ]
     _required_col_names = set([rq_col[0] for rq_col in required_cols])
 
-    def __init__(self, data=None, track_filtered=False, wcs=None, mjd_mid=None):
+    def __init__(self, data=None, track_filtered=False, wcs=None):
         """Create a ResultTable class.
 
         Parameters
@@ -72,11 +74,9 @@ class Results:
             more memory and is recommended only for analysis.
         wcs : `astropy.wcs.WCS`, optional
             A global WCS for the results.
-        mjd_mid : `np.ndarray`, optional
-            A list of times.
         """
         self.wcs = wcs
-        self.mjd_mid = mjd_mid
+        self.mjd_mid = None
 
         # Set up information to track which row is filtered at which round.
         self.track_filtered = track_filtered
@@ -115,6 +115,18 @@ class Results:
 
     def __getitem__(self, key):
         return self.table[key]
+
+    @property
+    def mjd_utc_mid(self):
+        return self.mjd_mid
+
+    @property
+    def mjd_tai_mid(self):
+        return Time(self.mjd_mid, format="mjd", scale="utc").tai.mjd
+
+    def set_mjd_utc_mid(self, times):
+        """Set the midpoint times in UTC MJD."""
+        self.mjd_mid = times
 
     @property
     def colnames(self):
@@ -195,13 +207,16 @@ class Results:
         else:
             wcs = None
 
-        # Check if we have a list of observed times.
-        if "mjd_mid" in data.meta:
-            mjd_mid = np.array(data.meta["mjd_mid"])
-        else:
-            mjd_mid = None
+        # Create the results object.
+        results = Results(data, track_filtered=track_filtered, wcs=wcs)
 
-        return Results(data, track_filtered=track_filtered, wcs=wcs, mjd_mid=mjd_mid)
+        # Check if we have a list of observed times.
+        if "mjd_utc_mid" in data.meta:
+            results.set_mjd_utc_mid(np.array(data.meta["mjd_utc_mid"]))
+        elif "mjd_mid" in data.meta:
+            results.set_mjd_utc_mid(np.array(data.meta["mjd_mid"]))
+
+        return results
 
     def remove_column(self, colname):
         """Remove a column from the results table.
@@ -689,7 +704,11 @@ class Results:
             logger.debug("Saving WCS to Results table meta data.")
             write_table.meta["wcs"] = serialize_wcs(self.wcs)
         if self.mjd_mid is not None:
+            # Save different format time stamps.
             write_table.meta["mjd_mid"] = self.mjd_mid
+            write_table.meta["mjd_utc_mid"] = self.mjd_mid
+            write_table.meta["mjd_tai_mid"] = self.mjd_tai_mid
+
         if extra_meta is not None:
             for key, val in extra_meta.items():
                 logger.debug(f"Saving {key} to Results table meta data.")

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -304,7 +304,7 @@ class SearchRunner:
             meta_to_save = {}
         meta_to_save["num_img"] = num_img
         meta_to_save["dims"] = stack.get_width(), stack.get_height()
-        keep.mjd_mid = np.array([stack.get_obstime(i) for i in range(num_img)])
+        keep.set_mjd_utc_mid(np.array([stack.get_obstime(i) for i in range(num_img)]))
 
         if config["result_filename"] is not None:
             logger.info(f"Saving results table to {config['result_filename']}")

--- a/src/kbmod/search/pydocs/image_stack_docs.h
+++ b/src/kbmod/search/pydocs/image_stack_docs.h
@@ -104,7 +104,7 @@ static const auto DOC_ImageStack_get_obstime = R"doc(
   Returns
   -------
   time : `double`
-      The observation time (in MJD).
+      The observation time (in UTC MJD).
 
   Raises
   ------

--- a/src/kbmod/search/pydocs/layered_image_docs.h
+++ b/src/kbmod/search/pydocs/layered_image_docs.h
@@ -118,11 +118,11 @@ static const auto DOC_LayeredImage_get_npixels = R"doc(
   )doc";
 
 static const auto DOC_LayeredImage_get_obstime = R"doc(
-  Get the image's observation time.
+  Get the image's observation time in UTC MJD.
   )doc";
 
 static const auto DOC_LayeredImage_set_obstime = R"doc(
-  Set the image's observation time.
+  Set the image's observation time in UTC MJD.
   )doc";
 
 static const auto DOC_LayeredImage_contains = R"doc(

--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -304,11 +304,11 @@ class ButlerStandardizer(Standardizer):
         half_way = mjd_start + (expt / 2) * u.s + 0.5 * u.s
         self._metadata["exposureTime"] = expt
 
-        # Note the timescales for MJD
-        # Name mjd into mjd_mid - make it obvious it's mdidle of exposure
-        # and add time scale like mjd_mid_utc
-        self._metadata["mjd_start"] = mjd_start.mjd
-        self._metadata["mjd_mid"] = half_way.mjd
+        # Note the timescales for MJD. The Butler uses TAI, but we convert
+        # time stamps to UTC for consistency.
+        # Name mjd into mjd_mid - make it obvious it's middle of exposure.
+        self._metadata["mjd_start"] = mjd_start.utc.mjd
+        self._metadata["mjd_mid"] = half_way.utc.mjd
 
         self._metadata["object"] = visit.object
         self._metadata["pointing_ra"] = visit.boresightRaDec.getRa().asDegrees()

--- a/src/kbmod/standardizers/fits_standardizers/fits_standardizer.py
+++ b/src/kbmod/standardizers/fits_standardizers/fits_standardizer.py
@@ -345,7 +345,7 @@ class FitsStandardizer(Standardizer):
         ======== ==============================================================
         Key      Description
         ======== ==============================================================
-        mjd_mid  Decimal MJD timestamp of the start of the observation
+        mjd_mid  Decimal MJD timestamp of the start of the observation (in UTC)
         ra       Right Ascension in ICRS coordinate system of the extracted, or
                  calculated on-sky poisiton of the central pixel, pointing
                  data.

--- a/src/kbmod/standardizers/fits_standardizers/kbmodv05.py
+++ b/src/kbmod/standardizers/fits_standardizers/kbmodv05.py
@@ -143,13 +143,13 @@ class KBMODV0_5(MultiExtensionFits):
         """Returns at least the following metadata, read from the primary header,
          as a dictionary:
 
-        ======== ========== ===================================================
+        ======== ========== =========================================================
         Key      Header Key Description
-        ======== ========== ===================================================
-        mjd      DATE-AVG   Decimal MJD timestamp of the middle of the exposure
+        ======== ========== =========================================================
+        mjd      DATE-AVG   Decimal MJD timestamp of the middle of the exposure (UTC)
         filter   FILTER     Filter band
         visit    EXPID      Exposure ID
-        ======== ========== ===================================================
+        ======== ========== =========================================================
         """
         # this is the 1 mandatory piece of metadata we need to extract
         standardizedHeader = {}

--- a/src/kbmod/standardizers/fits_standardizers/kbmodv1.py
+++ b/src/kbmod/standardizers/fits_standardizers/kbmodv1.py
@@ -138,10 +138,10 @@ class KBMODV1(MultiExtensionFits):
         """Returns the following metadata, read from the primary header, as a
         dictionary:
 
-        ======== ========== ===================================================
+        ======== ========== ===========================================================
         Key      Header Key Description
-        ======== ========== ===================================================
-        mjd_mid  DATE-AVG   Decimal MJD timestamp of the middle of the exposure
+        ======== ========== ===========================================================
+        mjd_mid  DATE-AVG   Decimal MJD timestamp of the middle of the exposure (UTC).
         FILTER   FILTER     Filter band
         visit    EXPID      Exposure ID
         IDNUM    IDNUM      Visit ID
@@ -149,7 +149,7 @@ class KBMODV1(MultiExtensionFits):
         obs_lat  OBS-LAT    Observatory Latitude
         obs_lon  OBS-LONG   Observatory Longitude
         obs_elev OBS-ELEV   Observatory elevation.
-        ======== ========== ===================================================
+        ======== ========== ===========================================================
         """
         # this is the 1 mandatory piece of metadata we need to extract
         standardizedHeader = {}

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -76,7 +76,7 @@ class WorkUnit:
         The paths for the shard files, only created if the `WorkUnit` is loaded
         in lazy mode.
     obstimes : `list[float]`
-        The MJD obstimes of the images.
+        The MJD obstimes of the midpoint of the images (in UTC).
 
     Parameters
     ----------
@@ -108,7 +108,7 @@ class WorkUnit:
         The paths for the shard files, only created if the `WorkUnit` is loaded
         in lazy mode.
     obstimes : `list[float]`
-        The MJD obstimes of the images.
+        The MJD obstimes of the midpoint of the images (in UTC).
     org_image_meta : `astropy.table.Table`, optional
         A table of per-image data for the constituent images.
     """

--- a/tests/test_butlerstd.py
+++ b/tests/test_butlerstd.py
@@ -61,7 +61,7 @@ class TestButlerStandardizer(unittest.TestCase):
             "GAINA": hdr["GAINA"],
             "GAINB": hdr["GAINB"],
             "DTNSANAM": hdr["DTNSANAM"],
-            "mjd_mid": Time(hdr["DATE-AVG"], format="isot").mjd
+            "mjd_mid": Time(hdr["DATE-AVG"], format="isot", scale="tai").utc.mjd
             + (hdr["EXPREQ"] + 0.5) / 2.0 / 60.0 / 60.0 / 24.0,
             "filter": hdr["FILTER"],
         }
@@ -110,7 +110,7 @@ class TestButlerStandardizer(unittest.TestCase):
             "detector": hdr["CCDNUM"],
             "exposureTime": hdr["EXPREQ"],
             "OBSID": hdr["OBSID"],
-            "mjd_mid": Time(hdr["DATE-AVG"], format="isot").mjd
+            "mjd_mid": Time(hdr["DATE-AVG"], format="isot", scale="tai").utc.mjd
             + (hdr["EXPREQ"] + 0.5) / 2.0 / 60.0 / 60.0 / 24.0,
             "filter": hdr["FILTER"],
         }

--- a/tests/utils/mock_butler.py
+++ b/tests/utils/mock_butler.py
@@ -333,7 +333,7 @@ class MockButler:
 
         mocked_visit = mock.Mock(name="VisitInfo")
         mocked_visit.exposureTime = prim["EXPREQ"]
-        expstart = Time(prim["DATE-AVG"], format="isot")
+        expstart = Time(prim["DATE-AVG"], format="isot", scale="tai")
         mocked_visit.date.toAstropy.return_value = expstart
         mocked_visit.date.toAstropy.return_value = expstart
         mocked_visit.date.return_value = expstart


### PR DESCRIPTION
Closes #865

Make UTC the standard throughout KBMOD. This changes the Butler standardizer (which returns times in TAI) to convert to UTC (requires a small change to the tests). It updates a bunch of comments throughout to help clarify. The FITS standardizers were already in UTC, so those just have comments added.