### PR TITLE
Compress the images within a WorkUnit

### DIFF
--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -1018,7 +1018,7 @@ def add_image_data_to_hdul(
     var_hdu.name = f"VAR_{idx}"
     var_hdu.header["MJD"] = obstime
 
-    mask_hdu = fits.ImageHDU(mask.astype(np.int32))
+    mask_hdu = fits.CompImageHDU(mask.astype(np.int32), compression_type="GZIP_1")
     mask_hdu.name = f"MSK_{idx}"
     mask_hdu.header["MJD"] = obstime
 

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -1000,12 +1000,14 @@ def add_image_data_to_hdul(
     wcs : `astropy.wcs.WCS`, optional
         An optional WCS to include in the header.
     """
-    # Compress using a high quantize_level to preserve most of the image information.
-    sci_hdu = fits.CompImageHDU(sci, compression_type="RICE_1", quantize_level=100.0)
+    # Use a high quantize_level to preserve most of the image information.
+    # In the tests a level of 100.0 did not add much noise, but we use
+    # 500.0 here to be conservative.
+    sci_hdu = fits.CompImageHDU(sci, compression_type="RICE_1", quantize_level=500.0)
     sci_hdu.name = f"SCI_{idx}"
     sci_hdu.header["MJD"] = obstime
 
-    var_hdu = fits.CompImageHDU(var, compression_type="RICE_1", quantize_level=100.0)
+    var_hdu = fits.CompImageHDU(var, compression_type="RICE_1", quantize_level=500.0)
     var_hdu.name = f"VAR_{idx}"
     var_hdu.header["MJD"] = obstime
 

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -1018,7 +1018,7 @@ def add_image_data_to_hdul(
     var_hdu.name = f"VAR_{idx}"
     var_hdu.header["MJD"] = obstime
 
-    mask_hdu = fits.CompImageHDU(mask.astype(int))
+    mask_hdu = fits.ImageHDU(mask.astype(np.int32))
     mask_hdu.name = f"MSK_{idx}"
     mask_hdu.header["MJD"] = obstime
 

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -1000,11 +1000,12 @@ def add_image_data_to_hdul(
     wcs : `astropy.wcs.WCS`, optional
         An optional WCS to include in the header.
     """
-    sci_hdu = fits.CompImageHDU(sci, compression_type="RICE_1")
+    # Compress using a high quantize_level to preserve most of the image information.
+    sci_hdu = fits.CompImageHDU(sci, compression_type="RICE_1", quantize_level=100.0)
     sci_hdu.name = f"SCI_{idx}"
     sci_hdu.header["MJD"] = obstime
 
-    var_hdu = fits.CompImageHDU(var, compression_type="RICE_1")
+    var_hdu = fits.CompImageHDU(var, compression_type="RICE_1", quantize_level=100.0)
     var_hdu.name = f"VAR_{idx}"
     var_hdu.header["MJD"] = obstime
 

--- a/tests/test_reprojection.py
+++ b/tests/test_reprojection.py
@@ -99,19 +99,19 @@ class test_reprojection(unittest.TestCase):
                         1.0,
                     ]
                 ).astype("float32")
-                # make sure the PSF for the object hasn't been warped
-                # in the no-op case
-                print(data[0][0][5][53])
-                print(test_vals[0])
-                assert data[0][0][5][53] == test_vals[0]
+
+                # Make sure the PSF for the object hasn't been warped in the no-op case.
+                # We allow a little error in case the result is compressed as it is written
+                # to a file.
+                self.assertAlmostEqual(data[0][0][5][53], test_vals[0], delta=0.05)
 
                 # test other object locations
-                assert data[1][0][30][36] == test_vals[1]
-                assert data[2][0][4][18] == test_vals[2]
+                self.assertAlmostEqual(data[1][0][30][36], test_vals[1], delta=0.05)
+                self.assertAlmostEqual(data[2][0][4][18], test_vals[2], delta=0.05)
 
                 # test variance
                 assert not pixel_value_valid(data[2][1][25][0])
-                assert data[2][1][25][9] == test_vals[3]
+                self.assertAlmostEqual(data[2][1][25][9], test_vals[3], delta=0.05)
 
                 # test that mask values are projected without interpolation/bleeding
                 assert len(data[2][2][36][data[2][2][36] == 1.0]) == 9

