### PR TITLE
Store all Psi and Phi data as Image instead of RawImage

### DIFF
--- a/src/kbmod/search/image_stack.cpp
+++ b/src/kbmod/search/image_stack.cpp
@@ -141,7 +141,7 @@ void ImageStack::copy_to_gpu() {
 void ImageStack::clear_from_gpu() {
     logging::Logger* logger = logging::getLogger("kbmod.search.image_stack");
     logger->debug(stat_gpu_memory_mb());
-    
+
     if (gpu_image_array.on_gpu()) {
         logger->debug("Freeing images on GPU. " + gpu_image_array.stats_string());
         gpu_image_array.free_gpu_memory();
@@ -151,7 +151,7 @@ void ImageStack::clear_from_gpu() {
         logger->debug("Freeing times on GPU: " + gpu_time_array.stats_string());
         gpu_time_array.free_gpu_memory();
     }
-    
+
     logger->debug(stat_gpu_memory_mb());
     data_on_gpu = false;
 }

--- a/src/kbmod/search/layered_image.cpp
+++ b/src/kbmod/search/layered_image.cpp
@@ -148,8 +148,8 @@ void LayeredImage::set_variance(RawImage& im) {
     variance = im;
 }
 
-RawImage LayeredImage::generate_psi_image() {
-    RawImage result(width, height);
+Image LayeredImage::generate_psi_image() {
+    Image result = Image::Zero(height, width);
     float* result_arr = result.data();
     float* sci_array = science.data();
     float* var_array = variance.data();
@@ -168,7 +168,7 @@ RawImage LayeredImage::generate_psi_image() {
     }
 
     // Convolve with the PSF.
-    result.convolve(psf);
+    result = convolve_image(result, psf);
 
     logging::getLogger("kbmod.search.layered_image")
             ->debug("Generated psi image. " + std::to_string(no_data_count) + " of " +
@@ -177,8 +177,8 @@ RawImage LayeredImage::generate_psi_image() {
     return result;
 }
 
-RawImage LayeredImage::generate_phi_image() {
-    RawImage result(width, height);
+Image LayeredImage::generate_phi_image() {
+    Image result = Image::Zero(height, width);
     float* result_arr = result.data();
     float* var_array = variance.data();
 
@@ -197,7 +197,7 @@ RawImage LayeredImage::generate_phi_image() {
 
     // Convolve with the PSF squared.
     Image psfsq = square_psf(psf);  // Copy
-    result.convolve(psfsq);
+    result = convolve_image(result, psfsq);
 
     logging::getLogger("kbmod.search.layered_image")
             ->debug("Generated phi image. " + std::to_string(no_data_count) + " of " +

--- a/src/kbmod/search/layered_image.h
+++ b/src/kbmod/search/layered_image.h
@@ -6,10 +6,12 @@
 #include <string>
 #include <random>
 #include <stdexcept>
+
 #include "raw_image.h"
 #include "common.h"
 #include "pydocs/layered_image_docs.h"
 #include "logging.h"
+#include "image_utils_cpp.h"
 
 namespace search {
 class LayeredImage {
@@ -81,8 +83,8 @@ public:
     virtual ~LayeredImage(){};
 
     // Generate psi and phi images from the science and variance layers.
-    RawImage generate_psi_image();
-    RawImage generate_phi_image();
+    Image generate_psi_image();
+    Image generate_phi_image();
 
 private:
     unsigned width;

--- a/src/kbmod/search/psi_phi_array_utils.h
+++ b/src/kbmod/search/psi_phi_array_utils.h
@@ -25,10 +25,10 @@
 namespace search {
 
 // Compute the min, max, and scale parameter from the a vector of image data.
-std::array<float, 3> compute_scale_params_from_image_vect(const std::vector<RawImage>& imgs, int num_bytes);
+std::array<float, 3> compute_scale_params_from_image_vect(const std::vector<Image>& imgs, int num_bytes);
 
-void fill_psi_phi_array(PsiPhiArray& result_data, int num_bytes, const std::vector<RawImage>& psi_imgs,
-                        const std::vector<RawImage>& phi_imgs, const std::vector<double> zeroed_times);
+void fill_psi_phi_array(PsiPhiArray& result_data, int num_bytes, const std::vector<Image>& psi_imgs,
+                        const std::vector<Image>& phi_imgs, const std::vector<double> zeroed_times);
 
 void fill_psi_phi_array_from_image_stack(PsiPhiArray& result_data, ImageStack& stack, int num_bytes);
 

--- a/src/kbmod/search/pydocs/layered_image_docs.h
+++ b/src/kbmod/search/pydocs/layered_image_docs.h
@@ -197,12 +197,13 @@ static const auto DOC_LayeredImage_generate_psi_image = R"doc(
   resulting image is science[p] / variance[p]. To handle masked bits
   apply_mask() must be called before the psi image is generated. Otherwise,
   all pixels are used.
+
   Convolves the resulting image with the PSF.
 
   Returns
   -------
-  result : `kbmod.RawImage`
-      A ``RawImage`` of the same dimensions as the ``LayeredImage``.
+  result : `numpy.ndarray`
+      A numpy array the same shape as the input image.
   )doc";
 
 static const auto DOC_LayeredImage_generate_phi_image = R"doc(
@@ -210,12 +211,13 @@ static const auto DOC_LayeredImage_generate_phi_image = R"doc(
   resulting image is 1.0 / variance[p]. To handle masked bits
   apply_mask() must be called before the phi image is generated. Otherwise,
   all pixels are used.
-  Convolves the resulting image with the PSF.
+
+  Convolves the resulting image with the square of the PSF.
 
   Returns
   -------
-  result : `kbmod.RawImage`
-      A ``RawImage`` of the same dimensions as the ``LayeredImage``.
+  result : `numpy.ndarray`
+      A numpy array the same shape as the input image.
   )doc";
 
 }  // namespace pydocs

--- a/src/kbmod/search/pydocs/psi_phi_array_docs.h
+++ b/src/kbmod/search/pydocs/psi_phi_array_docs.h
@@ -187,9 +187,9 @@ static const auto DOC_PsiPhiArray_fill_psi_phi_array = R"doc(
     num_bytes : `int`
         The type of encoding to use (1, 2, or 4).
     psi_imgs : `list`
-        A list of psi images.
+        A list of psi images as numpy arrays.
     phi_imgs : `list`
-        A list of phi images.
+        A list of phi images as numpy arrays.
     zeroed_times : `list`
         A list of floating point times starting at zero.
 

--- a/tests/test_layered_image.py
+++ b/tests/test_layered_image.py
@@ -242,28 +242,26 @@ class test_LayeredImage(unittest.TestCase):
 
         # Generate and check psi and phi images.
         psi = img.generate_psi_image()
-        self.assertEqual(psi.width, 6)
-        self.assertEqual(psi.height, 5)
+        self.assertEqual(psi.shape, (5, 6))
 
         phi = img.generate_phi_image()
-        self.assertEqual(phi.width, 6)
-        self.assertEqual(phi.height, 5)
+        self.assertEqual(phi.shape, (5, 6))
 
         for y in range(5):
             for x in range(6):
-                psi_has_data = y != 3 or x > 4
-                self.assertEqual(psi.pixel_has_data(y, x), psi_has_data)
-                if psi_has_data:
-                    self.assertAlmostEqual(psi.get_pixel(y, x), x / (y + 1), delta=1e-5)
+                psi_val = psi[y, x]
+                if y != 3 or x > 4:
+                    self.assertTrue(np.isfinite(psi_val))
+                    self.assertAlmostEqual(psi_val, x / (y + 1), delta=1e-5)
                 else:
-                    self.assertFalse(pixel_value_valid(psi.get_pixel(y, x)))
+                    self.assertFalse(np.isfinite(psi_val))
 
-                phi_has_data = y != 3 or x > 2
-                self.assertEqual(phi.pixel_has_data(y, x), phi_has_data)
-                if phi_has_data:
-                    self.assertAlmostEqual(phi.get_pixel(y, x), 1.0 / (y + 1), delta=1e-5)
+                phi_val = phi[y, x]
+                if y != 3 or x > 2:
+                    self.assertTrue(np.isfinite(phi_val))
+                    self.assertAlmostEqual(phi_val, 1.0 / (y + 1), delta=1e-5)
                 else:
-                    self.assertFalse(pixel_value_valid(phi.get_pixel(y, x)))
+                    self.assertFalse(np.isfinite(phi_val))
 
 
 if __name__ == "__main__":

--- a/tests/test_psi_phi_array.py
+++ b/tests/test_psi_phi_array.py
@@ -9,7 +9,6 @@ from kbmod.search import (
     KB_NO_DATA,
     ImageStack,
     PsiPhiArray,
-    RawImage,
     compute_scale_params_from_image_vect,
     decode_uint_scalar,
     encode_uint_scalar,
@@ -26,15 +25,13 @@ class test_psi_phi_array(unittest.TestCase):
         self.height = 5
 
         psi_1_vals = np.arange(0, self.width * self.height, dtype=np.single)
-        psi_1_arr = psi_1_vals.reshape(self.height, self.width)
-        self.psi_1 = RawImage(img=psi_1_arr)
+        self.psi_1 = psi_1_vals.reshape(self.height, self.width)
 
         psi_2_vals = np.arange(self.width * self.height, 2 * self.width * self.height, dtype=np.single)
-        psi_2_arr = psi_2_vals.reshape(self.height, self.width)
-        self.psi_2 = RawImage(img=psi_2_arr)
+        self.psi_2 = psi_2_vals.reshape(self.height, self.width)
 
-        self.phi_1 = RawImage(np.full((self.height, self.width), 0.1, dtype=np.single))
-        self.phi_2 = RawImage(np.full((self.height, self.width), 0.2, dtype=np.single))
+        self.phi_1 = np.full((self.height, self.width), 0.1, dtype=np.single)
+        self.phi_2 = np.full((self.height, self.width), 0.2, dtype=np.single)
 
         self.zeroed_times = [0.0, 1.0]
 


### PR DESCRIPTION
The `RawImage` wrapper isn't necessary for storing psi or phi data. Using the raw Eigen array provides the same power and reduces overhead of the accessors.