### PR TITLE
Optimize the clustering filters

### DIFF
--- a/src/kbmod/filters/clustering_filters.py
+++ b/src/kbmod/filters/clustering_filters.py
@@ -124,12 +124,12 @@ class ClusterPredictionFilter(DBSCANFilter):
         # Set up the clustering algorithm's name.
         self.cluster_type = f"position t={self.times}"
 
-    def _build_clustering_data(self, results):
+    def _build_clustering_data(self, result_data):
         """Build the specific data set for this clustering approach.
 
         Parameters
         ----------
-        results: `Results`
+        result_data: `Results`
             The set of results to filter.
 
         Returns
@@ -138,12 +138,12 @@ class ClusterPredictionFilter(DBSCANFilter):
            The N x D matrix to cluster where N is the number of results
            and D is the number of attributes.
         """
-        x0_arr = results["x"][:, np.newaxis].astype(np.float32)
-        xv_arr = results["vx"][:, np.newaxis].astype(np.float32)
+        x0_arr = result_data["x"][:, np.newaxis].astype(np.float32)
+        xv_arr = result_data["vx"][:, np.newaxis].astype(np.float32)
         pred_x = x0_arr + xv_arr * self.times[np.newaxis, :]
 
-        y0_arr = results["y"][:, np.newaxis].astype(np.float32)
-        yv_arr = results["vy"][:, np.newaxis].astype(np.float32)
+        y0_arr = result_data["y"][:, np.newaxis].astype(np.float32)
+        yv_arr = result_data["vy"][:, np.newaxis].astype(np.float32)
         pred_y = y0_arr + yv_arr * self.times[np.newaxis, :]
         return np.hstack([pred_x, pred_y])
 
@@ -230,12 +230,12 @@ class NNSweepFilter:
         """
         return f"NNFilter times={self.times} eps={self.thresh}"
 
-    def _build_clustering_data(self, results):
+    def _build_clustering_data(self, result_data):
         """Build the specific data set for this clustering approach.
 
         Parameters
         ----------
-        results: `Results`
+        result_data: `Results`
             The set of results to filter.
 
         Returns
