### PR TITLE
Add helper functions to extract components from a list of trajectories

### DIFF
--- a/src/kbmod/filters/clustering_grid.py
+++ b/src/kbmod/filters/clustering_grid.py
@@ -1,5 +1,18 @@
 """A data structure for online clustering of result trajectories."""
 
+import numpy as np
+
+from kbmod.search import (
+    extract_all_trajectory_flux,
+    extract_all_trajectory_lh,
+    extract_all_trajectory_obs_count,
+    extract_all_trajectory_vx,
+    extract_all_trajectory_vy,
+    extract_all_trajectory_x,
+    extract_all_trajectory_y,
+    Trajectory,
+)
+
 
 class TrajectoryClusterGrid:
     """A spatial hash of trajectory results.
@@ -81,6 +94,44 @@ class TrajectoryClusterGrid:
             self.count[bin_key] += 1
 
         self.total_count += 1
+
+    def add_trajectory_list(self, trj_list):
+        """Add a list of results to the table.
+
+        Parameters
+        ----------
+        trj_list : `list` of `Trajectory`
+            The trajectories to add.
+        """
+        # Extract the components for all results.
+        x0 = np.asanyarray(extract_all_trajectory_x(trj_list))
+        y0 = np.asanyarray(extract_all_trajectory_y(trj_list))
+        vx = np.asanyarray(extract_all_trajectory_vx(trj_list))
+        vy = np.asanyarray(extract_all_trajectory_vy(trj_list))
+
+        # Compute the spatial bin (vectorized) for all results.
+        xs_bin = (x0 / self.bin_width).astype(int)
+        ys_bin = (y0 / self.bin_width).astype(int)
+        xe_bin = ((x0 + self.max_time * vx) / self.bin_width).astype(int)
+        ye_bin = ((y0 + self.max_time * vy) / self.bin_width).astype(int)
+
+        # We need to insert the trajectories serially because we are modifying the table.
+        for idx, trj in enumerate(trj_list):
+            bin_key = (xs_bin[idx], ys_bin[idx], xe_bin[idx], ye_bin[idx])
+            old_result = self.table.get(bin_key, None)
+
+            if old_result is None:
+                self.table[bin_key] = trj
+                self.count[bin_key] = 1
+                self.idx_table[bin_key] = idx
+            elif trj.lh > old_result.lh:
+                self.table[bin_key] = trj
+                self.idx_table[bin_key] = idx
+                self.count[bin_key] += 1
+            else:
+                self.count[bin_key] += 1
+
+        self.total_count += len(trj_list)
 
     def get_trajectories(self):
         """Get all of the best trajectories from each bin.

--- a/src/kbmod/search/pydocs/trajectory_list_docs.h
+++ b/src/kbmod/search/pydocs/trajectory_list_docs.h
@@ -191,6 +191,104 @@ static const auto DOC_TrajectoryList_filter_by_obs_count = R"doc(
   Raises a ``RuntimeError`` the data is on GPU.
   )doc";
 