--- a/tests/test_reprojection.py
+++ b/tests/test_reprojection.py
@@ -101,6 +101,8 @@ class test_reprojection(unittest.TestCase):
                 ).astype("float32")
                 # make sure the PSF for the object hasn't been warped
                 # in the no-op case
+                print(data[0][0][5][53])
+                print(test_vals[0])
                 assert data[0][0][5][53] == test_vals[0]
 
                 # test other object locations

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -22,7 +22,6 @@ from kbmod.work_unit import (
     create_image_metadata,
     hdu_to_image_metadata_table,
     image_metadata_table_to_hdu,
-    raw_image_to_hdu,
     WorkUnit,
 )
 
@@ -232,10 +231,11 @@ class test_work_unit(unittest.TestCase):
                 li = work2.im_stack.get_single_image(i)
                 self.assertEqual(li.get_obstime(), 59000.0 + (2 * i + 1))
 
-                # Check the three image layers match.
+                # Check the three image layers match. We give a lot of flexibility to the science and
+                # variance images due to compression.
                 li_org = self.im_stack.get_single_image(i)
-                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.001))
-                self.assertTrue(image_allclose(li.get_variance().image, li_org.get_variance().image, 0.001))
+                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.1))
+                self.assertTrue(image_allclose(li.get_variance().image, li_org.get_variance().image, 0.01))
                 self.assertTrue(image_allclose(li.get_mask().image, li_org.get_mask().image, 0.001))
 
                 # Check the PSF layer matches.
@@ -299,10 +299,11 @@ class test_work_unit(unittest.TestCase):
                 li = work2.im_stack.get_single_image(i)
                 self.assertEqual(li.get_obstime(), 59000.0 + (2 * i + 1))
 
-                # Check the three image layers match.
+                # Check the three image layers match. We give a lot of flexibility to the science and
+                # variance images due to compression.
                 li_org = self.im_stack.get_single_image(i)
-                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.001))
-                self.assertTrue(image_allclose(li.get_variance().image, li_org.get_variance().image, 0.001))
+                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.1))
+                self.assertTrue(image_allclose(li.get_variance().image, li_org.get_variance().image, 0.01))
                 self.assertTrue(image_allclose(li.get_mask().image, li_org.get_mask().image, 0.001))
 
             # Check that we read in the configuration values correctly.
@@ -341,10 +342,11 @@ class test_work_unit(unittest.TestCase):
                 li = work2.im_stack.get_single_image(i)
                 self.assertEqual(li.get_obstime(), 59000.0 + (2 * i + 1))
 
-                # Check the three image layers match.
+                # Check the three image layers match. We give a lot of flexibility to the science and
+                # variance images due to compression.
                 li_org = self.im_stack.get_single_image(i)
-                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.001))
-                self.assertTrue(image_allclose(li.get_variance().image, li_org.get_variance().image, 0.001))
+                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.1))
+                self.assertTrue(image_allclose(li.get_variance().image, li_org.get_variance().image, 0.01))
                 self.assertTrue(image_allclose(li.get_mask().image, li_org.get_mask().image, 0.001))
 
                 # Check the PSF layer matches.
@@ -384,10 +386,11 @@ class test_work_unit(unittest.TestCase):
                 li = work2.im_stack.get_single_image(i)
                 self.assertEqual(li.get_obstime(), 59000.0 + (2 * i + 1))
 
-                # Check the three image layers match.
+                # Check the three image layers match. We give a lot of flexibility to the science and
+                # variance images due to compression.
                 li_org = self.im_stack.get_single_image(i)
-                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.001))
-                self.assertTrue(image_allclose(li.get_variance().image, li_org.get_variance().image, 0.001))
+                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.1))
+                self.assertTrue(image_allclose(li.get_variance().image, li_org.get_variance().image, 0.01))
                 self.assertTrue(image_allclose(li.get_mask().image, li_org.get_mask().image, 0.001))
 
             # Check that we read in the configuration values correctly.

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -231,10 +231,11 @@ class test_work_unit(unittest.TestCase):
                 li = work2.im_stack.get_single_image(i)
                 self.assertEqual(li.get_obstime(), 59000.0 + (2 * i + 1))
 