@@ -244,12 +244,12 @@ class NNSweepFilter:
            The N x D matrix to cluster where N is the number of results
            and D is the number of attributes.
         """
-        x0_arr = results["x"][:, np.newaxis].astype(np.float32)
-        xv_arr = results["vx"][:, np.newaxis].astype(np.float32)
+        x0_arr = result_data["x"][:, np.newaxis].astype(np.float32)
+        xv_arr = result_data["vx"][:, np.newaxis].astype(np.float32)
         pred_x = x0_arr + xv_arr * self.times[np.newaxis, :]
 
-        y0_arr = results["y"][:, np.newaxis].astype(np.float32)
-        yv_arr = results["vy"][:, np.newaxis].astype(np.float32)
+        y0_arr = result_data["y"][:, np.newaxis].astype(np.float32)
+        yv_arr = result_data["vy"][:, np.newaxis].astype(np.float32)
         pred_y = y0_arr + yv_arr * self.times[np.newaxis, :]
         return np.hstack([pred_x, pred_y])
 

--- a/tests/test_clustering_filters.py
+++ b/tests/test_clustering_filters.py
@@ -82,6 +82,48 @@ class test_clustering_filters(unittest.TestCase):
         f4 = ClusterPosVelFilter(cluster_eps=5.0, cluster_v_scale=1e-9)
         self.assertEqual(f4.keep_indices(rs), [0, 3])
 
+    def test_cluster_build_data(self):
+        """Test that we predict the correct positions."""
+        rs = self._make_result_data(
+            [
+                [10, 11, 0, 0],
+                [10, 11, 1, 2],
+            ]
+        )
+        times = [0.0, 0.5, 1.0, 1.5, 2.0]
+
+        f1 = ClusterPosVelFilter(cluster_eps=5.0, cluster_v_scale=1.0)
+        cluster_data = f1._build_clustering_data(rs)
+        expected_data = np.array(
+            [
+                [10.0, 11.0, 0.0, 0.0],
+                [10.0, 11.0, 1.0, 2.0],
+            ]
+        )
+        self.assertEqual(cluster_data.dtype, np.float32)
+        self.assertTrue(np.allclose(cluster_data, expected_data))
+
+    def test_cluster_build_data_prediction(self):
+        """Test that we predict the correct positions."""
+        rs = self._make_result_data(
+            [
+                [10, 11, 0, 0],
+                [10, 11, 1, 2],
+            ]
+        )
+        times = [0.0, 0.5, 1.0, 1.5, 2.0]
+
+        f1 = ClusterPredictionFilter(cluster_eps=2.0, pred_times=times)
+        predicted_pos = f1._build_clustering_data(rs)
+        expected_pos = np.array(
+            [
+                [10.0, 10.0, 10.0, 10.0, 10.0, 11.0, 11.0, 11.0, 11.0, 11.0],
+                [10.0, 10.5, 11.0, 11.5, 12.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+            ]
+        )
+        self.assertEqual(predicted_pos.dtype, np.float32)
+        self.assertTrue(np.allclose(predicted_pos, expected_pos))
+
     def test_dbscan_mid_pos(self):
         rs = self._make_result_data(
             [
@@ -170,6 +212,27 @@ class test_clustering_filters(unittest.TestCase):
         cluster_params["cluster_type"] = "invalid"
         self.assertRaises(ValueError, apply_clustering, results2, cluster_params)
 
+    def test_nnsweep_build_data(self):
+        """Test that we predict the correct positions."""
+        rs = self._make_result_data(
+            [
+                [10, 11, 0, 0],
+                [10, 11, 1, 2],
+            ]
+        )
+        times = [0.0, 0.5, 1.0, 1.5, 2.0]
+
+        f1 = NNSweepFilter(cluster_eps=2.0, pred_times=times)
+        predicted_pos = f1._build_clustering_data(rs)
+        expected_pos = np.array(
+            [
+                [10.0, 10.0, 10.0, 10.0, 10.0, 11.0, 11.0, 11.0, 11.0, 11.0],
+                [10.0, 10.5, 11.0, 11.5, 12.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+            ]
+        )
+        self.assertEqual(predicted_pos.dtype, np.float32)
+        self.assertTrue(np.allclose(predicted_pos, expected_pos))
+
     def test_nnfilter(self):
         """Test filtering based on removing neighbors."""
         trjs = [
@@ -199,6 +262,15 @@ class test_clustering_filters(unittest.TestCase):
         # Using only the start time filters on the (x, y) values only.
         f3 = NNSweepFilter(cluster_eps=5.0, pred_times=[0.0])
         self.assertEqual(f3.keep_indices(rs), [2, 5, 6, 7])
+
+        # Using five times.
+        f4 = NNSweepFilter(cluster_eps=5.0, pred_times=[0.0, 5.0, 10.0, 15.0, 20.0])
+        self.assertEqual(f4.keep_indices(rs), [2, 3, 5, 6, 7])
+
+        # Using five times and a tiny threshold. Everything should be its
+        # own cluster except 9 which is an exact match with 7.
+        f5 = NNSweepFilter(cluster_eps=1e-8, pred_times=[0.0, 5.0, 10.0, 15.0, 20.0])
+        self.assertEqual(f5.keep_indices(rs), [0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11])
 
     def test_cluster_grid_filter(self):
         """Test filtering based on a discrete grid."""


### PR DESCRIPTION
Optimize the clustering filters to remove overhead including:
- Use float32 for all matrices to save memory.
- Use more vectorized operations (and remove some loops) when constructing the data.
- The different types of DBScan filters were incorrectly building (D, N) matrices instead of (N, D) then transposing them in `keep_indices`.
- The code was doing an unnecessary data copy in `keep_indices` (fixed removing `np.array` cast).