### PR TITLE
Add psi and phi generation in Python

### DIFF
--- a/src/kbmod/core/psf.py
+++ b/src/kbmod/core/psf.py
@@ -104,13 +104,17 @@ class PSF:
         new_kernel = self.kernel**2
         return PSF(new_kernel)
 
-    def convolve_image(self, image, in_place=False, device=None):
+    def convolve_image(self, image, scale_by_masked=True, in_place=False, device=None):
         """Perform the 2D convolution where NO_DATA or NaN values are masked.
 
         Parameters
         ----------
         image : `numpy.ndarray`
             A 2D array of image data.
+        scale_by_masked : `bool`
+            The convolution is scaled to account for masked pixels so as to preserve to the
+            flux in the unmasked pixels.
+            Default is True.
         in_place : `bool`, optional
             If True, the convolution is performed in place, modifying the input image.
             If False, a new array is created and returned.
@@ -125,10 +129,16 @@ class PSF:
         result : `numpy.ndarray`
             A 2D array of the same shape as the image data.
         """
-        return convolve_psf_and_image(image, self.kernel, in_place=in_place, device=device)
+        return convolve_psf_and_image(
+            image,
+            self.kernel,
+            scale_by_masked=scale_by_masked,
+            in_place=in_place,
+            device=device,
+        )
 
 
-def convolve_psf_and_image(image, kernel, in_place=False, device=None):
+def convolve_psf_and_image(image, kernel, scale_by_masked=True, in_place=False, device=None):
     """Perform the 2D convolution where NO_DATA or NaN values are masked.
 
     Parameters
@@ -137,6 +147,10 @@ def convolve_psf_and_image(image, kernel, in_place=False, device=None):
         A 2D array of image data.
     kernel : `numpy.ndarray`
         A 2D array representing the PSF kernel. Must be square.
+    scale_by_masked : `bool`
+        The convolution is scaled to account for masked pixels so as to preserve to the
+        flux in the unmasked pixels.
+        Default is True.
     in_place : `bool`, optional
         If True, the convolution is performed in place, modifying the input image.
         If False, a new array is created and returned.
@@ -172,6 +186,16 @@ def convolve_psf_and_image(image, kernel, in_place=False, device=None):
 
     # Perform the convolution. Using padding="same" to effectively zero-pad the image.
     convolved_image = torch.nn.functional.conv2d(image_tensor, kernel_tensor, padding="same")
+
+    if scale_by_masked:
+        # To account for the masked pixels, we divide by the sum of kernel values that
+        # landed on unmasked pixels.
+        bin_tensor = torch.where(data_mask, 1.0, 0.0)
+        scale = torch.clamp(
+            torch.nn.functional.conv2d(bin_tensor, kernel_tensor, padding="same"),
+            min=1e-24,  # Avoid divide by zero.
+        )
+        convolved_image = convolved_image / scale
 
     # Re-mask the masked points.
     convolved_image[~data_mask] = float("nan")

--- a/src/kbmod/core/shift_and_stack.py
+++ b/src/kbmod/core/shift_and_stack.py
@@ -1,0 +1,45 @@
+"""Functions for performing core shift and stack functionality."""
+
+import numpy as np
+
+from kbmod.core.psf import convolve_psf_and_image, PSF
+
+
+def generate_psi_phi_images(sci, var, psf):
+    """Generate the PSI and PHI images from a given science image,
+    variance image, and psf.
+
+    Parameters
+    ----------
+    sci : `numpy.ndarray`
+        The H x W matrix of image pixels.
+    var : `numpy.ndarray`
+        The H x W matrix of variance pixels.
+    psf : `numpy.ndarray` or PSF.
+        The PSF data as a PSF object or a matrix of kernel values.
+
+    Returns
+    -------
+    psi : `numpy.ndarray`
+        The H x W matrix of the PSI image.
+    phi : `numpy.ndarray`
+        The H x W matrix of the PHI image.
+    """
+    psi = np.full_like(sci, np.nan)
+    phi = np.full_like(sci, np.nan)
+    valid_mask = ~(np.isnan(sci) | np.isnan(var) | (var <= 0.0))
+
+    psi[valid_mask] = sci[valid_mask] / var[valid_mask]
+    phi[valid_mask] = 1.0 / var[valid_mask]
+
+    # Convolve psi with the PSF and phi with the square of the PSF.
+    # Note that convolve_image correctly preserves NaNs (and uses them
+    # for scaling).
+    if isinstance(psf, PSF):
+        psf = psf.kernel
+    psi = convolve_psf_and_image(psi, psf, scale_by_masked=True)
+
+    psf_sq = psf**2
+    phi = convolve_psf_and_image(phi, psf_sq, scale_by_masked=True)
+
+    return psi, phi

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -37,18 +37,6 @@ class test_PSF(unittest.TestCase):
             p = PSF(std_val / 5 + 0.2)
             self.assertGreater(np.sum(p.kernel), 0.95)
 
-    def test_square(self):
-        for std_val in range(1, 10):
-            p = PSF(std_val / 5 + 0.2)
-
-            # Create a square of the PSF.
-            x = p.make_square()
-            self.assertTrue(np.not_equal(x.kernel, p.kernel).any())
-
-            # Squaring the PSF should not change any of the parameters.
-            self.assertEqual(x.width, p.width)
-            self.assertEqual(x.radius, p.radius)
-
     def test_convolve_psf_identity(self):
         psf_data = np.zeros((3, 3), dtype=np.single)
         psf_data[1, 1] = 1.0

--- a/tests/test_python_parity.py
+++ b/tests/test_python_parity.py
@@ -7,7 +7,8 @@ import unittest
 import numpy as np
 
 from kbmod.core.psf import convolve_psf_and_image, PSF
-from kbmod.search import RawImage
+from kbmod.search import LayeredImage, RawImage
+from kbmod.core.shift_and_stack import generate_psi_phi_images
 
 
 class test_python_parity(unittest.TestCase):
@@ -36,6 +37,60 @@ class test_python_parity(unittest.TestCase):
                     self.assertTrue(np.isnan(img_p[y, x]))
                 else:
                     self.assertAlmostEqual(img_c.image[y, x], img_p[y, x], places=4)
+
+    def test_convolve_non_unit(self):
+        """Test that convolution produces the same result when the kernel does
+        not sum up to 1.0."""
+        height = 40
+        width = 30
+        img_p = (0.1 * np.arange(height * width)).reshape((height, width)).astype(np.single)
+
+        # Mask out a few pixels.
+        for py, px in [(3, 1), (10, 10), (10, 11), (10, 12), (15, 4)]:
+            img_p[py, px] = np.nan
+
+        # Create a C++ version of the image.
+        img_c = RawImage(img_p)
+
+        # Create the PSF from a Gaussian kernel and then square its values.
+        psf = PSF.make_gaussian_kernel(0.9) ** 2
+
+        # Do the convolution with the C++ and Python functions.
+        img_c.convolve(psf)
+        img_p = convolve_psf_and_image(img_p, psf)
+
+        for y in range(height):
+            for x in range(width):
+                if np.isnan(img_c.image[y, x]):
+                    self.assertTrue(np.isnan(img_p[y, x]))
+                else:
+                    self.assertAlmostEqual(img_c.image[y, x], img_p[y, x], places=4)
+
+    def test_psi_phi_generation(self):
+        height = 40
+        width = 35
+        sci = np.array([np.arange(width) for _ in range(height)], dtype=np.single)
+        var = np.array([0.1 * (h + 1) * np.ones(width) for h in range(height)], dtype=np.single)
+        msk = np.zeros_like(sci)
+
+        # Mask out a few pixels.
+        for py, px in [(3, 1), (10, 10), (10, 11), (10, 12), (15, 4), (35, 20), (35, 21), (35, 22)]:
+            sci[py, px] = np.nan
+            var[py, px] = np.nan
+
+        # Create the PSF.
+        psf = PSF.make_gaussian_kernel(1.2)
+
+        # Create a C++ version of the image and use it to generate psi and phi images.
+        img_c = LayeredImage(sci, var, msk, psf, 1.0)
+        psi_c = img_c.generate_psi_image()
+        phi_c = img_c.generate_phi_image()
+
+        # Generate psi and phi via python and compare the results.
+        psi_p, phi_p = generate_psi_phi_images(sci, var, psf)
+
+        self.assertTrue(np.allclose(psi_c, psi_p, rtol=0.001, atol=0.001, equal_nan=True))
+        self.assertTrue(np.allclose(phi_c, phi_p, rtol=0.001, atol=0.001, equal_nan=True))
 
 
 if __name__ == "__main__":

--- a/tests/test_python_parity.py
+++ b/tests/test_python_parity.py
@@ -1,0 +1,42 @@
+"""This is a temporary set of tests to confirm that the Python KBMOD
+code is performing the same as the C++ KBMOD code.
+"""
+
+import unittest
+
+import numpy as np
+
+from kbmod.core.psf import convolve_psf_and_image, PSF
+from kbmod.search import RawImage
+
+
+class test_python_parity(unittest.TestCase):
+    def test_convolve(self):
+        height = 40
+        width = 30
+        img_p = (0.1 * np.arange(height * width)).reshape((height, width)).astype(np.single)
+
+        # Mask out a few pixels.
+        for py, px in [(3, 1), (10, 10), (10, 11), (10, 12), (15, 4)]:
+            img_p[py, px] = np.nan
+
+        # Create a C++ version of the image.
+        img_c = RawImage(img_p)
+
+        # Create the PSF.
+        psf = PSF.make_gaussian_kernel(1.2)
+
+        # Do the convolution with the C++ and Python functions.
+        img_c.convolve(psf)
+        img_p = convolve_psf_and_image(img_p, psf)
+
+        for y in range(height):
+            for x in range(width):
+                if np.isnan(img_c.image[y, x]):
+                    self.assertTrue(np.isnan(img_p[y, x]))
+                else:
+                    self.assertAlmostEqual(img_c.image[y, x], img_p[y, x], places=4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shift_and_stack.py
+++ b/tests/test_shift_and_stack.py
@@ -1,0 +1,82 @@
+import math
+import numpy as np
+import unittest
+
+from kbmod.core.shift_and_stack import generate_psi_phi_images
+
+
+class test_shift_and_stack(unittest.TestCase):
+    def test_generate_psi_phi_images_no_psf(self):
+        """Test that we can create psi and phi images with a no-op psf."""
+        width = 10
+        height = 20
+        psf_kernel = np.array([[1.0]])  # No-op kernel
+        sci = np.array([np.arange(width) for _ in range(height)], dtype=np.single)
+        var = np.array([0.1 * (h + 1) * np.ones(width) for h in range(height)], dtype=np.single)
+
+        # Mask a few of the values.
+        for y, x in [(3, 4), (15, 3), (1, 1)]:
+            sci[y, x] = np.nan
+            var[y, x] = np.nan
+
+        psi, phi = generate_psi_phi_images(sci, var, psf_kernel)
+        for y in range(height):
+            for x in range(width):
+                if np.isnan(sci[y, x]):
+                    self.assertTrue(np.isnan(psi[y, x]))
+                    self.assertTrue(np.isnan(phi[y, x]))
+                else:
+                    self.assertAlmostEqual(psi[y, x], x / (0.1 * (y + 1)), places=5)
+                    self.assertAlmostEqual(phi[y, x], 1.0 / (0.1 * (y + 1)), places=5)
+
+    def test_generate_psi_phi_images_given_psf(self):
+        """Test that we can create psi and phi images with a given psf."""
+        sci = np.array(
+            [
+                [0.0, 1.0, 2.0, 3.0],
+                [4.0, 5.0, np.nan, 7.0],
+                [8.0, 9.0, 10.0, 11.0],
+            ],
+            dtype=np.single,
+        )
+        var = np.array(
+            [
+                [0.1, 0.1, 0.1, 0.1],
+                [0.2, 0.2, np.nan, 0.2],
+                [0.1, 0.1, 0.1, 0.1],
+            ],
+            dtype=np.single,
+        )
+        psf_kernel = np.array(
+            [
+                [0.0, 0.1, 0.0],
+                [0.1, 0.6, 0.1],
+                [0.0, 0.1, 0.0],
+            ]
+        )
+
+        # Compare to manually computed psi and phi values.
+        psi_expected = np.array(
+            [
+                [3.75, 11.66666, 20.0, 29.375],
+                [25.0, 30.0, np.nan, 43.75],
+                [73.75, 82.77777, 100.0, 99.375],
+            ],
+            dtype=np.single,
+        )
+        phi_expected = np.array(
+            [
+                [3.9473684, 3.9487179, 4.0, 3.94736842],
+                [2.1025641, 2.1025641, np.nan, 2.10526316],
+                [3.9473684, 3.9487179, 4.0, 3.94736842],
+            ],
+            dtype=np.single,
+        )
+        psi, phi = generate_psi_phi_images(sci, var, psf_kernel)
+
+        self.assertTrue(np.allclose(psi, psi_expected, rtol=0.001, atol=0.001, equal_nan=True))
+        self.assertTrue(np.allclose(phi, phi_expected, rtol=0.001, atol=0.001, equal_nan=True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds more code to operation on images in Python (specifically `generate_psi_phi_images`). In the process I noticed a bug with the previous python convolve code. So this PR also adds some tests to check that the C++ and Python operations are giving the same results for non-toy data.

Also removes the Python PSF class's `make_square()` function because it isn't going to be used.