### PR TITLE
Create KBMOD commandline scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ dependencies = [
     "PyYAML>=6.0"
 ]
 
+[project.scripts]
+kbmod-create-fake-data = "kbmod_cmdline.kbmod_create_fake_data:main"
+
 [project.urls]
 Documentation = "https://epyc.astro.washington.edu/~kbmod/"
 Repository = "https://github.com/dirac-institute/kbmod"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 ]
 
 [project.scripts]
-kbmod-create-fake-data = "kbmod_cmdline.kbmod_create_fake_data:main"
+kbmod-create-test-data = "kbmod_cmdline.kbmod_create_test_data:main"
 
 [project.urls]
 Documentation = "https://epyc.astro.washington.edu/~kbmod/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
 
 [project.scripts]
 kbmod-create-test-data = "kbmod_cmdline.kbmod_create_test_data:main"
+kbmod-stamps = "kbmod_cmdline.kbmod_stamps:main"
 
 [project.urls]
 Documentation = "https://epyc.astro.washington.edu/~kbmod/"

--- a/src/kbmod_cmdline/kbmod_create_fake_data.py
+++ b/src/kbmod_cmdline/kbmod_create_fake_data.py
@@ -1,0 +1,112 @@
+import argparse
+import logging
+import numpy as np
+
+from kbmod.fake_data.fake_data_creator import create_fake_times, FakeDataSet
+from kbmod.results import Results
+
+
+def execute(args):
+    """Run the program from the given arguments.
+
+    Parameters
+    ----------
+    args : `argparse.Namespace`
+        The input arguments.
+    """
+    if args.verbose:
+        print("KBMOD Fake Data and Results Generation:")
+        for key, val in vars(args).items():
+            print(f"  {key}: {val}")
+        logging.basicConfig(level=logging.DEBUG)
+
+    # Validate all the parameters.
+    if args.num_times <= 0:
+        raise ValueError(f"Invalid number of times: {args.num_times}. Must be >= 1.")
+    if args.height <= 0:
+        raise ValueError(f"Invalid image height: {args.height}. Must be >= 1.")
+    if args.width <= 0:
+        raise ValueError(f"Invalid image width: {args.width}. Must be >= 1.")
+    if args.num_trjs < 0:
+        raise ValueError(f"Invalid number of trajectories: {args.num_trjs}. Must be >= 0.")
+
+    # Generate and save the fake data.
+    times = create_fake_times(args.num_times)
+    fake_ds = FakeDataSet(args.width, args.height, times)
+    for id_x in range(args.num_trjs):
+        fake_ds.insert_random_object(200.0)
+    fake_ds.save_fake_data_to_work_unit(args.workunit)
+
+    # Assign a reasonable (random) likelihood to each trajectory, build
+    # a results table, and save it.
+    for trj in fake_ds.trajectories:
+        trj.lh = 5.0 + np.random.random() * 5.0
+        trj.obs_count = args.num_times
+    results = Results.from_trajectories(fake_ds.trajectories)
+    results.write_table(args.results)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="kbmod-generate-fake-data",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="A program to create a fake WorkUnit and Results data for testing purposes.",
+    )
+    parser.add_argument(
+        "--workunit",
+        default="./fake_wu.fits",
+        dest="workunit",
+        type=str,
+        help="The file path for the generated workunit file with the image data.",
+    )
+    parser.add_argument(
+        "--results",
+        default="./fake_results.ecsv",
+        dest="results",
+        type=str,
+        help="The file path for the generated results file.",
+    )
+    parser.add_argument(
+        "-t",
+        "--num_times",
+        default=20,
+        dest="num_times",
+        type=int,
+        help="The number of fake images (time steps) generated.",
+    )
+    parser.add_argument(
+        "-h",
+        "--height",
+        default=400,
+        dest="height",
+        type=int,
+        help="The height of the generated images (in pixels).",
+    )
+    parser.add_argument(
+        "-w",
+        "--width",
+        default=400,
+        dest="width",
+        type=int,
+        help="The width of the generated images (in pixels).",
+    )    
+    parser.add_argument(
+        "-r",
+        "--num_trjs",
+        default=20,
+        dest="num_trjs",
+        type=int,
+        help="The number of fake trajectories to insert into the data.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        default=False,
+        dest="verbose",
+        action="store_true",
+        help="Output verbose status messages.",
+    )
+
+    # Run the actual program.
+    args = parser.parse_args()
+    execute(args)

