### PR TITLE
Change Python Image Stack's Storage

### DIFF
--- a/src/kbmod/core/image_stack_py.py
+++ b/src/kbmod/core/image_stack_py.py
@@ -17,58 +17,75 @@ class ImageStackPy:
 
     Notes
     -----
-    The images are not required to be in sorted time order, but the first
-    image is used for t=0.0 when computing zeroed times (which might make
-    some times negative).
+    The images in the stack must all be the same shape (height and width).
+    They are not required to be in sorted time order, but the first image
+    is used for t=0.0 when computing zeroed times (which might make some
+    times negative).
 
     Attributes
     ----------
     times : np.array
         The length T array of time stamps (in UTC MJD).
-    sci : np.array
-        The T x H x W array of science data.
-    var : np.array
-        The T x H x W array of variance data.
-    mask : np.array
-        The T x H x W array of Boolean mask data.
+    sci : list of np.array
+        A length T list of H x W arrays of science data.
+    var : list of np.array
+        A length T list of H x W arrays of variance data.
     psfs : list of numpy arrays
         The length T array of PSF information.  This is a list instead of a
         numpy array because the PSFs can be different sizes. If a list of PSF
         objects is provided, only the kernels are stored.
-    wcs : list of astropy.wcs.WCS
-        The length T array of WCS information.
     num_times : int
         The number of times in the stack.
+    height : int
+        The height of each image in pixels.
+    width : int
+        The width of each image in pixels.
     zeroed_times : np.array
         The length T array of zeroed times.
     """
 
-    def __init__(self, times, sci, var, mask=None, psfs=None, wcs=None):
+    def __init__(self, times, sci, var, mask=None, psfs=None):
         if times is None or len(times) == 0:
             raise ValueError("Cannot create an ImageStack with no times.")
         self.num_times = len(times)
         self.times = np.asarray(times, dtype=float)
         self.zeroed_times = self.times - self.times[0]
 
-        self.sci = np.asarray(sci, dtype=float)
-        self.var = np.asarray(var, dtype=float)
-        if len(self.sci.shape) != 3:
-            raise ValueError("3d (T x H x W) numpy array of science data required to build stack.")
-        if self.sci.shape[0] != self.num_times:
-            raise ValueError(f"Science data must have {self.num_times} images.")
-        if self.sci.shape != self.var.shape:
-            raise ValueError("Science and variance data must have the same shape.")
+        # Get and validate the image size information.
+        if len(sci) != self.num_times:
+            raise ValueError(
+                f"Incorrect number of science images. Expected {self.num_times}. Received {len(sci)}."
+            )
+        if len(var) != self.num_times:
+            raise ValueError(
+                f"Incorrect number of variance images. Expected {self.num_times}. Received {len(var)}."
+            )
+        if mask is not None and len(mask) != self.num_times:
+            raise ValueError(
+                f"Incorrect number of mask images. Expected {self.num_times}. Received {len(mask)}."
+            )
+        self.height = len(sci[0])
+        self.width = len(sci[0][0])
 
-        # If a mask is given, apply it now. Save it as a boolean array.
+        # Validate and save each of the science images.
+        self.sci = []
+        for img in sci:
+            self.sci.append(self._standardize_image(img))
+
+        # Validate and save each of the variance images.
+        self.var = []
+        for img in var:
+            self.var.append(self._standardize_image(img))
+
+        # If a mask is given, apply it now.
         if mask is not None:
-            if mask.shape != sci.shape:
-                raise ValueError("Science and Mask data must have the same shape.")
-            mask = np.asarray(mask) > 0
-            sci[mask] = np.nan
-            var[mask] = np.nan
-            self.mask = np.asarray(mask > 0, dtype=bool)
-        else:
-            self.mask = np.full_like(self.sci, False, dtype=bool)
+            for idx in range(self.num_times):
+                current_mask = np.asanyarray(mask[idx])
+                if current_mask.shape != (self.height, self.width):
+                    raise ValueError("Science and Mask data must have the same shape.")
+                masked_pixels = current_mask > 0
+                self.sci[idx][masked_pixels] = np.nan
+                self.var[idx][masked_pixels] = np.nan
 
         # Checks (and creates defaults) for the PSF input.
         if psfs is None:
@@ -87,105 +104,52 @@ class ImageStackPy:
                 else:
                     raise ValueError("PSF data must be a PSF object or a numpy array.")
 
-        # Preprocess the WCS data.
-        if wcs is None:
-            self.wcs = [None for i in range(self.num_times)]
-        elif len(wcs) != self.num_times:
-            raise ValueError(f"WCS data must have {self.num_times} entries.")
-        else:
-            self.wcs = wcs
+    def _standardize_image(self, img):
+        """Validate that an image is in the form that is expected,
+        transforming it if not.
+
+        Parameters
+        ----------
+        img : np.ndarray
+            The incoming image.
+
+        Returns
+        -------
+        img : np.ndarray
+            The standardized image.
+        """
+        # All images should be a numpy array in single precision floating point.
+        img = np.asanyarray(img)
+        if img.dtype != np.single:
+            img = img.astype(np.single)
+
+        # Check that the image is the correct size.
+        if img.shape[1] != self.width:
+            raise ValueError(f"Incorrect image width. Expected {self.width}. Received {img.shape[1]}")
+        if img.shape[0] != self.height:
+            raise ValueError(f"Incorrect image height. Expected {self.height}. Received {img.shape[0]}")
+
+        return img
 
     def __len__(self):
         return self.num_times
 
     @property
-    def height(self):
-        """Return each image's height."""
-        return self.sci.shape[1]
-
-    @property
-    def width(self):
-        """Return each image's width."""
-        return self.sci.shape[2]
-
-    @property
-    def num_images(self):
-        """Return the number of images."""
-        return self.num_times
-
-    @property
     def npixels(self):
         """Return the number of pixels in each image."""
