### PR TITLE
Fix compile fail for v29_0_0 stack

### DIFF
--- a/src/kbmod/search/kernels/kernel_memory.h
+++ b/src/kbmod/search/kernels/kernel_memory.h
@@ -10,6 +10,7 @@
 
 #include <string.h>
 #include <stdexcept>
+#include <stdint.h>
 
 namespace search {
 


### PR DESCRIPTION
Explicit include for uint64 error during build with new v29_0_0 LSST Stack.