-                # Check the three image layers match.
+                # Check the three image layers match. We use more permissive values for science and
+                # variance because of quantization during compression.
                 li_org = self.im_stack.get_single_image(i)
-                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.01))
-                self.assertTrue(image_allclose(li.get_variance().image, li_org.get_variance().image, 0.01))
+                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.05))
+                self.assertTrue(image_allclose(li.get_variance().image, li_org.get_variance().image, 0.05))
                 self.assertTrue(image_allclose(li.get_mask().image, li_org.get_mask().image, 0.001))
 
                 # Check the PSF layer matches.
@@ -290,10 +291,11 @@ class test_work_unit(unittest.TestCase):
                 li = work2.im_stack.get_single_image(i)
                 self.assertEqual(li.get_obstime(), 59000.0 + (2 * i + 1))
 
-                # Check the three image layers match.
+                # Check the three image layers match. We use more permissive values for science and
+                # variance because of quantization during compression.
                 li_org = self.im_stack.get_single_image(i)
-                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.01))
-                self.assertTrue(image_allclose(li.get_variance().image, li_org.get_variance().image, 0.01))
+                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.05))
+                self.assertTrue(image_allclose(li.get_variance().image, li_org.get_variance().image, 0.05))
                 self.assertTrue(image_allclose(li.get_mask().image, li_org.get_mask().image, 0.001))
 
                 # Check the PSF layer matches.

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -231,10 +231,9 @@ class test_work_unit(unittest.TestCase):
                 li = work2.im_stack.get_single_image(i)
                 self.assertEqual(li.get_obstime(), 59000.0 + (2 * i + 1))
 
-                # Check the three image layers match. We give a lot of flexibility to the science and
-                # variance images due to compression.
+                # Check the three image layers match.
                 li_org = self.im_stack.get_single_image(i)
-                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.1))
+                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.01))
                 self.assertTrue(image_allclose(li.get_variance().image, li_org.get_variance().image, 0.01))
                 self.assertTrue(image_allclose(li.get_mask().image, li_org.get_mask().image, 0.001))
 
@@ -269,57 +268,6 @@ class test_work_unit(unittest.TestCase):
             # We succeed if overwrite=True
             work.to_fits(file_path, overwrite=True)
 
-    def test_save_and_load_fits_compressed(self):
-        with tempfile.TemporaryDirectory() as dir_name:
-            file_path = os.path.join(dir_name, "test_workunit.bz2")
-
-            # Write out the existing WorkUnit with a different per-image wcs for all the entries.
-            # work = WorkUnit(self.im_stack, self.config, None, self.diff_wcs).
-            # Include extra per-image metadata.
-            extra_meta = {
-                "data_loc": np.array(self.constituent_images),
-                "int_index": np.arange(self.num_images),
-                "uri": np.array([f"file_loc_{i}" for i in range(self.num_images)]),
-            }
-            work = WorkUnit(
-                im_stack=self.im_stack,
-                config=self.config,
-                wcs=None,
-                per_image_wcs=self.diff_wcs,
-                org_image_meta=Table(extra_meta),
-            )
-            work.to_fits(file_path)
-            self.assertTrue(Path(file_path).is_file())
-
-            # Read in the file and check that the values agree.
-            work2 = WorkUnit.from_fits(file_path)
-            self.assertEqual(work2.im_stack.img_count(), self.num_images)
-            self.assertIsNone(work2.wcs)
-            for i in range(self.num_images):
-                li = work2.im_stack.get_single_image(i)
-                self.assertEqual(li.get_obstime(), 59000.0 + (2 * i + 1))
-
-                # Check the three image layers match. We give a lot of flexibility to the science and
-                # variance images due to compression.
-                li_org = self.im_stack.get_single_image(i)
-                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.1))
-                self.assertTrue(image_allclose(li.get_variance().image, li_org.get_variance().image, 0.01))
-                self.assertTrue(image_allclose(li.get_mask().image, li_org.get_mask().image, 0.001))
-
-            # Check that we read in the configuration values correctly.
-            self.assertEqual(work2.config["result_filename"], "Here")
-            self.assertEqual(work2.config["num_obs"], self.num_images)
-
-            # Check that we retrieved the extra metadata that we added.
-            npt.assert_array_equal(work2.get_constituent_meta("uri"), extra_meta["uri"])
-            npt.assert_array_equal(work2.get_constituent_meta("int_index"), extra_meta["int_index"])
-            npt.assert_array_equal(work2.get_constituent_meta("data_loc"), self.constituent_images)
-
-            # Check that the compressed file is smaller.
-            file_path_fits = os.path.join(dir_name, "test_workunit.fits")
-            work.to_fits(file_path_fits)
-            self.assertLess(os.path.getsize(file_path), os.path.getsize(file_path_fits))
-
     def test_save_and_load_fits_shard(self):
         with tempfile.TemporaryDirectory() as dir_name:
             file_path = os.path.join(dir_name, "test_workunit.fits")
