### PR TITLE
Test Compression of Results

### DIFF
--- a/docs/source/user_manual/search_params.rst
+++ b/docs/source/user_manual/search_params.rst
@@ -102,7 +102,8 @@ Configuration Parameters
 |                        |                             | pixels                                 |
 +------------------------+-----------------------------+----------------------------------------+
 | ``result_filename``    | None                        | Full filename and path for a single    |
-|                        |                             | tabular result saves as ecsv.          |
+|                        |                             | tabular result saved as an ecsv, hdf5, |
+|                        |                             | or parquet depending on the suffix.    |
 +------------------------+-----------------------------+----------------------------------------+
 | ``results_per_pixel``  | 8                           | The maximum number of results to       |
 |                        |                             | to return for each pixel search.       |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "jplephem",
     "matplotlib>=3.5",
     "numpy<2.0",
+    "pyarrow",
     "reproject",
     "scipy>=1.9.2",
     "scikit_learn>=1.0.0",

--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -63,6 +63,9 @@ class Results:
     ]
     _required_col_names = set([rq_col[0] for rq_col in required_cols])
 
+    # We only support a few output formats since we need to save metadata.
+    _supported_formats = [".ecsv", ".parq", ".parquet", ".hdf5"]
+
     def __init__(self, data=None, track_filtered=False, wcs=None):
         """Create a ResultTable class.
 
@@ -192,7 +195,9 @@ class Results:
 
     @classmethod
     def read_table(cls, filename, track_filtered=False):
-        """Read the ResultList from a table file.
+        """Read the ResultList from a table file. The file format is automatically
+        determined from the file name's suffix which must be one of ".ecsv",
+        ".parquet", ".parq", or ".hdf5".
 
         Parameters
         ----------
@@ -208,8 +213,13 @@ class Results:
         """
         logger.info(f"Reading results from {filename}")
 
-        if not Path(filename).is_file():
+        filepath = Path(filename)
+        if not filepath.is_file():
             raise FileNotFoundError(f"File {filename} not found.")
+        if filepath.suffix not in cls._supported_formats:
+            raise ValueError(
+                f"Unsupported file type '{filepath.suffix}' " f"use one of {cls._supported_formats}."
+            )
         data = Table.read(filename)
 
         # Check if we have stored a global WCS.
@@ -683,13 +693,22 @@ class Results:
 
         return self
 
-    def write_table(self, filename, overwrite=True, cols_to_drop=(), extra_meta=None):
-        """Write the unfiltered results to a single (ecsv) file.
+    def write_table(
+        self,
+        filename,
+        overwrite=True,
+        cols_to_drop=(),
+        extra_meta=None,
+    ):
+        """Write the unfiltered results to a single file.  The file format is automatically
+        determined from the file name's suffix which must be one of ".ecsv", ".parquet",
+        ".parq", or ".hdf5".  We recommend ".parquet".
 
         Parameters
         ----------
         filename : `str`
-            The name of the result file.
+            The name of the result file.  Must have a suffix matching one of ".ecsv",
+            ".parquet", ".parq", or ".hdf5".
         overwrite : `bool`
             Overwrite the file if it already exists. [default: True]
         cols_to_drop : `tuple`
@@ -698,6 +717,13 @@ class Results:
             Any additional meta data to save with the table.
         """
         logger.info(f"Saving results to {filename}")
+
+        # Check that we are using a valid file format.
+        filepath = Path(filename)
+        if filepath.suffix not in self._supported_formats:
+            raise ValueError(
+                f"Unsupported file type '{filepath.suffix}' " f"use one of {self._supported_formats}."
+            )
 
         # Make a copy so we can modify the table
         write_table = self.table.copy()
@@ -725,7 +751,6 @@ class Results:
                 logger.debug(f"Saving {key} to Results table meta data.")
                 write_table.meta[key] = val
 
-        # Write out the table.
         write_table.write(filename, overwrite=overwrite)
 
     def write_column(self, colname, filename):

--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -751,6 +751,7 @@ class Results:
                 logger.debug(f"Saving {key} to Results table meta data.")
                 write_table.meta[key] = val
 
+        # Write out the table.
         write_table.write(filename, overwrite=overwrite)
 
     def write_column(self, colname, filename):

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -520,6 +520,40 @@ class test_results(unittest.TestCase):
             self.assertIsNotNone(table3.wcs)
             self.assertTrue(wcs_fits_equal(table3.wcs, fake_wcs))
 
+    def test_to_from_table_file_formats(self):
+        max_save = 5
+        table = Results.from_trajectories(self.trj_list[0:max_save], track_filtered=True)
+        table.table["other"] = [i for i in range(max_save)]
+        self.assertEqual(len(table), max_save)
+
+        # Create a fake WCS to use for serialization tests.
+        fake_wcs = make_fake_wcs(25.0, -7.5, 800, 600, deg_per_pixel=0.01)
+        table.wcs = fake_wcs
+
+        # Add fake times.
+        table.mjd_mid = np.array([1, 2, 3, 4, 5])
+
+        # Test read/write to file.
+        with tempfile.TemporaryDirectory() as dir_name:
+            for fmt in ["ecsv", "parq", "parquet", "hdf5"]:
+                with self.subTest(fmt_used=fmt):
+                    file_path = os.path.join(dir_name, f"results.{fmt}")
+                    table.write_table(file_path)
+                    self.assertTrue(Path(file_path).is_file())
+
+                    table2 = Results.read_table(file_path)
+                    self.assertEqual(len(table2), max_save)
+
+                    # Check that we saved the additional meta data, including the WCS.
+                    self.assertTrue(np.array_equal(table2.table.meta["mjd_mid"], [1, 2, 3, 4, 5]))
+                    self.assertIsNotNone(table2.wcs)
+                    self.assertTrue(wcs_fits_equal(table2.wcs, fake_wcs))
+
+            # Check that we fail when using an unsupported file type.
+            with self.assertRaises(ValueError):
+                file_path = os.path.join(dir_name, f"results.fits")
+                table.write_table(file_path)
+
     def test_write_and_load_column(self):
         table = Results.from_trajectories(self.trj_list)
         self.assertFalse("all_stamps" in table.colnames)


### PR DESCRIPTION
This PR is the other half of addressing #875 

The Results data structure supports writes in ecsv, hdf5, and parquet. Using takes a fraction of the space (~30% in tests) of ecsv. We need to change the file suffixes in the workflow to enable this switch.