### PR TITLE
Remove unused RawImage references

### DIFF
--- a/src/kbmod/analysis/visualizer.py
+++ b/src/kbmod/analysis/visualizer.py
@@ -91,9 +91,6 @@ class Visualizer:
             if result_row["obs_valid"][i]:
                 day = mjd_to_day(self.im_stack.get_obstime(i))
                 curr_stamp = result_row["all_stamps"][i]
-                # Depending on where "all_stamps" is generated may be a RawImage
-                if not isinstance(curr_stamp, np.ndarray):
-                    curr_stamp = curr_stamp.image
 
                 if day not in daily_coadds:
                     # Create the initial coadd

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -20,7 +20,7 @@ from kbmod import is_interactive
 from kbmod.configuration import SearchConfiguration
 from kbmod.image_utils import stat_image_stack, validate_image_stack
 from kbmod.reprojection_utils import invert_correct_parallax
-from kbmod.search import ImageStack, LayeredImage, RawImage, Logging, Trajectory
+from kbmod.search import ImageStack, LayeredImage, Logging, Trajectory
 from kbmod.util_functions import get_matched_obstimes
 from kbmod.wcs_utils import (
     append_wcs_to_hdu_header,


### PR DESCRIPTION
Remove a few instances where `RawImage` is referenced, but not used. For example `reproject_image` provides an option to take `RawImage`, but it is only passed `LayeredImage` by the rest of the code.