### PR TITLE
Do not copy results table before write

### DIFF
--- a/docs/source/user_manual/search_params.rst
+++ b/docs/source/user_manual/search_params.rst
@@ -63,6 +63,9 @@ Configuration Parameters
 | ``cpu_only``           | False                       | Perform the core search on the CPU     |
 |                        |                             | (even if the GPU is available).        |
 +------------------------+-----------------------------+----------------------------------------+
+| ``compute_ra_dec``     | True                        | Compute and save the predicted RA and  |
+|                        |                             | dec for each result at each time.      |
++------------------------+-----------------------------+----------------------------------------+
 | ``debug``              | False                       | Display debugging output.              |
 +------------------------+-----------------------------+----------------------------------------+
 | ``do_clustering``      | True                        | Cluster the resulting trajectories to  |

--- a/src/kbmod/configuration.py
+++ b/src/kbmod/configuration.py
@@ -29,6 +29,7 @@ class SearchConfiguration:
             "cluster_type": "all",
             "cluster_v_scale": 1.0,
             "coadds": [],
+            "compute_ra_dec": True,
             "cpu_only": False,
             "debug": False,
             "do_clustering": True,

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -360,7 +360,8 @@ class SearchRunner:
         # including a global WCS and per-time (RA, dec) predictions for each image.
         if workunit is not None:
             keep.table.wcs = workunit.wcs
-            append_positions_to_results(workunit, keep)
+            if config["compute_ra_dec"]:
+                append_positions_to_results(workunit, keep)
 
         # Create and save any additional meta data that should be saved with the results.
         num_img = stack.img_count()
@@ -375,12 +376,7 @@ class SearchRunner:
 
         if config["result_filename"] is not None:
             logger.info(f"Saving results table to {config['result_filename']}")
-            if not config["save_all_stamps"]:
-                keep.write_table(
-                    config["result_filename"], cols_to_drop=["all_stamps"], extra_meta=meta_to_save
-                )
-            else:
-                keep.write_table(config["result_filename"], extra_meta=meta_to_save)
+            keep.write_table(config["result_filename"], extra_meta=meta_to_save)
         full_timer.stop()
 
         return keep

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -496,22 +496,17 @@ class test_results(unittest.TestCase):
 
             # Cannot overwrite with it set to False
             with self.assertRaises(OSError):
-                table.write_table(file_path, overwrite=False, cols_to_drop=["other"])
+                table.write_table(file_path, overwrite=False)
 
             # We can overwrite with droped columns and additional meta data.
             table.write_table(
                 file_path,
                 overwrite=True,
-                cols_to_drop=["other"],
                 extra_meta={"other": 100.0},
             )
 
             table3 = Results.read_table(file_path)
             self.assertEqual(len(table2), max_save)
-
-            # We only dropped the table from the save file.
-            self.assertFalse("other" in table3.colnames)
-            self.assertTrue("other" in table.colnames)
 
             # We saved the additional meta data, including the WCS.
             self.assertTrue(np.array_equal(table3.table.meta["mjd_mid"], [1, 2, 3, 4, 5]))


### PR DESCRIPTION
KBMOD was making a copy of the results table before writing it so it could drop columns. The only columns ever dropped were "all_stamps" which has a separate flag to disable. This PR removes the unneeded copy.

It also adds a flag to avoid computing the predicted RA and dec in case we want to save more space in the results.