### PR TITLE
Better GPU memory handling

### DIFF
--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -77,6 +77,9 @@ public:
 protected:
     std::vector<float> extract_psi_or_phi_curve(const Trajectory& trj, bool extract_psi);
 
+    // Clear everything off the GPU.
+    void clear_all_gpu();
+
     // Core data and search parameters. Note the StackSearch does not own
     // the ImageStack and it must exist for the duration of the object's life.
     ImageStack& stack;


### PR DESCRIPTION
A step towards solving #890 

Improve the GPU memory handling in case of failures.  For data structures that allocate multiple pieces of data (`ImageStack`, `StackSearch`, and `PsiPhiArray`) don't do a single check. Instead, during the clear operation, check each piece of memory individually in case some were successfully allocated before later ones failed. Also add try/catch blocks around allocations that force clear everything else if the allocation fails.