### PR TITLE
Ensure the psi and phi curves are stored as float32

### DIFF
--- a/src/kbmod/filters/sigma_g_filter.py
+++ b/src/kbmod/filters/sigma_g_filter.py
@@ -168,7 +168,7 @@ class SigmaGClipping:
         index_valid = torch.isfinite(torch_lh) & (torch_lh < upper_bnd) & (torch_lh > lower_bnd)
 
         # Return as a numpy array on the CPU.
-        return index_valid.cpu().numpy()
+        return index_valid.cpu().numpy().astype(bool)
 
 
 def apply_clipped_sigma_g(clipper, result_data):

--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -356,7 +356,7 @@ class Results:
         if filter_obs and "obs_valid" in self.table.colnames:
             valid = valid & self.table["obs_valid"]
 
-        lh_matrix = np.full(psi.shape, mask_value)
+        lh_matrix = np.full(psi.shape, mask_value, dtype=np.float32)
         lh_matrix[valid] = psi[valid] / np.sqrt(phi[valid])
         return lh_matrix
 
@@ -432,8 +432,8 @@ class Results:
                 f"Wrong number of phi curves provided. Expected {len(self.table)} rows."
                 f" Found {len(phi_array)} rows."
             )
-        self.table["psi_curve"] = psi_array
-        self.table["phi_curve"] = phi_array
+        self.table["psi_curve"] = np.asanyarray(psi_array, dtype=np.float32)
+        self.table["phi_curve"] = np.asanyarray(phi_array, dtype=np.float32)
 
         if obs_valid is not None:
             # Make the data to match.


### PR DESCRIPTION
Very small optimization. Psi and Phi curves were being stored in `Results` as float64, but the underlying data is float32.