### PR TITLE
Add data modification to Python ImageStack

### DIFF
--- a/src/kbmod/core/image_stack_py.py
+++ b/src/kbmod/core/image_stack_py.py
@@ -88,26 +88,36 @@ class ImageStackPy:
         The length T array of zeroed times.
     """
 
-    def __init__(self, times, sci, var, mask=None, psfs=None):
+    def __init__(self, times=None, sci=None, var=None, mask=None, psfs=None):
+        # If nothing is provided, create an empty data structure.
         if times is None or len(times) == 0:
-            raise ValueError("Cannot create an ImageStack with no times.")
+            if sci is not None or var is not None:
+                raise ValueError("Cannot create an ImageStackPy without times")
+            self.num_times = 0
+            self.times = np.array([])
+            self.sci = []
+            self.var = []
+            self.psfs = []
+            self.height = -1
+            self.width = -1
+            self.zeroed_times = np.array([])
+            return
+
         self.num_times = len(times)
         self.times = np.asarray(times, dtype=float)
         self.zeroed_times = self.times - self.times[0]
 
         # Get and validate the image size information.
-        if len(sci) != self.num_times:
-            raise ValueError(
-                f"Incorrect number of science images. Expected {self.num_times}. Received {len(sci)}."
-            )
-        if len(var) != self.num_times:
-            raise ValueError(
-                f"Incorrect number of variance images. Expected {self.num_times}. Received {len(var)}."
-            )
+        if sci is None:
+            raise ValueError("Missing science data.")
+        elif len(sci) != self.num_times:
+            raise ValueError(f"Expected {self.num_times} science images. Received {len(sci)}.")
+        if var is None:
+            raise ValueError("Missing variance data.")
+        elif len(var) != self.num_times:
+            raise ValueError(f"Expected {self.num_times} science images. Received {len(var)}.")
         if mask is not None and len(mask) != self.num_times:
-            raise ValueError(
-                f"Incorrect number of mask images. Expected {self.num_times}. Received {len(mask)}."
-            )
+            raise ValueError(f"Expected {self.num_times} mask images. Received {len(mask)}.")
         self.height = len(sci[0])
         self.width = len(sci[0][0])
 
@@ -167,6 +177,11 @@ class ImageStackPy:
         if img.dtype != np.single:
             img = img.astype(np.single)
 
+        # If we have not seen any data before (empty stack) use these image dimensions.
+        if self.num_times == 0:
+            self.width = img.shape[1]
+            self.height = img.shape[0]
+
         # Check that the image is the correct size.
         if img.shape[1] != self.width:
             raise ValueError(f"Incorrect image width. Expected {self.width}. Received {img.shape[1]}")
@@ -194,6 +209,108 @@ class ImageStackPy:
         for img in self.sci:
             total += np.sum(np.isnan(img))
         return total
+
+    def append_image(self, time, sci, var, mask=None, psf=None):
+        """Append an image onto the back of the stack.
+
+        Parameters
+        ----------
+        time : float
+            The observation time (in UTC MJD).
+        sci : np.array
+            A H x W array of science data.
+        var : np.array
+            A H x W array of variance data.
+        mask : np.array, optional
+            A H x W array of mask data. If not provided, nothing is masked.
+        psfs : np.array or PSF
+            The PSF information for this time.
+        """
+        current_idx = self.num_times
+        self.sci.append(self._standardize_image(sci))
+        self.var.append(self._standardize_image(var))
+        if psf is None:
+            psf = np.array([[1.0]])
+        elif isinstance(psf, PSF):
+            psf = psf.kernel
+        self.psfs.append(psf)
+
+        # Apply the mask if it is provided.
+        if mask is not None:
+            mask = np.asanyarray(mask)
+            if mask.shape != (self.height, self.width):
+                raise ValueError("Science and Mask data must have the same shape.")
+            masked_pixels = mask > 0
+            self.sci[current_idx][masked_pixels] = np.nan
+            self.var[current_idx][masked_pixels] = np.nan
+
+        # Set the time information.
+        self.num_times += 1
+        self.times = np.append(self.times, time)
+        self.zeroed_times = self.times - self.times[0]
+
+    def append_layered_image(self, layered_image):
+        """Append a LayeredImagePy object to the stack.
+        This is a wrapper for append_image.
+
+        Parameters
+        ----------
+        layered_image : LayeredImagePy
+            The image data to append.
+        """
+        self.append_image(
+            layered_image.time,
+            layered_image.sci,
+            layered_image.var,
+            mask=layered_image.mask,
+            psf=layered_image.psf,
+        )
+
+    def filter_images(self, mask):
+        """Remove images from the stack according to a mask.
+
+        Parameters
+        ----------
+        mask : list or np.ndarray
+            A Boolean array of the images to keep.
+        """
+        mask = np.asanyarray(mask)
+
+        new_sci = []
+        new_var = []
+        new_psfs = []
+        for idx in range(self.num_times):
+            if mask[idx]:
+                new_sci.append(self.sci[idx])
+                new_var.append(self.var[idx])
+                new_psfs.append(self.psfs[idx])
+        self.sci = new_sci
+        self.var = new_var
+        self.psfs = new_psfs
+
+        self.num_times = len(self.sci)
+        self.times = self.times[mask]
+        if self.num_times > 0:
+            self.zeroed_times = self.times - self.times[0]
+        else:
+            self.zeroed_times = []
+
+    def get_masked_fractions(self):
+        """Compute the fraction of masked pixels for each image.
+
+        Returns
+        -------
+        masked_fraction : np.ndarray
+            An array of the fraction of pixels that are masked.
+        """
+        masked_fraction = np.zeros(self.num_times)
+        total_pixels = float(self.width * self.height)
+
+        # Iterate through the list checking each image.
+        for idx in range(self.num_times):
+            is_masked = np.isnan(self.sci[idx]) | np.isnan(self.var[idx])
+            masked_fraction[idx] = np.count_nonzero(is_masked) / total_pixels
+        return masked_fraction
 
     def get_single_image(self, index):
         """Get a single image from the stack.

