### PR TITLE
Remove image_allclose

### DIFF
--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -7,45 +7,17 @@ from kbmod.fake_data.fake_data_creator import create_fake_times, FakeDataSet
 from kbmod.search import KB_NO_DATA, Trajectory
 
 from kbmod.image_utils import (
+    count_valid_images,
     create_stamps_from_image_stack,
     create_stamps_from_image_stack_xy,
     extract_sci_images_from_stack,
     extract_var_images_from_stack,
-    image_allclose,
     image_stack_from_components,
     validate_image_stack,
 )
 
 
 class test_image_utils(unittest.TestCase):
-    def test_image_allclose(self):
-        """Test that we can compare two images."""
-        arr1 = np.arange(12).reshape((3, 4)).astype(np.float32)
-        arr2 = np.arange(12).reshape((4, 3)).astype(np.float32)
-        self.assertFalse(image_allclose(arr1, arr2))
-
-        arr2 = np.arange(12).reshape((3, 4)).astype(np.float32)
-        self.assertTrue(image_allclose(arr1, arr2))
-
-        arr2[0, 1] = arr2[0, 1] + 0.001
-        self.assertFalse(image_allclose(arr1, arr2))
-
-        arr1[0, 1] = arr1[0, 1] + 0.001
-        self.assertTrue(image_allclose(arr1, arr2))
-
-        arr1[1, 2] = KB_NO_DATA
-        self.assertFalse(image_allclose(arr1, arr2))
-
-        arr2[1, 2] = KB_NO_DATA
-        self.assertTrue(image_allclose(arr1, arr2))
-
-        arr1[0, 3] = KB_NO_DATA
-        arr2[0, 3] = KB_NO_DATA
-        self.assertTrue(image_allclose(arr1, arr2))
-
-        arr1[2, 2] = 1.0
-        self.assertFalse(image_allclose(arr1, arr2))
-
     def test_extract_images_from_stack(self):
         """Tests that we can transform an ImageStack into a single numpy array."""
         num_times = 5
@@ -104,9 +76,9 @@ class test_image_utils(unittest.TestCase):
 
             # Check that the images are equal. We use a threshold of 0.001 because the
             # RawImage arrays will be converted into single precision floats.
-            self.assertTrue(image_allclose(img.get_science_array(), fake_sci[idx], atol=0.001))
-            self.assertTrue(image_allclose(img.get_variance_array(), fake_var[idx], atol=0.001))
-            self.assertTrue(image_allclose(img.get_mask_array(), fake_mask[idx], atol=0.001))
+            self.assertTrue(np.allclose(img.get_science_array(), fake_sci[idx], atol=0.001, equal_nan=True))
+            self.assertTrue(np.allclose(img.get_variance_array(), fake_var[idx], atol=0.001, equal_nan=True))
+            self.assertTrue(np.allclose(img.get_mask_array(), fake_mask[idx], atol=0.001, equal_nan=True))
 
         # Test that everything still works when we don't pass in a mask or PSFs.
         im_stack = image_stack_from_components(fake_times, fake_sci, fake_var)
@@ -166,6 +138,39 @@ class test_image_utils(unittest.TestCase):
 
         # Re-enable warnings.
         logging.disable(logging.NOTSET)
+
+    def test_count_valid_images(self):
+        """Tests that we can count the number of valid images in an ImageStack."""
+        # Start with a valid ImageStack.
+        num_times = 10
+        width = 20
+        height = 20
+        fake_times = np.arange(num_times)
+        fake_sci = [90.0 * np.random.random((height, width)) + 10.0 for _ in range(num_times)]
+        fake_var = [0.49 * np.random.random((height, width)) + 0.01 for _ in range(num_times)]
+        fake_mask = [np.zeros((height, width)) for _ in range(num_times)]
+        im_stack = image_stack_from_components(fake_times, fake_sci, fake_var, fake_mask)
+        self.assertEqual(im_stack.img_count(), 10)
+        self.assertTrue(count_valid_images(im_stack), 9)
+
+        # Mask most of the pixels in the science layer 1.
+        fake_sci[1][:, 1:width] = np.nan
+        im_stack = image_stack_from_components(fake_times, fake_sci, fake_var, fake_mask)
+        self.assertEqual(im_stack.img_count(), 10)
+        self.assertTrue(count_valid_images(im_stack, 0.8), 9)
+
+        # Mask most of the pixels in the mask layers 3 and 7.
+        fake_mask[3][:, 1:width] = 1
+        fake_mask[7][1:height, :] = 1
+        im_stack = image_stack_from_components(fake_times, fake_sci, fake_var, fake_mask)
+        self.assertEqual(im_stack.img_count(), 10)
+        self.assertTrue(count_valid_images(im_stack, 0.8), 7)
+
+        # Mask most of the science pixels in layer 3 (does not change count).
+        fake_sci[3][:, 1:width] = np.nan
+        im_stack = image_stack_from_components(fake_times, fake_sci, fake_var, fake_mask)
+        self.assertEqual(im_stack.img_count(), 10)
+        self.assertTrue(count_valid_images(im_stack, 0.8), 7)
 
     def test_create_stamps_from_image_stack(self):
         # Create a small fake data set for the tests.