-        return self.sci.shape[1] * self.sci.shape[2]
+        return self.height * self.width
 
     @property
     def total_pixels(self):
         """Return the total number of pixels in the stack."""
-        return self.sci.shape[0] * self.sci.shape[1] * self.sci.shape[2]
-
-    @classmethod
-    def make_empty(cls, num_times, height, width):
-        """Create an empty ImageStack with the given times, height, and width.
-
-        Parameters
-        ----------
-        num_times : int
-            The number of times in the stack.
-        height : int
-            The height of the images in pixels.
-        width : int
-            The width of the images in pixels.
-
-        Returns
-        -------
-        ImageStackPy
-            An empty ImageStack with the given parameters.
-        """
-        return cls(
-            np.zeros(num_times),
-            np.zeros((num_times, height, width), dtype=np.single),
-            np.zeros((num_times, height, width), dtype=np.single),
-        )
+        return self.height * self.width * self.num_times
 
     def num_masked_pixels(self):
         """Compute the number of masked pixels."""
-        return np.sum(np.isnan(self.sci))
-
-    def set_images_at_time(self, time_idx, sci, var, mask=None):
-        """Set the images at a specific time index.
-
-        Parameters
-        ----------
-        time_idx : int
-            The time index to set.
-        sci : np.array
-            The science image data (H x W).
-        var : np.array
-            The variance image data (H x W).
-        mask : np.array, optional
-            The mask image data (H x W). If None, no mask is applied.
-        """
-        if time_idx < 0 or time_idx >= self.num_times:
-            raise ValueError("Time index out of bounds.")
-        if sci.shape != self.sci[time_idx].shape:
-            raise ValueError("Science image must have the same shape as the stack.")
-        if var.shape != self.var[time_idx].shape:
-            raise ValueError("Variance image must have the same shape as the stack.")
-
-        # Set the science and variance images.
-        self.sci[time_idx] = np.asarray(sci, dtype=float)
-        self.var[time_idx] = np.asarray(var, dtype=float)
-
-        # Apply the mask if provided.
-        if mask is not None:
-            if mask.shape != sci.shape:
-                raise ValueError("Science and Mask data must have the same shape.")
-            mask = np.asarray(mask) > 0
-            self.sci[time_idx, mask] = np.nan
-            self.var[time_idx, mask] = np.nan
-            self.mask[time_idx] = np.asarray(mask > 0, dtype=bool)
-        else:
-            self.mask[time_idx, :, :] = False
+        total = 0
+        for img in self.sci:
+            total += np.sum(np.isnan(img))
+        return total
 
     def get_matched_obstimes(self, query_times, threshold=0.0007):
         """Given a list of times, returns the indices of images that are close
@@ -222,54 +186,6 @@ class ImageStackPy:
         min_inds = np.where(min_dist <= threshold, min_inds - 1, -1)
 
         return min_inds
-
-    def world_to_pixel(self, time_idx, ra, dec):
-        """Get the pixel coordinates for a given time index and RA/Dec.
-
-        Parameters
-        ----------
-        time_idx : int
-            The time index to use.
-        ra : `float`
-            The right ascension coordinates (in degrees).
-        dec : `float`
-            The declination coordinates (in degrees).
-
-        Returns
-        -------
-        x_pos : `float`
-            The X pixel position.
-        y_pos : `float`
-            The Y pixel position.
-        """
-        if self.wcs[time_idx] is None:
-            raise ValueError("No WCS information for this time index.")
-        x_pos, y_pos = self.wcs[time_idx].world_to_pixel(SkyCoord(ra=ra * u.degree, dec=dec * u.degree))
-        return x_pos, y_pos
-
-    def pixel_to_world(self, time_idx, x_pos, y_pos):
-        """Get the pixel coordinates for a given time index and RA/Dec.
-
-        Parameters
-        ----------
-        time_idx : int
-            The time index to use.
-        x_pos : `float`
-            The X pixel position.
-        y_pos : `float`
-            The Y pixel position.
-
-        Returns
-        -------
-        ra : `float`
-            The right ascension coordinates (in degrees).
-        dec : `float`
-            The declination coordinates (in degrees).
-        """
-        if self.wcs[time_idx] is None:
-            raise ValueError("No WCS information for this time index.")
-        coord = self.wcs[time_idx].pixel_to_world(x_pos, y_pos)
-        return coord.ra.deg, coord.dec.deg
 
 
 def make_fake_image_stack(width, height, times, noise_level=2.0, psf_val=0.5, rng=None):
@@ -338,4 +254,4 @@ def image_stack_add_fake_object(stack, x, y, vx, vy, flux):
                 img_x = px + psf_x - psf_radius
                 img_y = py + psf_y - psf_radius
                 if img_x >= 0 and img_x < stack.width and img_y >= 0 and img_y < stack.height:
-                    stack.sci[idx, img_y, img_x] += flux * psf_kernel[psf_y, psf_x]
+                    stack.sci[idx][img_y, img_x] += flux * psf_kernel[psf_y, psf_x]

--- a/tests/test_image_stack_py.py
+++ b/tests/test_image_stack_py.py
@@ -3,7 +3,6 @@ import numpy as np
 import unittest
 
 from kbmod.core.image_stack_py import (
-    generate_psi_phi,
     image_stack_add_fake_object,
     make_fake_image_stack,
     ImageStackPy,

--- a/tests/test_image_stack_py.py
+++ b/tests/test_image_stack_py.py
@@ -18,6 +18,38 @@ class test_image_stack_py(unittest.TestCase):
         width = 15
 
         times = np.arange(num_times)
+        sci = [np.full((height, width), 1.0) for _ in range(num_times)]
+        var = [np.full((height, width), 0.1) for _ in range(num_times)]
+
+        stack = ImageStackPy(times, sci, var)
+        self.assertEqual(stack.num_times, num_times)
+        self.assertEqual(stack.width, width)
+        self.assertEqual(stack.height, height)
+        self.assertEqual(stack.npixels, height * width)
+        self.assertEqual(stack.total_pixels, num_times * height * width)
+        self.assertEqual(stack.num_masked_pixels(), 0)
+
+        self.assertTrue(np.allclose(stack.times, times))
+        self.assertTrue(np.allclose(stack.zeroed_times, np.arange(num_times)))
+
+        for idx in range(num_times):
+            self.assertTrue(np.all(stack.sci[idx] == 1.0))
+            self.assertTrue(np.all(stack.var[idx] == 0.1))
+        self.assertEqual(len(stack.psfs), num_times)
+
+        # Test that we fail with bad input.
+        self.assertRaises(ValueError, ImageStackPy, np.array([]), sci, var)
+        self.assertRaises(ValueError, ImageStackPy, None, sci, var)
+        self.assertRaises(ValueError, ImageStackPy, times, [np.array([1.0])], var)
+        self.assertRaises(ValueError, ImageStackPy, times, sci, [np.array([1.0])])
+
+    def test_create_image_stack_from_nparray_py(self):
+        """Test that we can create an ImageStackPy from a single 3-d numpy array."""
+        num_times = 10
+        height = 20
+        width = 15
+
+        times = np.arange(num_times)
         sci = np.full((num_times, height, width), 1.0)
         var = np.full((num_times, height, width), 0.1)
 
@@ -32,64 +64,13 @@ class test_image_stack_py(unittest.TestCase):
         self.assertTrue(np.allclose(stack.times, times))
         self.assertTrue(np.allclose(stack.zeroed_times, np.arange(num_times)))
 
-        self.assertTrue(np.all(stack.sci == 1.0))
-        self.assertTrue(np.all(stack.var == 0.1))
+        for idx in range(num_times):
+            self.assertTrue(np.all(stack.sci[idx] == 1.0))
+            self.assertTrue(np.all(stack.var[idx] == 0.1))
         self.assertEqual(len(stack.psfs), num_times)
 
-        # Test that we fail with bad input.
-        self.assertRaises(ValueError, ImageStackPy, np.array([]), sci, var)
-        self.assertRaises(ValueError, ImageStackPy, None, sci, var)
-        self.assertRaises(ValueError, ImageStackPy, times, np.array([1.0]), var)
-        self.assertRaises(ValueError, ImageStackPy, times, sci, np.array([1.0]))
-
-    def test_make_empty_image_stack(self):
-        """Test that we can create an empty ImageStackPy"""
-        num_times = 5
-        height = 6
-        width = 4
-
-        stack = ImageStackPy.make_empty(num_times, height, width)
-        self.assertEqual(stack.num_times, num_times)
-        self.assertEqual(stack.width, width)
-        self.assertEqual(stack.height, height)
-        self.assertEqual(stack.npixels, height * width)
-        self.assertEqual(stack.total_pixels, num_times * height * width)
-        self.assertEqual(stack.num_masked_pixels(), 0)
-        self.assertTrue(np.all(stack.times == 0.0))
-        self.assertTrue(np.all(stack.zeroed_times == 0.0))
-        self.assertTrue(np.all(stack.sci == 0.0))
-        self.assertTrue(np.all(stack.var == 0.0))
-        self.assertTrue(np.all(stack.mask == False))
-
-        # Test that we can insert a layer.
-        fake_sci = 5.0 * np.ones((height, width), dtype=np.single)
-        fake_var = np.ones((height, width), dtype=np.single)
-        fake_mask = np.zeros((height, width))
-        fake_mask[2, 1] = 1
-        stack.set_images_at_time(3, fake_sci, fake_var, mask=fake_mask)
-
-        # Compute the expected (masked) values.
-        expected_sci = 5.0 * np.ones((height, width), dtype=np.single)
-        expected_var = np.ones((height, width), dtype=np.single)
-        expected_mask = np.full((height, width), False, dtype=bool)
-        expected_mask[2, 1] = True
-        expected_sci[2, 1] = np.nan
-        expected_var[2, 1] = np.nan
-
-        # The inserted layer should have the correct values.
-        self.assertTrue(np.array_equal(stack.sci[3], expected_sci, equal_nan=True))
-        self.assertTrue(np.array_equal(stack.var[3], expected_var, equal_nan=True))
-        self.assertTrue(np.array_equal(stack.mask[3], expected_mask))
-
-        # All other times are unchanged.
-        for i in range(num_times):
-            if i != 3:
-                self.assertTrue(np.all(stack.sci[i] == 0.0))
-                self.assertTrue(np.all(stack.var[i] == 0.0))
-                self.assertTrue(np.all(stack.mask[i] == False))
-
     def test_create_image_stack_py_masked(self):
-        """Test that we can create an ImageStackPy"""
+        """Test that we can create an ImageStackPy with masked pixels."""
         num_times = 3
         height = 8
         width = 5
@@ -101,7 +82,6 @@ class test_image_stack_py(unittest.TestCase):
         mask[0, 1, 2] = 1
         mask[0, 1, 3] = 1
         mask[2, 4, 4] = 1
-        mask_mask = mask > 0
 
         stack = ImageStackPy(times, sci, var, mask=mask)
         self.assertEqual(stack.num_times, num_times)
@@ -114,11 +94,14 @@ class test_image_stack_py(unittest.TestCase):
         self.assertTrue(np.allclose(stack.times, times))
         self.assertTrue(np.allclose(stack.zeroed_times, np.arange(num_times)))
 
-        self.assertTrue(np.all(stack.sci[~mask_mask] == 1.0))
-        self.assertTrue(np.all(np.isnan(stack.sci[mask_mask])))
+        for idx in range(num_times):
+            mask_mask = mask[idx] > 0
 
-        self.assertTrue(np.all(stack.var[~mask_mask] == 0.1))
-        self.assertTrue(np.all(np.isnan(stack.var[mask_mask])))
+            self.assertTrue(np.all(stack.sci[idx][~mask_mask] == 1.0))
+            self.assertTrue(np.all(np.isnan(stack.sci[idx][mask_mask])))
+
+            self.assertTrue(np.all(stack.var[idx][~mask_mask] == 0.1))
+            self.assertTrue(np.all(np.isnan(stack.var[idx][mask_mask])))
 
     def test_get_matched_obstimes(self):
         obstimes = [1.0, 2.0, 3.0, 4.0, 6.0, 7.5, 9.0, 10.1]
@@ -136,59 +119,6 @@ class test_image_stack_py(unittest.TestCase):
         expected = [-1, 0, 0, -1, 1, 4, 5, 5, 7, 7, -1]
         self.assertTrue(np.array_equal(matched_inds, expected))
 
-    def test_pixel_to_from_world(self):
-        num_times = 10
-        height = 500
-        width = 700
-        times = np.arange(num_times)
-
-        # Create a fake WCS for testing.
-        wcs_dict = {
-            "WCSAXES": 2,
-            "CDELT1": 0.01,
-            "CDELT2": 0.01,
-            "CTYPE1": "RA---TAN-SIP",
-            "CTYPE2": "DEC--TAN-SIP",
-            "CRVAL1": 200.5,
-            "CRVAL2": -7.5,
-            "CRPIX1": height / 2.0,
-            "CRPIX2": width / 2.0,
-            "CTYPE1A": "LINEAR  ",
-            "CTYPE2A": "LINEAR  ",
-            "CUNIT1A": "PIXEL   ",
-            "CUNIT2A": "PIXEL   ",
-            "NAXIS1": height,
-            "NAXIX2": width,
-        }
-        wcs = astropy.wcs.WCS(wcs_dict)
-        wcs.array_shape = (height, width)
-        wcs_list = [wcs if i % 2 == 0 else None for i in range(num_times)]
-
-        # Create a fake image stack.
-        sci = np.full((num_times, height, width), 1.0)
-        var = np.full((num_times, height, width), 0.1)
-        stack = ImageStackPy(times, sci, var, wcs=wcs_list)
-
-        # Compute the pixel locations of the SkyCoords.
-        query_ra = np.array([200.5, 200.55, 200.6])
-        query_dec = np.array([-7.5, -7.55, -7.60])
-        expected_x = np.array([249, 254, 259])
-        expected_y = np.array([349, 344, 339])
-        for idx in range(3):
-            x_pos, y_pos = stack.world_to_pixel(0, query_ra[idx], query_dec[idx])
-            self.assertAlmostEqual(x_pos, expected_x[idx], delta=0.2)
-            self.assertAlmostEqual(y_pos, expected_y[idx], delta=0.2)
-
-            ra, dec = stack.pixel_to_world(0, expected_x[idx], expected_y[idx])
-            self.assertAlmostEqual(ra, query_ra[idx], delta=0.001)
-            self.assertAlmostEqual(dec, query_dec[idx], delta=0.001)
-
-        # We fail if the WCS is not set.
-        with self.assertRaises(ValueError):
-            stack.world_to_pixel(1, 200.5, -7.5)
-        with self.assertRaises(ValueError):
-            stack.pixel_to_world(1, 249, 349)
-
     def test_make_fake_image_stack(self):
         """Test that we can create a fake ImageStackPy."""
         fake_times = np.arange(10)
@@ -199,12 +129,14 @@ class test_image_stack_py(unittest.TestCase):
         self.assertEqual(fake_stack.npixels, 200 * 300)
         self.assertEqual(fake_stack.total_pixels, 10 * 200 * 300)
         self.assertEqual(fake_stack.num_masked_pixels(), 0)
-        self.assertEqual(fake_stack.sci.shape, (10, 300, 200))
-        self.assertEqual(fake_stack.var.shape, (10, 300, 200))
+        self.assertEqual(len(fake_stack.sci), 10)
+        self.assertEqual(len(fake_stack.var), 10)
+        for idx in range(10):
+            self.assertEqual(fake_stack.sci[idx].shape, (300, 200))
+            self.assertEqual(fake_stack.var[idx].shape, (300, 200))
+            self.assertTrue(len(np.unique(fake_stack.sci[idx])) > 1)
+            self.assertTrue(np.allclose(fake_stack.var[idx], 4.0))
         self.assertEqual(len(fake_stack.psfs), 10)
-
-        self.assertTrue(len(np.unique(fake_stack.sci)) > 1)
-        self.assertTrue(np.allclose(fake_stack.var, 4.0))
 
     def test_image_stack_add_fake_object(self):
         """Test that we can inset a fake object into an ImageStackPy."""
@@ -224,11 +156,11 @@ class test_image_stack_py(unittest.TestCase):
             # is non-zero but less than the flux (due to the PSF) at each time step.
             px = int(50 + t_val + 0.5)
             py = int(60 + 2.0 * t_val + 0.5)
-            self.assertGreater(fake_stack.sci[t_idx, py, px], 50.0)
-            self.assertLess(fake_stack.sci[t_idx, py, px], 100.0)
+            self.assertGreater(fake_stack.sci[t_idx][py, px], 50.0)
+            self.assertLess(fake_stack.sci[t_idx][py, px], 100.0)
 
             # Far away from the object, the signal should be zero.
-            self.assertAlmostEqual(fake_stack.sci[t_idx, 30, 40], 0.0)
+            self.assertAlmostEqual(fake_stack.sci[t_idx][30, 40], 0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR switches the Python version of ImageStack to use a list of 2-d images instead of a single 3-d numpy array. This is a tradeoff. The downside is that it will increase the running time of some (infrequent) operations such as masking out pixels above a certain flux. The positive side is that it will enable more memory efficiency. Images can be loaded individually from WorkUnits without having to copy the data into a predefined 3-d matrix.