--- a/src/kbmod/core/image_stack_py.py
+++ b/src/kbmod/core/image_stack_py.py
@@ -312,6 +312,40 @@ class ImageStackPy:
             masked_fraction[idx] = np.count_nonzero(is_masked) / total_pixels
         return masked_fraction
 
+    def mask_by_science_bounds(self, min_val=-1e20, max_val=1e20):
+        """Mask pixels whose value in the science layer lies outside the given bounds.
+        Applies mask to both science and variance layer.
+
+        Parameter
+        ---------
+        min_val : float
+            The minimum acceptable flux. Default: -1e20
+        max_val : float
+            The maximum acceptable flux. Default: 1e20
+        """
+        for idx in range(self.num_times):
+            bad_values = (self.sci[idx] < min_val) | (self.sci[idx] > max_val)
+            self.sci[idx][bad_values] = np.nan
+            self.var[idx][bad_values] = np.nan
+
+    def mask_by_variance_bounds(self, min_val=1e-20, max_val=1e20):
+        """Mask pixels whose value in the variance layer lies outside the given bounds.
+        Applies mask to both science and variance layer.
+
+        Parameter
+        ---------
+        min_val : float
+            The minimum acceptable variance (should always be > 0.0 since negative
+            variance and 0.0 variance are both invalid).
+            Default: 1e-20
+        max_val : float
+            The maximum acceptable variance. Default: 1e20
+        """
+        for idx in range(self.num_times):
+            bad_values = (self.var[idx] < min_val) | (self.var[idx] > max_val)
+            self.sci[idx][bad_values] = np.nan
+            self.var[idx][bad_values] = np.nan
+
     def get_single_image(self, index):
         """Get a single image from the stack.
 

--- a/tests/test_image_stack_py.py
+++ b/tests/test_image_stack_py.py
@@ -57,11 +57,56 @@ class test_image_stack_py(unittest.TestCase):
             self.assertTrue(np.all(stack.var[idx] == 0.1))
         self.assertEqual(len(stack.psfs), num_times)
 
+        # We can append an image and a LayeredImage.
+        stack.append_image(0, sci[0], var[0])
+        self.assertEqual(stack.num_times, num_times + 1)
+        self.assertEqual(len(stack.sci), num_times + 1)
+        self.assertEqual(len(stack.var), num_times + 1)
+        self.assertEqual(len(stack.psfs), num_times + 1)
+        self.assertTrue(np.allclose(stack.times, np.append(times, 0.0)))
+
+        layered = LayeredImagePy(sci[1], var[1], time=5.0)
+        stack.append_layered_image(layered)
+        self.assertEqual(stack.num_times, num_times + 2)
+        self.assertEqual(len(stack.sci), num_times + 2)
+        self.assertEqual(len(stack.var), num_times + 2)
+        self.assertEqual(len(stack.psfs), num_times + 2)
+        self.assertEqual(stack.times[num_times + 1], 5.0)
+
         # Test that we fail with bad input.
-        self.assertRaises(ValueError, ImageStackPy, np.array([]), sci, var)
-        self.assertRaises(ValueError, ImageStackPy, None, sci, var)
+        self.assertRaises(ValueError, ImageStackPy, times)
         self.assertRaises(ValueError, ImageStackPy, times, [np.array([1.0])], var)
         self.assertRaises(ValueError, ImageStackPy, times, sci, [np.array([1.0])])
+
+    def test_create_empty_image_stack_py(self):
+        """Test that we can create an empty ImageStackPy"""
+        stack = ImageStackPy()
+        self.assertEqual(stack.num_times, 0)
+        self.assertEqual(stack.width, -1)
+        self.assertEqual(stack.height, -1)
+
+        # We can append the first few images.
+        num_times = 5
+        height = 20
+        width = 15
+        for idx in range(num_times):
+            sci = np.full((height, width), float(idx))
+            var = np.full((height, width), 0.1 * float(idx))
+            stack.append_image(float(idx + 5.0), sci, var)
+
+            self.assertEqual(stack.num_times, idx + 1)
+            self.assertEqual(stack.width, width)
+            self.assertEqual(stack.height, height)
+            self.assertTrue(np.allclose(stack.sci[idx], sci))
+            self.assertTrue(np.allclose(stack.var[idx], var))
+        self.assertTrue(np.allclose(stack.times, [5.0, 6.0, 7.0, 8.0, 9.0]))
+        self.assertTrue(np.allclose(stack.zeroed_times, [0.0, 1.0, 2.0, 3.0, 4.0]))
+
+        # We fail if we try to create an ImageStackPy with no times but other data.
+        times = np.arange(num_times)
+        sci = [np.full((height, width), float(i)) for i in range(num_times)]
+        var = [np.full((height, width), 0.1 * i) for i in range(num_times)]
+        self.assertRaises(ValueError, ImageStackPy, None, sci, var)
 
     def test_create_image_stack_from_nparray_py(self):
         """Test that we can create an ImageStackPy from a single 3-d numpy array."""
@@ -161,6 +206,36 @@ class test_image_stack_py(unittest.TestCase):
         self.assertEqual(stack.times[5], 10.0)
         self.assertEqual(stack.zeroed_times[5], 10.0)
 
+    def test_filter_image_stack_ph(self):
+        """Test that we can filter an ImageStackPy"""
+        num_times = 10
+        height = 20
+        width = 15
+
+        times = np.arange(num_times) + 3.0
+        sci = [np.full((height, width), float(i)) for i in range(num_times)]
+        var = [np.full((height, width), 0.1 * float(i)) for i in range(num_times)]
+        psfs = [np.array([[float(i)]]) for i in range(num_times)]
+
+        stack = ImageStackPy(times, sci, var, psfs=psfs)
+        self.assertEqual(stack.num_times, num_times)
+
+        keep_inds = np.array([1, 3, 5, 6, 7, 8])
+        keep_mask = np.full(num_times, False)
+        keep_mask[keep_inds] = True
+        stack.filter_images(keep_mask)
+        self.assertEqual(stack.num_times, len(keep_inds))
+
+        # Check that we saved the correct indices.
+        for new_idx, org_idx in enumerate(keep_inds):
+            self.assertTrue(np.allclose(stack.sci[new_idx], sci[org_idx]))
+            self.assertTrue(np.allclose(stack.var[new_idx], var[org_idx]))
+            self.assertTrue(np.allclose(stack.psfs[new_idx], psfs[org_idx]))
+
+        # Check the times. Note the zeroed times shift because we removed index 0.
+        self.assertTrue(np.allclose(stack.times, [4.0, 6.0, 8.0, 9.0, 10.0, 11.0]))
+        self.assertTrue(np.allclose(stack.zeroed_times, [0.0, 2.0, 4.0, 5.0, 6.0, 7.0]))
+
     def test_get_matched_obstimes(self):
         obstimes = [1.0, 2.0, 3.0, 4.0, 6.0, 7.5, 9.0, 10.1]
 
@@ -219,6 +294,30 @@ class test_image_stack_py(unittest.TestCase):
 
             # Far away from the object, the signal should be zero.
             self.assertAlmostEqual(fake_stack.sci[t_idx][30, 40], 0.0)
+
+    def test_get_masked_fractions(self):
+        """Test that we can compute the fraction of pixels masked at each index."""
+        num_times = 20
+        height = 20
+        width = 30
+        stack = ImageStackPy()
+
+        # Append images with an increasing fraction of masked pixels
+        for idx in range(num_times):
+            sci = np.full((height, width), float(idx))
+            var = np.full((height, width), 0.1 * float(idx))
+            msk = np.zeros((height, width))
+            msk[0:idx, :] = 1
+            stack.append_image(idx / 20.0, sci, var, mask=msk)
+
+        fractions = stack.get_masked_fractions()
+        self.assertTrue(np.allclose(fractions, np.arange(num_times) / float(num_times)))
+
+        # Filter out images with above a given masked fraction.
+        stack.filter_images(fractions < 0.5)
+        times_remaining = int(num_times / 2)
+        self.assertEqual(stack.num_times, times_remaining)
+        self.assertTrue(np.allclose(stack.times, np.arange(times_remaining) / float(num_times)))
 
     def test_image_stack_py_validate(self):
         """Tests that we can validate an ImageStackPy."""


### PR DESCRIPTION
Adds a series of helper functions to the Python version of the ImageStack (`ImageStackPy`) to support better data cleaning when we switch to the Python input reading:
- Mask out values that fall outside given ranges (in science or variance)
- Identify images with too many pixels masked so they can be removed.
- Remove images from an image stack (to use with the masking fraction above so we don't waste time and memory on images with >x% of the pixels masked).
- Append images to a stack (so we can reuse the WorkUnit's current loading logic).