### PR TITLE
Improve debug logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "numba",
     "numpy<2.0",
     "pandas",
+    "psutil",
     "pyarrow",
     "reproject",
     "scipy>=1.9.2",

--- a/src/kbmod/search/layered_image.cpp
+++ b/src/kbmod/search/layered_image.cpp
@@ -169,11 +169,6 @@ Image LayeredImage::generate_psi_image() {
 
     // Convolve with the PSF.
     result = convolve_image(result, psf);
-
-    logging::getLogger("kbmod.search.layered_image")
-            ->debug("Generated psi image. " + std::to_string(no_data_count) + " of " +
-                    std::to_string(num_pixels) + " had no data.");
-
     return result;
 }
 
@@ -198,11 +193,6 @@ Image LayeredImage::generate_phi_image() {
     // Convolve with the PSF squared.
     Image psfsq = square_psf(psf);  // Copy
     result = convolve_image(result, psfsq);
-
-    logging::getLogger("kbmod.search.layered_image")
-            ->debug("Generated phi image. " + std::to_string(no_data_count) + " of " +
-                    std::to_string(num_pixels) + " had no data.");
-
     return result;
 }
 


### PR DESCRIPTION
Improve logging throughout run_search:
- Add a "global" run time tracking and display summary statistics of the times taken during each phase at the end of a run. This means we do not have to hunt through the logs to see how long each phase takes.
- Track start and end memory usage of each phase (also displayed at the end of the run)
- Remove timing within each batch (which produced a lot of output).
- Remove the logging within `LayeredImage` psi and phi generation. This was replaced by a tool to stat the entire image stack a while back, so now it is duplicate and very spammy.