### PR TITLE
Remove C++ objects from Standardizers and ImageCollection

### DIFF
--- a/src/kbmod/image_collection.py
+++ b/src/kbmod/image_collection.py
@@ -518,12 +518,12 @@ class ImageCollection:
                     guess_dist,
                     earth_loc,
                 )
-                self.data[
-                    self.reflex_corrected_col(f"ra_{box_corner}", guess_dist)
-                ] = corrected_ra_dec_corner.ra.deg
-                self.data[
-                    self.reflex_corrected_col(f"dec_{box_corner}", guess_dist)
-                ] = corrected_ra_dec_corner.dec.deg
+
+                ra_col = self.reflex_corrected_col(f"ra_{box_corner}", guess_dist)
+                self.data[ra_col] = corrected_ra_dec_corner.ra.deg
+
+                dec_col = self.reflex_corrected_col(f"dec_{box_corner}", guess_dist)
+                self.data[dec_col] = corrected_ra_dec_corner.dec.deg
 
     def reflex_corrected_col(self, col_name, guess_dist):
         """Get the name of the reflex-corrected column for a given guess distance.

--- a/src/kbmod/image_collection.py
+++ b/src/kbmod/image_collection.py
@@ -17,7 +17,7 @@ from astropy.utils import isiterable
 
 import numpy as np
 
-from kbmod.search import ImageStack
+from kbmod.core.image_stack_py import ImageStackPy
 from .standardizers import Standardizer
 
 
@@ -518,12 +518,12 @@ class ImageCollection:
                     guess_dist,
                     earth_loc,
                 )
-                self.data[self.reflex_corrected_col(f"ra_{box_corner}", guess_dist)] = (
-                    corrected_ra_dec_corner.ra.deg
-                )
-                self.data[self.reflex_corrected_col(f"dec_{box_corner}", guess_dist)] = (
-                    corrected_ra_dec_corner.dec.deg
-                )
+                self.data[
+                    self.reflex_corrected_col(f"ra_{box_corner}", guess_dist)
+                ] = corrected_ra_dec_corner.ra.deg
+                self.data[
+                    self.reflex_corrected_col(f"dec_{box_corner}", guess_dist)
+                ] = corrected_ra_dec_corner.dec.deg
 
     def reflex_corrected_col(self, col_name, guess_dist):
         """Get the name of the reflex-corrected column for a given guess distance.
@@ -1030,18 +1030,6 @@ class ImageCollection:
             self.meta.pop("is_packed", None)
         return fitsio.hdu.BinTableHDU(self.data, name="IMGCOLL")
 
