### PR TITLE
Enable threading for the extraction of psi and phi curves

### DIFF
--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -135,6 +135,8 @@ class SearchRunner:
         keep : `Results`
             A Results object containing values from trajectories.
         """
+        num_times = search.get_num_images()
+
         # Retrieve a reference to all the results and compile the results table.
         result_trjs = search.get_all_results()
         logger.info(f"Retrieving Results (total={len(result_trjs)})")
@@ -144,9 +146,9 @@ class SearchRunner:
 
         if config["generate_psi_phi"]:
             logger.debug(f"Generating psi and phi curves.")
-            psi_batch = search.get_psi_curves(result_trjs)
-            phi_batch = search.get_phi_curves(result_trjs)
-            keep.add_psi_phi_data(psi_batch, phi_batch)
+            psi_phi = search.get_all_psi_phi_curves(result_trjs)
+            logger.debug(f"Saving psi and phi curves.")
+            keep.add_psi_phi_data(psi_phi[:, :num_times], psi_phi[:, num_times:])
 
         # Do the sigma-G filtering and subsequent stats filtering.
         if config["sigmaG_filter"]:

--- a/src/kbmod/search/pydocs/stack_search_docs.h
+++ b/src/kbmod/search/pydocs/stack_search_docs.h
@@ -164,6 +164,24 @@ static const auto DOC_StackSearch_get_phi_curves = R"doc(
      The phi values at each time step with NO_DATA replaced by 0.0.
   )doc";
 
+static const auto DOC_StackSearch_get_all_psi_phi_curves = R"doc(
+  Return a single matrix with both the psi and phi curves. Each
+  row corresponds to a single trajectory and the columns hold
+  the psi values then the phi values (in order of time).
+
+  Parameters
+  ----------
+  trj : `list` of `kb.Trajectory`
+      The input trajectories.
+
+  Returns
+  -------
+  result : `np.ndarray`
+     A shape (R, 2T) matrix where R is the number of trajectories and
+     T is the number of time steps. The first T columns contain the psi
+     values and the second T columns contain the phi columns.
+  )doc";
+
 static const auto DOC_StackSearch_clear_psi_phi = R"doc(
   Clear the pre-computed psi and phi data.
   )doc";

--- a/src/kbmod/search/pydocs/stack_search_docs.h
+++ b/src/kbmod/search/pydocs/stack_search_docs.h
@@ -136,34 +136,6 @@ static const auto DOC_StackSearch_get_imagestack = R"doc(
   Return the `kb.ImageStack` containing the data to search.
   )doc";
 
-static const auto DOC_StackSearch_get_psi_curves = R"doc(
-  Return the time series of psi values for a given trajectory in pixel space.
-
-  Parameters
-  ----------
-  trj : `kb.Trajectory` or `list` of `kb.Trajectory`
-      The input trajectory or trajectories.
-
-  Returns
-  -------
-  result : `list` of `float` or `list` of `list` of `float`
-     The psi values at each time step with NO_DATA replaced by 0.0.
-  )doc";
-
-static const auto DOC_StackSearch_get_phi_curves = R"doc(
-  Return the time series of phi values for a given trajectory in pixel space.
-
-  Parameters
-  ----------
-  trj : `kb.Trajectory` or `list` of `kb.Trajectory`
-      The input trajectory or trajectories.
-
-  Returns
-  -------
-  result : `list` of `float` or `list` of `list` of `float`
-     The phi values at each time step with NO_DATA replaced by 0.0.
-  )doc";
-
 static const auto DOC_StackSearch_get_all_psi_phi_curves = R"doc(
   Return a single matrix with both the psi and phi curves. Each
   row corresponds to a single trajectory and the columns hold

--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -9,6 +9,31 @@ extern "C" void evaluateTrajectory(PsiPhiArrayMeta psi_phi_meta, void* psi_phi_v
                                    SearchParameters params, Trajectory* candidate);
 #endif
 
+// A helper function to extact both the psi and phi information as a single
+// list with all psi values and then all phi values.
+std::vector<float> extract_joint_psi_phi_curve(const PsiPhiArray& psi_phi, const Trajectory& trj) {
+    const unsigned int num_times = psi_phi.get_num_times();
+    std::vector<float> result(2 * num_times, 0.0);
+
+    for (unsigned int i = 0; i < num_times; ++i) {
+        double time = psi_phi.read_time(i);
+
+        // Query the center of the predicted location's pixel.
+        PsiPhi psi_phi_val = psi_phi.read_psi_phi(i, trj.get_y_index(time), trj.get_x_index(time));
+        if (pixel_value_valid(psi_phi_val.psi)) {
+            result[i] = psi_phi_val.psi;
+        }
+        if (pixel_value_valid(psi_phi_val.phi)) {
+            result[i + num_times] = psi_phi_val.phi;
+        }
+    }
+    return result;
+}
+
+// --------------------------------------------
+// StackSearch
+// --------------------------------------------
+
 StackSearch::StackSearch(ImageStack& imstack) : stack(imstack), results(0), gpu_search_list(0) {
     psi_phi_generated = false;
 
@@ -298,6 +323,27 @@ std::vector<float> StackSearch::get_phi_curves(const Trajectory& trj) {
     return extract_psi_or_phi_curve(trj, false);
 }
 
+Image StackSearch::get_all_psi_phi_curves(const std::vector<Trajectory>& trajectories) {
+    // Allocate a (num_trj, 2 * num_times) image to store the curves for all the trajectories.
+    const unsigned int num_trj = trajectories.size();
+    const unsigned int num_times = stack.img_count();
+    Image results = Image::Zero(num_trj, 2 * num_times);
+
+    prepare_psi_phi();
+
+#pragma omp parallel for schedule(dynamic)
+    for (int i = 0; i < num_trj; ++i) {
+        std::vector<float> curve = extract_joint_psi_phi_curve(psi_phi_array, trajectories[i]);
+
+// Copy the data into the results.
+#pragma omp critical
+        for (int j = 0; j < 2 * num_times; ++j) {
+            results(i, j) = curve[j];
+        }
+    }
+    return results;
+}
+
 std::vector<Trajectory> StackSearch::get_results(uint64_t start, uint64_t count) {
     rs_logger->debug("Reading results [" + std::to_string(start) + ", " + std::to_string(start + count) +
                      ")");
@@ -358,6 +404,8 @@ static void stack_search_bindings(py::module& m) {
                  (std::vector<std::vector<float> >(ks::*)(const std::vector<tj>&)) & ks::get_psi_curves)
             .def("get_phi_curves",
                  (std::vector<std::vector<float> >(ks::*)(const std::vector<tj>&)) & ks::get_phi_curves)
+            .def("get_all_psi_phi_curves", &ks::get_all_psi_phi_curves,
+                 pydocs::DOC_StackSearch_get_all_psi_phi_curves)
             .def("prepare_psi_phi", &ks::prepare_psi_phi, pydocs::DOC_StackSearch_prepare_psi_phi)
             .def("clear_psi_phi", &ks::clear_psi_phi, pydocs::DOC_StackSearch_clear_psi_phi)
             .def("get_number_total_results", &ks::get_number_total_results,

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -61,10 +61,6 @@ public:
     void clear_results();
 
     // Getters for the Psi and Phi data.
-    std::vector<float> get_psi_curves(const Trajectory& t);
-    std::vector<float> get_phi_curves(const Trajectory& t);
-    std::vector<std::vector<float> > get_psi_curves(const std::vector<Trajectory>& trajectories);
-    std::vector<std::vector<float> > get_phi_curves(const std::vector<Trajectory>& trajectories);
     Image get_all_psi_phi_curves(const std::vector<Trajectory>& trajectories);
 
     // Helper functions for computing Psi and Phi
@@ -77,8 +73,6 @@ public:
     virtual ~StackSearch();
 
 protected:
-    std::vector<float> extract_psi_or_phi_curve(const Trajectory& trj, bool extract_psi);
-
     // Core data and search parameters. Note the StackSearch does not own
     // the ImageStack and it must exist for the duration of the object's life.
     ImageStack& stack;

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -10,6 +10,7 @@
 #include <chrono>
 #include <stdexcept>
 #include <float.h>
+#include <omp.h>
 
 #include "logging.h"
 #include "common.h"
@@ -23,7 +24,6 @@
 #include "trajectory_list.h"
 
 namespace search {
-using Point = indexing::Point;
 using Image = search::Image;
 
 class StackSearch {
@@ -65,6 +65,7 @@ public:
     std::vector<float> get_phi_curves(const Trajectory& t);
     std::vector<std::vector<float> > get_psi_curves(const std::vector<Trajectory>& trajectories);
     std::vector<std::vector<float> > get_phi_curves(const std::vector<Trajectory>& trajectories);
+    Image get_all_psi_phi_curves(const std::vector<Trajectory>& trajectories);
 
     // Helper functions for computing Psi and Phi
     void prepare_psi_phi();

--- a/src/kbmod/trajectory_explorer.py
+++ b/src/kbmod/trajectory_explorer.py
@@ -113,9 +113,11 @@ class TrajectoryExplorer:
         result = Results.from_trajectories([trj])
 
         # Get the psi and phi curves and do the sigma_g filtering.
-        psi_curve = np.asarray([self.search.get_psi_curves(trj)])
-        phi_curve = np.asarray([self.search.get_phi_curves(trj)])
-        obs_valid = np.full(psi_curve.shape, True)
+        num_times = self.im_stack.img_count()
+        psi_phi = self.search.get_all_psi_phi_curves([trj])
+        psi_curve = psi_phi[:, :num_times]
+        phi_curve = psi_phi[:, num_times:]
+        obs_valid = np.full(psi_curve.shape, True, dtype=bool)
         result.add_psi_phi_data(psi_curve, phi_curve, obs_valid)
 
         # Get the coadds and the individual stamps.


### PR DESCRIPTION
Restructure how the code extracts psi and phi curves and make it multi-threaded.

This change brings the cost of extracting the psi/phi curves to < 5% of the current running time (on a benchmark with 100,000 results and 100 time steps the running time went from 2.41s down to 67.1ms). It also brings the total running time of the "load and filter" step (including Sigma-G filtering) down to ~26% of current (2.94 s down to 782 ms). I have some more optimizations in mind for the larger step.