### PR TITLE
Allow direct access of LayeredImage's Image data

### DIFF
--- a/src/kbmod/search/layered_image.cpp
+++ b/src/kbmod/search/layered_image.cpp
@@ -254,6 +254,12 @@ static void layered_image_bindings(py::module& m) {
                  pydocs::DOC_LayeredImage_get_mask)
             .def("get_variance", &li::get_variance, py::return_value_policy::reference_internal,
                  pydocs::DOC_LayeredImage_get_variance)
+            .def("get_science_array", &li::get_science_array, py::return_value_policy::reference_internal,
+                 pydocs::DOC_LayeredImage_get_science_array)
+            .def("get_mask_array", &li::get_mask_array, py::return_value_policy::reference_internal,
+                 pydocs::DOC_LayeredImage_get_mask_array)
+            .def("get_variance_array", &li::get_variance_array, py::return_value_policy::reference_internal,
+                 pydocs::DOC_LayeredImage_get_variance_array)
             .def("set_science", &li::set_science, pydocs::DOC_LayeredImage_set_science)
             .def("set_mask", &li::set_mask, pydocs::DOC_LayeredImage_set_mask)
             .def("set_variance", &li::set_variance, pydocs::DOC_LayeredImage_set_variance)

--- a/src/kbmod/search/layered_image.h
+++ b/src/kbmod/search/layered_image.h
@@ -44,6 +44,11 @@ public:
     RawImage& get_mask() { return mask; }
     RawImage& get_variance() { return variance; }
 
+    // Getter functions for the data in the individual layers as Images.
+    Image& get_science_array() { return science.get_image(); }
+    Image& get_mask_array() { return mask.get_image(); }
+    Image& get_variance_array() { return variance.get_image(); }
+
     // Getter functions for the pixels of the science and variance layers that check
     // the mask layer for any set bits.
     inline float get_science_pixel(const Index& idx) const {

--- a/src/kbmod/search/pydocs/layered_image_docs.h
+++ b/src/kbmod/search/pydocs/layered_image_docs.h
@@ -67,15 +67,27 @@ static const auto DOC_LayeredImage_apply_mask = R"doc(
   )doc";
 
 static const auto DOC_LayeredImage_get_science = R"doc(
-  Returns the science layer `RawImage`.
+  Returns the science layer as a `RawImage`.
   )doc";
 
 static const auto DOC_LayeredImage_get_mask = R"doc(
-  Returns the mask layer `RawImage`.
+  Returns the mask layer as a `RawImage`.
   )doc";
 
 static const auto DOC_LayeredImage_get_variance = R"doc(
-  Returns the variance layer `RawImage`.
+  Returns the variance layer as a `RawImage`.
+  )doc";
+
+static const auto DOC_LayeredImage_get_science_array = R"doc(
+  Returns the science layer as an `Image`.
+  )doc";
+
+static const auto DOC_LayeredImage_get_mask_array = R"doc(
+  Returns the mask layer as an `Image`.
+  )doc";
+
+static const auto DOC_LayeredImage_get_variance_array = R"doc(
+  Returns the variance layer as an `Image`.
   )doc";
 
 static const auto DOC_LayeredImage_set_science = R"doc(

--- a/tests/test_layered_image.py
+++ b/tests/test_layered_image.py
@@ -32,10 +32,14 @@ class test_LayeredImage(unittest.TestCase):
         self.assertEqual(self.image.get_npixels(), 80 * 60)
         self.assertEqual(self.image.get_obstime(), 10.0)
 
-        # Create a fake LayeredImage.
+        # Check the created image.
         science = self.image.get_science()
         variance = self.image.get_variance()
         mask = self.image.get_mask()
+        science_arr = self.image.get_science_array()
+        variance_arr = self.image.get_variance_array()
+        mask_arr = self.image.get_mask_array()
+
         for y in range(self.image.get_height()):
             for x in range(self.image.get_width()):
                 self.assertEqual(mask.get_pixel(y, x), 0)
@@ -49,6 +53,11 @@ class test_LayeredImage(unittest.TestCase):
                 # Check direct lookup of pixel values matches the RawImage lookup.
                 self.assertEqual(science.get_pixel(y, x), self.image.get_science_pixel(y, x))
                 self.assertEqual(variance.get_pixel(y, x), self.image.get_variance_pixel(y, x))
+
+                # Check the arrays.
+                self.assertEqual(mask_arr[y, x], 0)
+                self.assertEqual(variance_arr[y, x], 4.0)
+                self.assertAlmostEqual(science.get_pixel(y, x), science_arr[y, x])
 
         # Check that the LayeredImage pixel lookups work with a masked pixel.
         # But the the mask was not applied yet to the images themselves.


### PR DESCRIPTION
Add a helper function to access pixel matrices from the `LayeredImage` directly.