+static const auto DOC_TrajectoryList_extract_all_x = R"doc(
+  Extract all the x values from a list of trajectories.
+
+  Parameters
+  ----------
+  trjs : `list` of `Trajectory`
+      The trajectories to process.
+      
+  Returns
+  -------
+  results : `list` of `int`
+      The x values for each trajectory in the list.
+  )doc";
+
+static const auto DOC_TrajectoryList_extract_all_y = R"doc(
+  Extract all the y values from a list of trajectories.
+
+  Parameters
+  ----------
+  trjs : `list` of `Trajectory`
+      The trajectories to process.
+      
+  Returns
+  -------
+  results : `list` of `int`
+      The y values for each trajectory in the list.
+  )doc";
+
+static const auto DOC_TrajectoryList_extract_all_vx = R"doc(
+  Extract all the vx values from a list of trajectories.
+
+  Parameters
+  ----------
+  trjs : `list` of `Trajectory`
+      The trajectories to process.
+      
+  Returns
+  -------
+  results : `list` of `float`
+      The vx values for each trajectory in the list.
+  )doc";
+
+static const auto DOC_TrajectoryList_extract_all_vy = R"doc(
+  Extract all the vy values from a list of trajectories.
+
+  Parameters
+  ----------
+  trjs : `list` of `Trajectory`
+      The trajectories to process.
+      
+  Returns
+  -------
+  results : `list` of `float`
+      The vy values for each trajectory in the list.
+  )doc";
+
+static const auto DOC_TrajectoryList_extract_all_lh = R"doc(
+  Extract all the likelihood values from a list of trajectories.
+
+  Parameters
+  ----------
+  trjs : `list` of `Trajectory`
+      The trajectories to process.
+      
+  Returns
+  -------
+  results : `list` of `float`
+      The likelihood values for each trajectory in the list.
+  )doc";
+
+static const auto DOC_TrajectoryList_extract_all_flux = R"doc(
+  Extract all the flux values from a list of trajectories.
+
+  Parameters
+  ----------
+  trjs : `list` of `Trajectory`
+      The trajectories to process.
+      
+  Returns
+  -------
+  results : `list` of `float`
+      The flux values for each trajectory in the list.
+  )doc";
+
+static const auto DOC_TrajectoryList_extract_all_obs_count = R"doc(
+  Extract all the vy values from a list of trajectories.
+
+  Parameters
+  ----------
+  trjs : `list` of `Trajectory`
+      The trajectories to process.
+      
+  Returns
+  -------
+  results : `list` of `int`
+      The obs_count values for each trajectory in the list.
+  )doc";
+
 }  // namespace pydocs
 
 #endif /* TRAJECTORY_LIST_DOCS_ */

--- a/src/kbmod/search/trajectory_list.cpp
+++ b/src/kbmod/search/trajectory_list.cpp
@@ -116,6 +116,80 @@ void TrajectoryList::move_to_cpu() {
 }
 
 // -------------------------------------------
+// --- Helper functions ----------------------
+// -------------------------------------------
+
+std::vector<int> extract_all_trajectory_x(const std::vector<Trajectory>& trajectories) {
+    size_t num_trj = trajectories.size();
+
+    std::vector<int> result(num_trj);
+    for (size_t i = 0; i < num_trj; ++i) {
+        result[i] = trajectories[i].x;
+    }
+    return result;
+}
+
+std::vector<int> extract_all_trajectory_y(const std::vector<Trajectory>& trajectories) {
+    size_t num_trj = trajectories.size();
+
+    std::vector<int> result(num_trj);
+    for (size_t i = 0; i < num_trj; ++i) {
+        result[i] = trajectories[i].y;
+    }
+    return result;
+}
+
+std::vector<float> extract_all_trajectory_vx(const std::vector<Trajectory>& trajectories) {
+    size_t num_trj = trajectories.size();
+
+    std::vector<float> result(num_trj);
+    for (size_t i = 0; i < num_trj; ++i) {
+        result[i] = trajectories[i].vx;
+    }
+    return result;
+}
+
+std::vector<float> extract_all_trajectory_vy(const std::vector<Trajectory>& trajectories) {
+    size_t num_trj = trajectories.size();
+
+    std::vector<float> result(num_trj);
+    for (size_t i = 0; i < num_trj; ++i) {
+        result[i] = trajectories[i].vy;
+    }
+    return result;
+}
+
+std::vector<float> extract_all_trajectory_lh(const std::vector<Trajectory>& trajectories) {
+    size_t num_trj = trajectories.size();
+
+    std::vector<float> result(num_trj);
+    for (size_t i = 0; i < num_trj; ++i) {
+        result[i] = trajectories[i].lh;
+    }
+    return result;
+}
+
+std::vector<float> extract_all_trajectory_flux(const std::vector<Trajectory>& trajectories) {
+    size_t num_trj = trajectories.size();
+
+    std::vector<float> result(num_trj);
+    for (size_t i = 0; i < num_trj; ++i) {
+        result[i] = trajectories[i].flux;
+    }
+    return result;
+}
+
+std::vector<int> extract_all_trajectory_obs_count(const std::vector<Trajectory>& trajectories) {
+    size_t num_trj = trajectories.size();
+
+    std::vector<int> result(num_trj);
+    for (size_t i = 0; i < num_trj; ++i) {
+        result[i] = trajectories[i].obs_count;
+    }
+    return result;
+}
+
+// -------------------------------------------
 // --- Python definitions --------------------
 // -------------------------------------------
 
