### PR TITLE
Add multiple checks for runs with insufficient images

### DIFF
--- a/docs/source/user_manual/search_params.rst
+++ b/docs/source/user_manual/search_params.rst
@@ -97,7 +97,10 @@ Configuration Parameters
 +------------------------+-----------------------------+----------------------------------------+
 | ``num_obs``            | 10                          | The minimum number of non-masked       |
 |                        |                             | observations for the object to be      |
-|                        |                             | accepted.                              |
+|                        |                             | accepted. If this is greater than the  |
+|                        |                             | number of the valid images or set to   |
+|                        |                             | -1 then it is reduced to the number of |
+|                        |                             | the valid images.                      |
 +------------------------+-----------------------------+----------------------------------------+
 | ``psf_val``            | 1.4                         | The value for the standard deviation of|
 |                        |                             | the point spread function (PSF) in     |

--- a/src/kbmod/image_utils.py
+++ b/src/kbmod/image_utils.py
@@ -239,6 +239,44 @@ def _im_stack_validation_error(msg, warn_only):
         raise ValueError(msg)
 
 
+def count_valid_images(im_stack, masked_fraction=0.5):
+    """Count the number of images in the ImageStack whose fraction
+    of masked pixels is below the given threshold. Used for checking
+    num_obs.
+
+    Parameters
+    ----------
+    im_stack : `ImageStack`
+        The images to validate.
+    masked_fraction: `float`
+        The maximum fraction of masked pixels allowed.
+        Default: 0.9
+
+    Returns
+    -------
+    count : `int`
+        The count of images with below the threshold fraction of masked pixels.
+    """
+    total_pixels = im_stack.get_height() * im_stack.get_width()
+    if total_pixels == 0 or im_stack.img_count() == 0:
+        return 0
+
+    valid_count = 0
+    for idx in range(im_stack.img_count()):
+        img = im_stack.get_single_image(idx)
+        sci = img.get_science_array()
+        var = img.get_variance_array()
+        mask = img.get_mask_array()
+
+        # Check for masked pixels.
+        is_masked = np.isnan(sci) | np.isnan(var) | (mask != 0) | (var <= 0)
+        percent_masked = np.count_nonzero(is_masked) / total_pixels
+        if percent_masked <= masked_fraction:
+            valid_count += 1
+
+    return valid_count
+
+
 def validate_image_stack(
     im_stack,
     masked_fraction=0.5,

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -7,6 +7,7 @@ from kbmod.fake_data.fake_data_creator import create_fake_times, FakeDataSet
 from kbmod.search import KB_NO_DATA, Trajectory
 
 from kbmod.image_utils import (
+    count_valid_images,
     create_stamps_from_image_stack,
     create_stamps_from_image_stack_xy,
     extract_sci_images_from_stack,
@@ -166,6 +167,39 @@ class test_image_utils(unittest.TestCase):
 
         # Re-enable warnings.
         logging.disable(logging.NOTSET)
+
+    def test_count_valid_images(self):
+        """Tests that we can count the number of valid images in an ImageStack."""
+        # Start with a valid ImageStack.
+        num_times = 10
+        width = 20
+        height = 20
+        fake_times = np.arange(num_times)
+        fake_sci = [90.0 * np.random.random((height, width)) + 10.0 for _ in range(num_times)]
+        fake_var = [0.49 * np.random.random((height, width)) + 0.01 for _ in range(num_times)]
+        fake_mask = [np.zeros((height, width)) for _ in range(num_times)]
+        im_stack = image_stack_from_components(fake_times, fake_sci, fake_var, fake_mask)
+        self.assertEqual(im_stack.img_count(), 10)
+        self.assertTrue(count_valid_images(im_stack), 9)
+
+        # Mask most of the pixels in the science layer 1.
+        fake_sci[1][:, 1:width] = np.nan
+        im_stack = image_stack_from_components(fake_times, fake_sci, fake_var, fake_mask)
+        self.assertEqual(im_stack.img_count(), 10)
+        self.assertTrue(count_valid_images(im_stack, 0.8), 9)
+
+        # Mask most of the pixels in the mask layers 3 and 7.
+        fake_mask[3][:, 1:width] = 1
+        fake_mask[7][1:height, :] = 1
+        im_stack = image_stack_from_components(fake_times, fake_sci, fake_var, fake_mask)
+        self.assertEqual(im_stack.img_count(), 10)
+        self.assertTrue(count_valid_images(im_stack, 0.8), 7)
+
+        # Mask most of the science pixels in layer 3 (does not change count).
+        fake_sci[3][:, 1:width] = np.nan
+        im_stack = image_stack_from_components(fake_times, fake_sci, fake_var, fake_mask)
+        self.assertEqual(im_stack.img_count(), 10)
+        self.assertTrue(count_valid_images(im_stack, 0.8), 7)
 
     def test_create_stamps_from_image_stack(self):
         # Create a small fake data set for the tests.

--- a/tests/test_run_search.py
+++ b/tests/test_run_search.py
@@ -36,11 +36,6 @@ class test_run_search(unittest.TestCase):
         # Turn off the warnings for this test.
         logging.disable(logging.CRITICAL)
 
-        # Too few observations.
-        config = SearchConfiguration()
-        config.set("num_obs", 21)
-        self.assertRaises(ValueError, runner.run_search, config, fake_ds.stack)
-
         # Bad results_per_pixel.
         config = SearchConfiguration()
         config.set("results_per_pixel", -1)
@@ -57,6 +52,21 @@ class test_run_search(unittest.TestCase):
 
         # Re-enable warnings.
         logging.disable(logging.NOTSET)
+
+    def test_run_search_auto_config(self):
+        """Test that if we set num_obs to high, we down scale it."""
+        num_times = 10
+        width = 15
+        height = 10
+
+        fake_times = create_fake_times(num_times, t0=60676.0)
+        fake_ds = FakeDataSet(width, height, fake_times)
+        runner = SearchRunner()
+
+        config = SearchConfiguration()
+        config.set("num_obs", 21)
+        _ = runner.run_search(config, fake_ds.stack)
+        self.assertEqual(config["num_obs"], 10)
 
     def test_load_and_filter_results(self):
         num_times = 50

--- a/tests/test_run_search.py
+++ b/tests/test_run_search.py
@@ -92,6 +92,13 @@ class test_run_search(unittest.TestCase):
 
         search = StackSearch(fake_ds.stack)
         configure_kb_search_stack(search, config)
+
+        # Try extracting before we have inserted any results. We should get an empty Results.
+        runner = SearchRunner()
+        results_empty = runner.load_and_filter_results(search, config, batch_size=10)
+        self.assertEqual(len(results_empty), 0)
+
+        # Insert the fake results.
         search.set_results(trjs)
 
         # Extract the (fake) results from the runner. We filter a bunch of


### PR DESCRIPTION
Count the number of images with fewer than 90% of the pixels masked and: a) fail if there are no valid images, or b) set `num_obs` to be at most the number of valid images.

Also gracefully handle cases where no valid results are returned from the core search.