-    def toImageStack(self):
-        """Return an `~kbmod.search.image_stack` object for processing with
-        KBMOD.
-        Returns
-        -------
-        imageStack : `~kbmod.search.image_stack`
-            Image stack for processing with KBMOD.
-        """
-        logger.info("Building ImageStack from ImageCollection")
-        layeredImages = [img for std in self._standardizers for img in std.toLayeredImage()]
-        return ImageStack(layeredImages)
-
     def toWorkUnit(self, search_config=None, **kwargs):
         """Return an `~kbmod.WorkUnit` object for processing with
         KBMOD.
@@ -1072,10 +1060,10 @@ class ImageCollection:
         if None not in self.wcs:
             metadata["per_image_wcs"] = list(self.wcs)
 
-        # Create the basic WorkUnit from the ImageStack.
-        imgstack = ImageStack()
+        # Create the basic WorkUnit from the ImageStackPy.
+        imgstack = ImageStackPy()
         for layimg in layeredImages:
-            imgstack.append_image(layimg, force_move=True)
+            imgstack.append_layered_image(layimg)
         work = WorkUnit(imgstack, search_config, org_image_meta=metadata)
 
         return work

--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -14,7 +14,7 @@ import numpy as np
 from .standardizer import Standardizer, StandardizerConfig
 
 from kbmod.core.psf import PSF
-from kbmod.search import LayeredImage
+from kbmod.core.image_stack_py import LayeredImagePy
 
 
 __all__ = [
@@ -517,12 +517,12 @@ class ButlerStandardizer(Standardizer):
         # support different types, TODO: update when fixed
         mask = masks[0].astype(np.float32)
         imgs = [
-            LayeredImage(
+            LayeredImagePy(
                 self.standardizeScienceImage()[0],
                 self.standardizeVarianceImage()[0],
-                mask,
-                self.standardizePSF()[0],
-                self._metadata["mjd_mid"],
+                mask=mask,
+                psf=self.standardizePSF()[0],
+                time=self._metadata["mjd_mid"],
             ),
         ]
         if not self.config["greedy_export"]:

--- a/src/kbmod/standardizers/fits_standardizers/fits_standardizer.py
+++ b/src/kbmod/standardizers/fits_standardizers/fits_standardizer.py
@@ -19,7 +19,7 @@ import numpy as np
 from ..standardizer import Standardizer, StandardizerConfig, ConfigurationError
 
 from kbmod.core.psf import PSF
-from kbmod.search import LayeredImage
+from kbmod.core.image_stack_py import LayeredImagePy
 
 
 __all__ = [
@@ -389,7 +389,7 @@ class FitsStandardizer(Standardizer):
             raise TypeError("Expected a number or a list, got {type(stds)}: {stds}")
 
     def toLayeredImage(self):
-        """Returns a list of `~kbmod.search.layered_image` objects for each
+        """Returns a list of `~LayeredImagePy` objects for each
         entry marked as processable.
 
         Returns
@@ -411,10 +411,6 @@ class FitsStandardizer(Standardizer):
         else:
             mjds = (meta["mjd_mid"] for e in self.processable)
 
-        # Sci and var will be, potentially, loaded by AstroPy as float32 arrays
-        # already. Depends on the header keys really, but that's Standardizer's
-        # job. Lack of generics in CPP code forces casting of mask, making a
-        # copy. TODO: fix when/if CPP stuff is fixed.
         imgs = []
         for sci, var, mask, psf, t in zip(sciences, variances, masks, psfs, mjds):
             # Make sure the science and variance layers are float32.
@@ -423,7 +419,7 @@ class FitsStandardizer(Standardizer):
 
             # Converts nd array mask from bool to np.float32
             mask = mask.astype(np.float32)
-            imgs.append(LayeredImage(sci, var, mask, psf.astype(np.float32), obs_time=t))
+            imgs.append(LayeredImagePy(sci, var, mask=mask, psf=psf.astype(np.float32), time=t))
 
         if not self.config["greedy_export"]:
             for i in self.processable:

--- a/src/kbmod/standardizers/standardizer.py
+++ b/src/kbmod/standardizers/standardizer.py
@@ -1,4 +1,4 @@
-"""`Standardizer` converts data from a given data source into a `LayeredImage`
+"""`Standardizer` converts data from a given data source into a `LayeredImagePy`
 object, applying data-source specific, transformations in the process. A
 layered image is a collection containing:
  * science image

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -18,7 +18,8 @@ from tqdm import tqdm
 
 from kbmod import is_interactive
 from kbmod.configuration import SearchConfiguration
-from kbmod.image_utils import stat_image_stack, validate_image_stack
+from kbmod.core.image_stack_py import ImageStackPy, LayeredImagePy
+from kbmod.image_utils import image_stack_from_components, stat_image_stack, validate_image_stack
 from kbmod.reprojection_utils import invert_correct_parallax
 from kbmod.search import ImageStack, LayeredImage, Logging, Trajectory
 from kbmod.util_functions import get_matched_obstimes
@@ -129,6 +130,17 @@ class WorkUnit:
         obstimes=None,
         org_image_meta=None,
     ):
+        # Add a temporary bridge to convert the Python ImageStackPy into the C++
+        # version. This uses force_move and destroys the original im_stack.
+        if isinstance(im_stack, ImageStackPy):
+            im_stack = image_stack_from_components(
+                im_stack.times,
+                im_stack.sci,
+                im_stack.var,
+                psfs=im_stack.psfs,
+            )
+
+        # Assign the core components.
         self.im_stack = im_stack
         self.config = config
         self.lazy = lazy

--- a/tests/test_butlerstd.py
+++ b/tests/test_butlerstd.py
@@ -255,14 +255,14 @@ class TestButlerStandardizer(unittest.TestCase):
         img = butler_imgs[0]
 
         # Compare standardized images
-        np.testing.assert_equal(fits["IMAGE"].data, img.get_science_array())
-        np.testing.assert_equal(fits["VARIANCE"].data, img.get_variance_array())
-        np.testing.assert_equal(fits["MASK"].data, img.get_mask_array())
+        np.testing.assert_equal(fits["IMAGE"].data, img.sci)
+        np.testing.assert_equal(fits["VARIANCE"].data, img.var)
+        np.testing.assert_equal(fits["MASK"].data, img.mask)
 
         # Test that we correctly set metadata
         # times can only be compred approximately, because sometimes we
         # calculate the time in the middle of the exposure
-        self.assertAlmostEqual(expected_mjd, img.get_obstime(), 2)
+        self.assertAlmostEqual(expected_mjd, img.time, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_standardizer.py
+++ b/tests/test_standardizer.py
@@ -350,12 +350,12 @@ class TestKBMODV1(unittest.TestCase):
         img = layered_imgs[0]
 
         # Compare standardized images
-        np.testing.assert_equal(self.fits["IMAGE"].data, img.get_science_array())
-        np.testing.assert_equal(self.fits["VARIANCE"].data, img.get_variance_array())
-        np.testing.assert_equal(self.fits["MASK"].data, img.get_mask_array())
+        np.testing.assert_equal(self.fits["IMAGE"].data, img.sci)
+        np.testing.assert_equal(self.fits["VARIANCE"].data, img.var)
+        np.testing.assert_equal(self.fits["MASK"].data, img.mask)
 
         # Test that we correctly set metadata
-        self.assertEqual(expected_mjd, img.get_obstime())
+        self.assertEqual(expected_mjd, img.time)
 
     def test_to_layered_image_no_greedy(self):
         """Test that KBMODV1 standardizer can create LayeredImages. Explicitly
@@ -381,7 +381,7 @@ class TestKBMODV1(unittest.TestCase):
         self.assertIsNone(self.fits["IMAGE"].data)
 
         # Test that we correctly set metadata
-        self.assertEqual(expected_mjd, img.get_obstime())
+        self.assertEqual(expected_mjd, img.time)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Remove the dependency of both the Standardizers and ImageCollection on the C++ objects.  Within the standardizers use `LayeredImagePy` instead of `LayeredImage` since all we need is a data class to hold the various pieces of information.

Have `ImageCollection` build an `ImageStackPy` instead of a C++ `ImageStack`. This requires a slight change to `WorkUnit` to convert between the two types (moving the image references), so that we do not have to change everything that uses the `WorkUnit` or its `ImageStack` yet. Later changes will continue to push the boundary of the C++ code back.