@@ -146,6 +220,22 @@ static void trajectory_list_binding(py::module& m) {
                  pydocs::DOC_TrajectoryList_filter_by_obs_count)
             .def("move_to_cpu", &trjl::move_to_cpu, pydocs::DOC_TrajectoryList_move_to_cpu)
             .def("move_to_gpu", &trjl::move_to_gpu, pydocs::DOC_TrajectoryList_move_to_gpu);
+
+    // Add the helper functions.
+    m.def("extract_all_trajectory_x", &search::extract_all_trajectory_x,
+          pydocs::DOC_TrajectoryList_extract_all_x);
+    m.def("extract_all_trajectory_y", &search::extract_all_trajectory_y,
+          pydocs::DOC_TrajectoryList_extract_all_y);
+    m.def("extract_all_trajectory_vx", &search::extract_all_trajectory_vx,
+          pydocs::DOC_TrajectoryList_extract_all_vx);
+    m.def("extract_all_trajectory_vy", &search::extract_all_trajectory_vy,
+          pydocs::DOC_TrajectoryList_extract_all_vy);
+    m.def("extract_all_trajectory_lh", &search::extract_all_trajectory_lh,
+          pydocs::DOC_TrajectoryList_extract_all_lh);
+    m.def("extract_all_trajectory_flux", &search::extract_all_trajectory_flux,
+          pydocs::DOC_TrajectoryList_extract_all_flux);
+    m.def("extract_all_trajectory_obs_count", &search::extract_all_trajectory_obs_count,
+          pydocs::DOC_TrajectoryList_extract_all_obs_count);
 }
 #endif
 

--- a/src/kbmod/search/trajectory_list.h
+++ b/src/kbmod/search/trajectory_list.h
@@ -41,6 +41,12 @@ public:
         return cpu_list[index];
     }
 
+    inline std::vector<Trajectory>& get_list() {
+        if (data_on_gpu) throw std::runtime_error("Data on GPU");
+        return cpu_list;
+    }
+
+    // --- Setter functions ----------------
     inline void set_trajectory(uint64_t index, const Trajectory& new_value) {
         if (index >= max_size) throw std::runtime_error("Index out of bounds.");
         if (data_on_gpu) throw std::runtime_error("Data on GPU");
@@ -48,11 +54,6 @@ public:
     }
 
     void set_trajectories(const std::vector<Trajectory>& new_values);
-
-    inline std::vector<Trajectory>& get_list() {
-        if (data_on_gpu) throw std::runtime_error("Data on GPU");
-        return cpu_list;
-    }
 
     // Forcibly resize. May add blank data.
     void resize(uint64_t new_size);
@@ -80,6 +81,15 @@ private:
     std::vector<Trajectory> cpu_list;
     GPUArray<Trajectory> gpu_array;
 };
+
+// Helper functions for extracting individual components from trajectories.
+std::vector<int> extract_all_trajectory_x(const std::vector<Trajectory>& trajectories);
+std::vector<int> extract_all_trajectory_y(const std::vector<Trajectory>& trajectories);
+std::vector<float> extract_all_trajectory_vx(const std::vector<Trajectory>& trajectories);
+std::vector<float> extract_all_trajectory_vy(const std::vector<Trajectory>& trajectories);
+std::vector<float> extract_all_trajectory_lh(const std::vector<Trajectory>& trajectories);
+std::vector<float> extract_all_trajectory_flux(const std::vector<Trajectory>& trajectories);
+std::vector<int> extract_all_trajectory_obs_count(const std::vector<Trajectory>& trajectories);
 
 } /* namespace search */
 