--- a/tests/test_image_utils_cpp.py
+++ b/tests/test_image_utils_cpp.py
@@ -5,7 +5,6 @@ import tempfile
 import unittest
 
 from kbmod.core.psf import PSF
-from kbmod.image_utils import image_allclose
 from kbmod.search import (
     HAS_GPU,
     KB_NO_DATA,

--- a/tests/test_raw_image.py
+++ b/tests/test_raw_image.py
@@ -3,7 +3,6 @@ import numpy as np
 import unittest
 
 from kbmod.core.psf import PSF
-from kbmod.image_utils import image_allclose
 from kbmod.search import (
     HAS_GPU,
     KB_NO_DATA,
@@ -243,7 +242,7 @@ class test_RawImage(unittest.TestCase):
         stamp = img2.create_stamp(7.5, 5.5, 1, True)
         self.assertEqual(stamp.image.shape, (3, 3))
         stamp2 = RawImage(img2.image[4:7, 6:9])
-        self.assertTrue(image_allclose(stamp.image, stamp2.image, 0.01))
+        self.assertTrue(np.allclose(stamp.image, stamp2.image, atol=0.01, equal_nan=True))
 
         # Test a stamp with masked pixels and replacement.
         stamp = img2.create_stamp(7.5, 5.5, 2, False)

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -15,7 +15,6 @@ import warnings
 from kbmod.configuration import SearchConfiguration
 from kbmod.core.psf import PSF
 from kbmod.fake_data.fake_data_creator import make_fake_layered_image
-from kbmod.image_utils import image_allclose
 import kbmod.search as kb
 from kbmod.reprojection_utils import fit_barycentric_wcs
 from kbmod.wcs_utils import make_fake_wcs, wcs_fits_equal
@@ -245,9 +244,17 @@ class test_work_unit(unittest.TestCase):
                 # Check the three image layers match. We use more permissive values for science and
                 # variance because of quantization during compression.
                 li_org = self.im_stack.get_single_image(i)
-                self.assertTrue(image_allclose(li.get_science_array(), li_org.get_science_array(), 0.05))
-                self.assertTrue(image_allclose(li.get_variance_array(), li_org.get_variance_array(), 0.05))
-                self.assertTrue(image_allclose(li.get_mask_array(), li_org.get_mask_array(), 0.001))
+                self.assertTrue(
+                    np.allclose(li.get_science_array(), li_org.get_science_array(), atol=0.05, equal_nan=True)
+                )
+                self.assertTrue(
+                    np.allclose(
+                        li.get_variance_array(), li_org.get_variance_array(), atol=0.05, equal_nan=True
+                    )
+                )
+                self.assertTrue(
+                    np.allclose(li.get_mask_array(), li_org.get_mask_array(), atol=0.001, equal_nan=True)
+                )
 
                 # Check the PSF layer matches.
                 p1 = self.p[i]
@@ -305,9 +312,17 @@ class test_work_unit(unittest.TestCase):
                 # Check the three image layers match. We use more permissive values for science and
                 # variance because of quantization during compression.
                 li_org = self.im_stack.get_single_image(i)
-                self.assertTrue(image_allclose(li.get_science_array(), li_org.get_science_array(), 0.05))
-                self.assertTrue(image_allclose(li.get_variance_array(), li_org.get_variance_array(), 0.05))
-                self.assertTrue(image_allclose(li.get_mask_array(), li_org.get_mask_array(), 0.001))
+                self.assertTrue(
+                    np.allclose(li.get_science_array(), li_org.get_science_array(), atol=0.05, equal_nan=True)
+                )
+                self.assertTrue(
+                    np.allclose(
+                        li.get_variance_array(), li_org.get_variance_array(), atol=0.05, equal_nan=True
+                    )
+                )
+                self.assertTrue(
+                    np.allclose(li.get_mask_array(), li_org.get_mask_array(), atol=0.001, equal_nan=True)
+                )
 
                 # Check the PSF layer matches.
                 p1 = self.p[i]


### PR DESCRIPTION
Since we moved RawImages to Eigen a while back, `image_allclose` is effectively `np.allclose`. This removes the unneeded helper function and just uses np.allclose in tests.