--- a/src/kbmod_cmdline/kbmod_create_test_data.py
+++ b/src/kbmod_cmdline/kbmod_create_test_data.py
@@ -1,3 +1,7 @@
+"""A proof of concept program for generating fake data and results
+to use for testing.
+"""
+
 import argparse
 import logging
 import numpy as np
@@ -67,7 +71,6 @@ def main():
         help="The file path for the generated results file.",
     )
     parser.add_argument(
-        "-t",
         "--num_times",
         default=20,
         dest="num_times",
@@ -75,7 +78,6 @@ def main():
         help="The number of fake images (time steps) generated.",
     )
     parser.add_argument(
-        "-h",
         "--height",
         default=400,
         dest="height",
@@ -83,7 +85,6 @@ def main():
         help="The height of the generated images (in pixels).",
     )
     parser.add_argument(
-        "-w",
         "--width",
         default=400,
         dest="width",
@@ -91,7 +92,6 @@ def main():
         help="The width of the generated images (in pixels).",
     )    
     parser.add_argument(
-        "-r",
         "--num_trjs",
         default=20,
         dest="num_trjs",

--- a/src/kbmod_cmdline/kbmod_create_test_data.py
+++ b/src/kbmod_cmdline/kbmod_create_test_data.py
@@ -90,7 +90,7 @@ def main():
         dest="width",
         type=int,
         help="The width of the generated images (in pixels).",
-    )    
+    )
     parser.add_argument(
         "--num_trjs",
         default=20,

--- a/src/kbmod_cmdline/kbmod_stamps.py
+++ b/src/kbmod_cmdline/kbmod_stamps.py
@@ -1,0 +1,188 @@
+"""A program to generate stamps from a file of KBMOD results."""
+
+import argparse
+import logging
+import numpy as np
+
+from kbmod.core.stamp_utils import (
+    coadd_mean,
+    coadd_median,
+    coadd_sum,
+    extract_stamp_stack,
+)
+from kbmod.results import Results
+from kbmod.trajectory_utils import predict_pixel_locations
+from kbmod.work_unit import WorkUnit
+
+
+def generate_all_stamps(results, images, radius=10, indices=None):
+    """Generate the stamps and save them to an output file.
+
+    Parameters
+    ----------
+    results : `Results`
+        The results file.
+    images : `ImageStack`
+        The full set of images to use for the stamps.
+    radius : `int`
+        The stamp radius.
+        Default: 10
+    indices : `list[int]` or `None`, optional
+        The optional list of result indices to use. If None, all results
+        are used.
+        Default: None
+
+    Returns
+    -------
+    all_stamps : `np.ndarray`
+        The R x T x W x W array of stamps where R is the number of results
+        to process (from indices), T is the the number of time steps, and
+        W is the stamp radius (2 * radius + 1).
+    """
+    # Extract and validate the stamp generation parameters.
+    if radius <= 0:
+        raise ValueError(f"Stamp radius must be > 0 (received {radius}).")
+    width = 2 * radius + 1
+
+    if indices is None:
+        indices = np.arange(len(results))
+    else:
+        indices = np.array(indices)
+    num_res = len(indices)
+
+    # Extract the image data we need to build stamps.
+    times = np.asarray(images.build_zeroed_times())
+    num_times = len(times)
+    sci_data = [images.get_single_image(i).get_science_array() for i in range(num_times)]
+
+    # Generate the stamps.
+    xvals = predict_pixel_locations(times, results["x"], results["vx"], centered=True, as_int=True)
+    yvals = predict_pixel_locations(times, results["y"], results["vy"], centered=True, as_int=True)
+    all_stamps = np.zeros((num_res, num_times, width, width), dtype=np.float32)
+    for out_i, in_i in enumerate(indices):
+        all_stamps[out_i, :, :, :] = extract_stamp_stack(sci_data, xvals[in_i, :], yvals[in_i, :], radius)
+
+    return all_stamps
+
+
+def coadd_all_stamps(all_stamps, coadd_type):
+    """Coadd the stamps in a matrix of all stamps.
+
+    Parameters
+    ----------
+    all_stamps : `np.ndarray`
+        The R x T x W x W array of stamps where R is the number of results
+        to process (from indices), T is the the number of time steps, and
+        W is the stamp radius (2 * radius + 1).
+    coadd_type : `str`
+        The type of coadd to use. Must be one of 'mean', 'median', or 'sum'.
+
+    Returns
+    -------
+    coadds : `np.ndarray`
+        The R x W x W array of coadd stamps where R is the number of results
+        to process (from indices) and W is the stamp radius (2 * radius + 1).
+    """
+    num_stamps = all_stamps.shape[0]
+    width = all_stamps.shape[2]
+    coadds = np.zeros((num_stamps, width, width))
+
+    for idx in range(num_stamps):
+        if coadd_type == "mean":
+            coadds[idx, :, :] = coadd_mean(all_stamps[idx, :, :, :])
+        elif coadd_type == "median":
+            coadds[idx, :, :] = coadd_median(all_stamps[idx, :, :, :])
+        elif coadd_type == "sum":
+            coadds[idx, :, :] = coadd_sum(all_stamps[idx, :, :, :])
+        else:
+            raise ValueError(f"Unrecognized coadd type {coadd_type}")
+    return coadds
+
+
+def execute(args):
+    """Run the program from the given arguments.
+
+    Parameters
+    ----------
+    args : `argparse.Namespace`
+        The input arguments.
+    """
+    if args.verbose:
+        print("KBMOD Stamp Generation:")
+        for key, val in vars(args).items():
+            print(f"  {key}: {val}")
+        logging.basicConfig(level=logging.DEBUG)
+
+    # Load the results and the image data.
+    results = Results.read_table(args.input)
+    wu = WorkUnit.from_fits(args.workunit, show_progress=args.verbose)
+
+    all_stamps = generate_all_stamps(results, wu, args.radius, args.indices)
+
+    if args.coadd_type == "all":
+        np.save(args.outfile, all_stamps)
+    else:
+        coadds = coadd_all_stamps(all_stamps, args.coadd_type)
+        np.save(args.outfile, coadds)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="kbmod-stamps",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="A program to create stamps from KBMOD results data.",
+    )
+    parser.add_argument(
+        "--workunit",
+        dest="workunit",
+        type=str,
+        help="The file path for the workunit file with the image data.",
+    )
+    parser.add_argument(
+        "--results",
+        dest="results",
+        type=str,
+        help="The file path for the input Results file to process.",
+    )
+
+    optional = parser.add_argument_group("Optional arguments")
+    optional.add_argument(
+        "-o",
+        "--outfile",
+        help="File path to store the resulting stamps.",
+        type=str,
+        dest="outfile",
+        required=False,
+        default="./stamps.npy",
+    )
+    optional.add_argument(
+        "-r",
+        "--radius",
+        default=10,
+        dest="radius",
+        help="The stamp radius in pixels.",
+    )
+    optional.add_argument(
+        "--type",
+        type=str,
+        default="all",
+        dest="coadd_type",
+        help="The stamp type. Must be one of 'all', 'sum', 'mean', or 'median'.",
+    )
+    optional.add_argument(
+        "indices",
+        nargs="+",
+        type=int,
+        help="A comma separated list of indices to extract. If not provided, uses all results.",
+    )
+    optional.add_argument(
+        "-v",
+        "--verbose",
+        default=False,
+        dest="verbose",
+        action="store_true",
+        help="Output verbose status messages.",
+    )
+
+    # Run the actual program.
+    execute(args)


### PR DESCRIPTION
This PR is an initial step in breaking the monolithic KBMOD search into stages. It introduces command line scripts that can be independently run. The first two scripts are:
- A fake data creator (needed for testing other scripts)
- A utility to extract the stamps from image data. This is particularly meant for the "all" stamps, which generates number of results x number of times stamps.