--- a/src/kbmod/trajectory_utils.py
+++ b/src/kbmod/trajectory_utils.py
@@ -16,7 +16,16 @@ import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.wcs import WCS
 
-from kbmod.search import Trajectory
+from kbmod.search import (
+    extract_all_trajectory_flux,
+    extract_all_trajectory_lh,
+    extract_all_trajectory_obs_count,
+    extract_all_trajectory_vx,
+    extract_all_trajectory_vy,
+    extract_all_trajectory_x,
+    extract_all_trajectory_y,
+    Trajectory,
+)
 
 
 def predict_pixel_locations(times, x0, vx, centered=True, as_int=True):
@@ -174,35 +183,16 @@ def trajectories_to_dict(trj_list):
     trj_dict : `Trajectory`
         The corresponding trajectory object.
     """
-    # Create the lists to fill.
-    num_trjs = len(trj_list)
-    x0 = [0] * num_trjs
-    y0 = [0] * num_trjs
-    vx = [0.0] * num_trjs
-    vy = [0.0] * num_trjs
-    lh = [0.0] * num_trjs
-    flux = [0.0] * num_trjs
-    obs_count = [0] * num_trjs
-
-    # Extract the values from each Trajectory object.
-    for idx, trj in enumerate(trj_list):
-        x0[idx] = trj.x
-        y0[idx] = trj.y
-        vx[idx] = trj.vx
-        vy[idx] = trj.vy
-        lh[idx] = trj.lh
-        flux[idx] = trj.flux
-        obs_count[idx] = trj.obs_count
-
-    # Store the lists in a dictionary and return that.
+    # Use the C++ functions to extract each parameter as a list,
+    # store the lists in a dictionary, and return that.
     trj_dict = {
-        "x": x0,
-        "y": y0,
-        "vx": vx,
-        "vy": vy,
-        "likelihood": lh,
-        "flux": flux,
-        "obs_count": obs_count,
+        "x": extract_all_trajectory_x(trj_list),
+        "y": extract_all_trajectory_y(trj_list),
+        "vx": extract_all_trajectory_vx(trj_list),
+        "vy": extract_all_trajectory_vy(trj_list),
+        "likelihood": extract_all_trajectory_lh(trj_list),
+        "flux": extract_all_trajectory_flux(trj_list),
+        "obs_count": extract_all_trajectory_obs_count(trj_list),
     }
     return trj_dict
 

--- a/tests/test_clustering_grid.py
+++ b/tests/test_clustering_grid.py
@@ -56,6 +56,35 @@ class test_trajectory_cluster_grid(unittest.TestCase):
         self.assertEqual(set(table.get_indices()), set([10, 1, 3]))
         self.assertEqual(len(table.get_trajectories()), 3)
 
+    def test_trajectory_cluster_add_list(self):
+        """Tests that we can add a list of Trajectories to the grid."""
+        table = TrajectoryClusterGrid(10, 1.0)
+        self.assertEqual(len(table), 0)
+        self.assertEqual(table.total_count, 0)
+
+        trj_list = [
+            Trajectory(0, 0, 0.0, 0.0, 1.0, 10.0, 10),
+            Trajectory(21, 21, 10.0, 10.0, 1.0, 10.0, 10),
+            Trajectory(21, 21, 0.0, 0.0, 1.0, 10.0, 10),
+            Trajectory(21, 21, 0.0, 0.0, 1.0, 100.0, 9),
+            Trajectory(0, 0, 0.0, 0.0, 1.0, 5.0, 5),
+        ]
+        table.add_trajectory_list(trj_list)
+
+        self.assertEqual(len(table), 3)
+        self.assertEqual(table.total_count, 5)
+        self.assertIsNotNone(table.table.get((0, 0, 0, 0)))
+        self.assertIsNotNone(table.table.get((2, 2, 3, 3)))
+        self.assertIsNotNone(table.table.get((2, 2, 2, 2)))
+        self.assertEqual(table.count.get((0, 0, 0, 0)), 2)
+        self.assertEqual(table.count.get((2, 2, 3, 3)), 1)
+        self.assertEqual(table.count.get((2, 2, 2, 2)), 2)
+        self.assertEqual(table.table[(0, 0, 0, 0)].obs_count, 10)
+        self.assertEqual(table.table[(2, 2, 2, 2)].obs_count, 9)
+
+        self.assertEqual(set(table.get_indices()), set([0, 1, 3]))
+        self.assertEqual(len(table.get_trajectories()), 3)
+
     def test_apply_trajectory_grid_filter(self):
         trjs = [
             Trajectory(0, 0, 0.0, 0.0, 1.0, 10.0, 10),

--- a/tests/test_trajectory_list.py
+++ b/tests/test_trajectory_list.py
@@ -1,6 +1,18 @@
+import numpy as np
 import unittest
 
-from kbmod.search import HAS_GPU, Trajectory, TrajectoryList
+from kbmod.search import (
+    extract_all_trajectory_flux,
+    extract_all_trajectory_lh,
+    extract_all_trajectory_obs_count,
+    extract_all_trajectory_vx,
+    extract_all_trajectory_vy,
+    extract_all_trajectory_x,
+    extract_all_trajectory_y,
+    HAS_GPU,
+    Trajectory,
+    TrajectoryList,
+)
 
 
 class test_trajectory_list(unittest.TestCase):
@@ -151,6 +163,38 @@ class test_trajectory_list(unittest.TestCase):
         # Moving back to CPU again doesn't do anything.
         self.trj_list.move_to_cpu()
         self.assertFalse(self.trj_list.on_gpu)
+
+    def test_extraction_helpers(self):
+        """Test that we can extract components of trajectories from a list."""
+        num_trjs = 20
+        all_x = [(i + 2) for i in range(num_trjs)]
+        all_y = [(105 - i) for i in range(num_trjs)]
+        all_vx = [(0.5 + 0.01 * i) for i in range(num_trjs)]
+        all_vy = [(0.2 - 0.01 * i) for i in range(num_trjs)]
+        all_lh = [(0.1 * i) for i in range(num_trjs)]
+        all_flux = [(2.0 * i) for i in range(num_trjs)]
+        all_obs_count = [(10 + i) for i in range(num_trjs)]
+
+        trj_list = []
+        for i in range(num_trjs):
+            trj = Trajectory(
+                x=all_x[i],
+                y=all_y[i],
+                vx=all_vx[i],
+                vy=all_vy[i],
+                lh=all_lh[i],
+                flux=all_flux[i],
+                obs_count=all_obs_count[i],
+            )
+            trj_list.append(trj)
+
+        self.assertTrue(np.allclose(extract_all_trajectory_x(trj_list), all_x))
+        self.assertTrue(np.allclose(extract_all_trajectory_y(trj_list), all_y))
+        self.assertTrue(np.allclose(extract_all_trajectory_vx(trj_list), all_vx))
+        self.assertTrue(np.allclose(extract_all_trajectory_vy(trj_list), all_vy))
+        self.assertTrue(np.allclose(extract_all_trajectory_lh(trj_list), all_lh))
+        self.assertTrue(np.allclose(extract_all_trajectory_flux(trj_list), all_flux))
+        self.assertTrue(np.allclose(extract_all_trajectory_obs_count(trj_list), all_obs_count))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There are a few places in the Python code where we need the components of a list of trajectories and loop over each trajectory. This provides helper functions in C++ to do the same thing.

It produces moderate speedups in the code, including:
- 4x faster for `trajectories_to_dict()` which is used when creating a `Results` object.
- 20% faster for the near duplicates filter (`TrajectoryClusterGrid`).
There are probably a bunch of other places we can use this as well.