### PR TITLE
Add near duplicate pre-filtering

### DIFF
--- a/docs/source/user_manual/results_filtering.rst
+++ b/docs/source/user_manual/results_filtering.rst
@@ -1,9 +1,28 @@
 Results Filtering
 =================
 
-The output files contain the set of all trajectories discovered by KBMOD. Many of these trajectories are false positive detections, some area already known objects and, because of the way KBMOD performs the search, some are duplicates. In the following sections we describe the various steps that remove unwanted trajectories from the set of results. These steps are applied by KBMOD in the order listed below.
+The output files contain the set of all trajectories discovered by KBMOD. Many of these trajectories are false positive detections, some are already known objects and, because of the way KBMOD performs the search, some are duplicates. In the following sections we describe the various steps that remove unwanted trajectories from the set of results. These steps are applied by KBMOD in the order listed below.
 
 The user can also define custom filters and apply additional filters. For more details see :ref:`Custom Filtering`.
+
+
+Likelihood and Obs_count Filtering
+----------------------------------
+
+The first step after the core search is to filter trajectories by their likelihoods and number of observations.  The relevant parameters are:
+
+ * ``lh_level`` - The minimum likelihood for a candidate trajectory to be kept.
+ * ``num_obs`` - The minimum number of non-masked observations for a candidate trajectory to be kept.
+
+
+Near Duplicate Pre-filtering
+----------------------------
+
+After the trajectories with too few observations or too small a likelihood are removed, the code then removes any near-duplicate results. Near duplicate detection uses an approximate hash table-based approach (the same as described in the "Grid Filtering" section below).  The pixel space is broken up into a grid at both the first and last time and each trajectory's indices in those grids are computed. If multiple candidates share the same starting **and** ending grid box, only the one with the highest likelihood is kept.
+
+The relevant parameters are:
+
+ * ``near_dup_thresh `` - Defines the size of the grid cells (in pixels). If the user sets ``None`` or a value <= 0, the near duplicate filtering is skipped.
 
 
 Clipped SigmaG Filtering

--- a/docs/source/user_manual/search_params.rst
+++ b/docs/source/user_manual/search_params.rst
@@ -91,6 +91,10 @@ Configuration Parameters
 | ``lh_level``           | 10.0                        | The minimum computed likelihood for an |
 |                        |                             | object to be accepted.                 |
 +------------------------+-----------------------------+----------------------------------------+
+| ``near_dup_thresh``    | 10                          | The grid size (in pixels) for near     |
+|                        |                             | duplicate pre-filtering. Use ``None``  |
+|                        |                             | to skip this filtering step.           |
++------------------------+-----------------------------+----------------------------------------+
 | ``num_obs``            | 10                          | The minimum number of non-masked       |
 |                        |                             | observations for the object to be      |
 |                        |                             | accepted.                              |

--- a/src/kbmod/configuration.py
+++ b/src/kbmod/configuration.py
@@ -45,6 +45,7 @@ class SearchConfiguration:
             "generate_psi_phi": True,
             "gpu_filter": False,
             "lh_level": 10.0,
+            "near_dup_thresh": 10,
             "num_obs": 10,
             "psf_val": 1.4,
             "result_filename": None,

--- a/src/kbmod/filters/clustering_grid.py
+++ b/src/kbmod/filters/clustering_grid.py
@@ -101,3 +101,28 @@ class TrajectoryClusterGrid:
             A list of the indices of the best trajectory results from each bin.
         """
         return list(self.idx_table.values())
+
+
+def apply_trajectory_grid_filter(trajectories, bin_width, max_dt):
+    """Use the TrajectoryClusterGrid to remove near duplicates.
+
+    Parameters
+    ----------
+    trajectories : `list` of `Trajectory`
+        The trajectories to filter.
+    bin_width : `int`
+        The width of the bins in TrajectoryClusterGrid.
+    max_dt : `float`
+        The maximum time to use.
+
+    Returns
+    -------
+    results : `list` of `Trajectory`
+        The unfiltered trajectories.
+    indices : `list` of `int`
+        The indices of the unfiltered trajectories.
+    """
+    grid_filter = TrajectoryClusterGrid(bin_width=bin_width, max_time=max_dt)
+    for idx, trj in enumerate(trajectories):
+        grid_filter.add_trajectory(trj, idx=idx)
+    return grid_filter.get_trajectories(), grid_filter.get_indices()

--- a/tests/test_clustering_grid.py
+++ b/tests/test_clustering_grid.py
@@ -1,6 +1,6 @@
 import unittest
 
-from kbmod.filters.clustering_grid import TrajectoryClusterGrid
+from kbmod.filters.clustering_grid import apply_trajectory_grid_filter, TrajectoryClusterGrid
 from kbmod.search import Trajectory
 
 
@@ -55,6 +55,21 @@ class test_trajectory_cluster_grid(unittest.TestCase):
 
         self.assertEqual(set(table.get_indices()), set([10, 1, 3]))
         self.assertEqual(len(table.get_trajectories()), 3)
+
+    def test_apply_trajectory_grid_filter(self):
+        trjs = [
+            Trajectory(0, 0, 0.0, 0.0, 1.0, 10.0, 10),
+            Trajectory(21, 21, 10.0, 10.0, 1.0, 10.0, 10),
+            Trajectory(21, 21, 0.0, 0.0, 1.0, 10.0, 10),
+            Trajectory(21, 21, 0.0, 0.0, 1.0, 100.0, 9),
+            Trajectory(0, 0, 0.0, 0.0, 1.0, 5.0, 5),
+            Trajectory(0, 0, 0.0, 0.0, 1.0, 15.0, 15),
+        ]
+
+        results, indices = apply_trajectory_grid_filter(trjs, bin_width=10, max_dt=1.0)
+        self.assertEqual(len(results), 3)
+        self.assertEqual(len(indices), 3)
+        self.assertEqual(set(indices), set([5, 1, 3]))
 
 
 if __name__ == "__main__":

--- a/tests/test_run_search.py
+++ b/tests/test_run_search.py
@@ -81,12 +81,14 @@ class test_run_search(unittest.TestCase):
                 else:
                     sci.set_pixel(trj.y, trj.x, 10.0)
 
-        # Set up the search object.
+        # Set up the search object.  We turn off near duplicate filtering because
+        # the trajectories are all near duplicates.
         config = SearchConfiguration()
         config.set("num_obs", 39)
         config.set("lh_level", 1.0)
         config.set("sigmaG_filter", True)
         config.set("sigmaG_lims", [10, 90])
+        config.set("near_dup_thresh", None)
 
         search = StackSearch(fake_ds.stack)
         configure_kb_search_stack(search, config)

--- a/tests/test_stack_search_results.py
+++ b/tests/test_stack_search_results.py
@@ -136,6 +136,7 @@ class test_search(unittest.TestCase):
             "clip_negative": False,
             "chunk_size": 500000,
             "lh_level": 10.0,
+            "near_dup_thresh": None,  # Test trajectories are intentionally close
             "num_cores": 1,
             "num_obs": 5,
             "sigmaG_lims": [25, 75],


### PR DESCRIPTION
Use a hash table-based approximate filtering to remove near duplicates before doing any computational intensive filtering, such as sigma-G or full clustering.