### PR TITLE
Move compute_bounds out of RawImage

### DIFF
--- a/src/kbmod/search/psi_phi_array.cpp
+++ b/src/kbmod/search/psi_phi_array.cpp
@@ -203,20 +203,16 @@ double PsiPhiArray::read_time(uint64_t time_index) {
 std::array<float, 3> compute_scale_params_from_image_vect(const std::vector<RawImage>& imgs, int num_bytes) {
     int num_images = imgs.size();
 
-    // Do a linear pass through the data to compute the scaling parameters for psi and phi.
+    // Do a linear pass through the all the pixels to compute the scaling parameters for psi and phi.
     float min_val = FLT_MAX;
     float max_val = -FLT_MAX;
     for (int i = 0; i < num_images; ++i) {
-        std::array<float, 2> bnds = imgs[i].compute_bounds(false);
-
-        // Check if we have hit a case where the image is effectively empty (all zero).
-        if ((bnds[0] == 0.0) && (bnds[1] == 0.0)) {
-            logging::getLogger("kbmod.search.psi_phi_array")
-                    ->debug("Image " + std::to_string(i) + " has no data.\n");
+        for (auto elem : imgs[i].get_image().reshaped()) {
+            if (pixel_value_valid(elem)) {
+                min_val = std::min(min_val, elem);
+                max_val = std::max(max_val, elem);
+            }
         }
-
-        if (bnds[0] < min_val) min_val = bnds[0];
-        if (bnds[1] > max_val) max_val = bnds[1];
     }
 
     // Set the scale if we are encoding the values.

--- a/src/kbmod/search/pydocs/raw_image_docs.h
+++ b/src/kbmod/search/pydocs/raw_image_docs.h
@@ -176,21 +176,6 @@ static const auto DOC_RawImage_replace_masked_values = R"doc(
       The value to swap in. Default = 0.0.
   )doc";
 
-static const auto DOC_RawImage_compute_bounds = R"doc(
-  Returns min and max pixel values, ignoring the masked pixels.
-
-  Parameters
-  ----------
-  strict_checks : `bool`
-      If True and none of the pixels contain data, then raises an RuntimeError.
-      If False and none of the pixels contain data, returns (0.0, 0.0).
-
-  Returns
-  -------
-  bounds : `tuple`
-      A ``(min, max)`` tuple.
-  )doc";
-
 static const auto DOC_RawImage_create_stamp = R"doc(
   Create an image stamp around a given region.
 

--- a/src/kbmod/search/raw_image.cpp
+++ b/src/kbmod/search/raw_image.cpp
@@ -80,29 +80,6 @@ RawImage RawImage::create_stamp(const Point& p, const int radius, const bool kee
     return result;
 }
 
-std::array<float, 2> RawImage::compute_bounds(bool strict_checks) const {
-    float min_val = FLT_MAX;
-    float max_val = -FLT_MAX;
-
-    for (auto elem : image.reshaped())
-        if (pixel_value_valid(elem)) {
-            min_val = std::min(min_val, elem);
-            max_val = std::max(max_val, elem);
-        }
-
-    // Assert that we have seen at least some valid data.
-    if ((max_val == -FLT_MAX) || (min_val == FLT_MAX)) {
-        if (strict_checks) {
-            throw std::runtime_error("No valid pixels found during RawImage.compute_bounds()");
-        } else {
-            min_val = 0.0;
-            max_val = 0.0;
-        }
-    }
-
-    return {min_val, max_val};
-}
-
 void RawImage::convolve_cpu(Image& psf) {
     Image result = Image::Zero(height, width);
 
@@ -352,8 +329,6 @@ static void raw_image_bindings(py::module& m) {
             // methods
             .def("replace_masked_values", &rie::replace_masked_values, py::arg("value") = 0.0f,
                  pydocs::DOC_RawImage_replace_masked_values)
-            .def("compute_bounds", &rie::compute_bounds, py::arg("strict_checks") = true,
-                 pydocs::DOC_RawImage_compute_bounds)
             .def("create_stamp", &rie::create_stamp, pydocs::DOC_RawImage_create_stamp)
             .def("apply_mask", &rie::apply_mask, pydocs::DOC_RawImage_apply_mask)
             .def("convolve_gpu", &rie::convolve, pydocs::DOC_RawImage_convolve_gpu)

--- a/src/kbmod/search/raw_image.h
+++ b/src/kbmod/search/raw_image.h
@@ -78,9 +78,6 @@ public:
     // keep_no_data indicates whether to use the NO_DATA flag or replace with 0.0.
     RawImage create_stamp(const Point& p, const int radius, const bool keep_no_data) const;
 
-    // Compute the min and max bounds of values in the image.
-    std::array<float, 2> compute_bounds(bool strict_checks = true) const;
-
     // Convolve the image with a point spread function.
     void convolve(Image& psf);
     void convolve_cpu(Image& psf);

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -108,30 +108,6 @@ class test_RawImage(unittest.TestCase):
         img.mask_pixel(0, 0)
         self.assertFalse(img.pixel_has_data(0, 0))
 
-    def test_compute_bounds(self):
-        """Test RawImage masked min/max bounds."""
-        img = RawImage(self.masked_array)
-        lower, upper = img.compute_bounds()
-        self.assertAlmostEqual(lower, 0.1, delta=1e-6)
-        self.assertAlmostEqual(upper, 100.0, delta=1e-6)
-
-        # Insert a NaN and make sure that does not mess up the computation.
-        img.set_pixel(2, 3, math.nan)
-        img.set_pixel(3, 2, np.nan)
-        lower, upper = img.compute_bounds()
-        self.assertAlmostEqual(lower, 0.1, delta=1e-6)
-        self.assertAlmostEqual(upper, 100.0, delta=1e-6)
-
-        # If the entire image is NaN the function should raise an error by default.
-        bad_arr = np.full((2, 2), KB_NO_DATA, dtype=np.single)
-        bad_img = RawImage(bad_arr)
-        self.assertRaises(RuntimeError, bad_img.compute_bounds)
-
-        # The function does not raise an error when strict_checks=False.
-        lower, upper = bad_img.compute_bounds(strict_checks=False)
-        self.assertEqual(lower, 0.0)
-        self.assertEqual(upper, 0.0)
-
     def test_replace_masked_values(self):
         img2 = RawImage(np.copy(self.masked_array))
         img2.replace_masked_values(0.0)


### PR DESCRIPTION
The `compute_bounds()` function is only used for creating Psi and Phi arrays. This moves the functionality directly into the creation of Psi / Phi arrays (reducing the amount we need to rely on `RawImage`).