@@ -342,10 +290,9 @@ class test_work_unit(unittest.TestCase):
                 li = work2.im_stack.get_single_image(i)
                 self.assertEqual(li.get_obstime(), 59000.0 + (2 * i + 1))
 
-                # Check the three image layers match. We give a lot of flexibility to the science and
-                # variance images due to compression.
+                # Check the three image layers match.
                 li_org = self.im_stack.get_single_image(i)
-                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.1))
+                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.01))
                 self.assertTrue(image_allclose(li.get_variance().image, li_org.get_variance().image, 0.01))
                 self.assertTrue(image_allclose(li.get_mask().image, li_org.get_mask().image, 0.001))
 
@@ -367,42 +314,6 @@ class test_work_unit(unittest.TestCase):
 
             # We succeed if overwrite=True
             work.to_sharded_fits("test_workunit.fits", dir_name, overwrite=True)
-
-    def test_save_and_load_fits_shard_compressed(self):
-        with tempfile.TemporaryDirectory() as dir_name:
-            file_path = os.path.join(dir_name, "test_workunit.bz2")
-
-            # Write out the existing WorkUnit with a different per-image wcs for all the entries.
-            # work = WorkUnit(self.im_stack, self.config, None, self.diff_wcs)
-            work = WorkUnit(im_stack=self.im_stack, config=self.config, wcs=None, per_image_wcs=self.diff_wcs)
-            work.to_sharded_fits("test_workunit.bz2", dir_name)
-            self.assertTrue(Path(file_path).is_file())
-
-            # Read in the file and check that the values agree.
-            work2 = WorkUnit.from_sharded_fits(filename="test_workunit.bz2", directory=dir_name)
-            self.assertEqual(work2.im_stack.img_count(), self.num_images)
-            self.assertIsNone(work2.wcs)
-            for i in range(self.num_images):
-                li = work2.im_stack.get_single_image(i)
-                self.assertEqual(li.get_obstime(), 59000.0 + (2 * i + 1))
-
-                # Check the three image layers match. We give a lot of flexibility to the science and
-                # variance images due to compression.
-                li_org = self.im_stack.get_single_image(i)
-                self.assertTrue(image_allclose(li.get_science().image, li_org.get_science().image, 0.1))
-                self.assertTrue(image_allclose(li.get_variance().image, li_org.get_variance().image, 0.01))
-                self.assertTrue(image_allclose(li.get_mask().image, li_org.get_mask().image, 0.001))
-
-            # Check that we read in the configuration values correctly.
-            self.assertEqual(work2.config["result_filename"], "Here")
-            self.assertEqual(work2.config["num_obs"], self.num_images)
-
-            # Check that the compressed file is smaller.
-            work.to_sharded_fits("test_workunit.fits", dir_name)
-
-            file0_fits = os.path.join(dir_name, "0_test_workunit.fits")
-            file0_bz2 = os.path.join(dir_name, "0_test_workunit.bz2")
-            self.assertLess(os.path.getsize(file0_bz2), os.path.getsize(file0_fits))
 
     def test_save_and_load_fits_shard_lazy(self):
         with tempfile.TemporaryDirectory() as dir_name:


### PR DESCRIPTION
Partially addresses #875 

Adds compression for the images within a WorkUnit. Also refactors the code a bit to reduce duplication. 

The compression starts with quantization which can produce small changes to the images. We set a very conservative level of 500.0 (in tests 100.0 seemed reasonable) to make sure we lose minimal data.

Remove the read/write tests using whole file compression (".bz2" suffix) since those are no longer needed.