### PR TITLE
Add ability to clear results from CPU memory

### DIFF
--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -67,7 +67,7 @@ def configure_kb_search_stack(search, config):
     # set the parameters.
     if config["encode_num_bytes"] > 0:
         search.enable_gpu_encoding(config["encode_num_bytes"])
-        
+
     # Clear the cached results.
     search.clear_results()
 

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -67,6 +67,9 @@ def configure_kb_search_stack(search, config):
     # set the parameters.
     if config["encode_num_bytes"] > 0:
         search.enable_gpu_encoding(config["encode_num_bytes"])
+        
+    # Clear the cached results.
+    search.clear_results()
 
 
 def check_gpu_memory(config, stack, trj_generator=None):
@@ -217,7 +220,7 @@ class SearchRunner:
         # Load the results.
         keep = self.load_and_filter_results(search, config)
 
-        # Force the deletion of the on-GPU data.
+        # Force the deletion of the on-GPU and on-CPU data.
         search.clear_psi_phi()
 
         return keep

--- a/src/kbmod/search/image_stack.cpp
+++ b/src/kbmod/search/image_stack.cpp
@@ -88,7 +88,6 @@ void ImageStack::sort_by_time() {
               [](const LayeredImage& a, const LayeredImage& b) { return a.get_obstime() < b.get_obstime(); });
 }
 
-
 #ifdef Py_PYTHON_H
 static void image_stack_bindings(py::module& m) {
     using is = search::ImageStack;

--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -303,14 +303,19 @@ std::vector<Trajectory> StackSearch::get_results(uint64_t start, uint64_t count)
                      ")");
     return results.get_batch(start, count);
 }
-    
-std::vector<Trajectory>& StackSearch::get_all_results() {
-    return results.get_list();
-}
+
+std::vector<Trajectory>& StackSearch::get_all_results() { return results.get_list(); }
 
 // This function is used only for testing by injecting known result trajectories.
 void StackSearch::set_results(const std::vector<Trajectory>& new_results) {
     results.set_trajectories(new_results);
+}
+
+void StackSearch::clear_results() {
+    if (results.on_gpu()) {
+        results.move_to_cpu();
+    }
+    results.resize(0);
 }
 
 #ifdef Py_PYTHON_H
@@ -360,6 +365,7 @@ static void stack_search_bindings(py::module& m) {
             .def("get_results", &ks::get_results, pydocs::DOC_StackSearch_get_results)
             .def("get_all_results", &ks::get_all_results, pydocs::DOC_StackSearch_get_all_results)
             .def("set_results", &ks::set_results, pydocs::DOC_StackSearch_set_results)
+            .def("clear_results", &ks::clear_results, pydocs::DOC_StackSearch_clear_results)
             .def("compute_max_results", &ks::compute_max_results, pydocs::DOC_StackSearch_compute_max_results)
             .def("prepare_search", &ks::prepare_search, pydocs::DOC_StackSearch_prepare_batch_search)
             .def("finish_search", &ks::finish_search, pydocs::DOC_StackSearch_finish_search);

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -58,6 +58,7 @@ public:
     uint64_t get_number_total_results() { return results.get_size(); }
     std::vector<Trajectory> get_results(uint64_t start, uint64_t count);
     std::vector<Trajectory>& get_all_results();
+    void clear_results();
 
     // Getters for the Psi and Phi data.
     std::vector<float> get_psi_curves(const Trajectory& t);

--- a/src/kbmod/search/trajectory_list.cpp
+++ b/src/kbmod/search/trajectory_list.cpp
@@ -84,7 +84,7 @@ void TrajectoryList::filter_by_likelihood(float min_lh) {
 
 void TrajectoryList::filter_by_obs_count(int min_obs_count) {
     if (data_on_gpu) throw std::runtime_error("Data on GPU");
-    
+
     auto new_end = std::remove_if(cpu_list.begin(), cpu_list.end(), [min_obs_count](const Trajectory& a) {
         return (a.obs_count < min_obs_count);
     });

--- a/tests/test_stack_search_results.py
+++ b/tests/test_stack_search_results.py
@@ -54,6 +54,11 @@ class test_search(unittest.TestCase):
 
         # Check invalid settings
         self.assertRaises(RuntimeError, self.search.get_results, 0, 0)
+        
+        # Check that we can clear the results.
+        self.search.clear_results()
+        self.assertEqual(len(self.search.get_all_results()), 0)
+        
 
     def test_psi_phi_curves(self):
         psi_curves = np.array(self.search.get_psi_curves(self.fake_trjs))

--- a/tests/test_stack_search_results.py
+++ b/tests/test_stack_search_results.py
@@ -54,11 +54,10 @@ class test_search(unittest.TestCase):
 
         # Check invalid settings
         self.assertRaises(RuntimeError, self.search.get_results, 0, 0)
-        
+
         # Check that we can clear the results.
         self.search.clear_results()
         self.assertEqual(len(self.search.get_all_results()), 0)
-        
 
     def test_psi_phi_curves(self):
         psi_curves = np.array(self.search.get_psi_curves(self.fake_trjs))


### PR DESCRIPTION
Once we load the results from the `StackSearch` object into the results table, we no longer need them. This PR adds the ability to clear them from CPU memory.