### PR TITLE
Add cached data to StackSearch

### DIFF
--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -245,8 +245,7 @@ class SearchRunner:
         if config["near_dup_thresh"] is not None and config["near_dup_thresh"] > 0:
             self._start_phase("near duplicate removal")
             bin_width = config["near_dup_thresh"]
-            all_times = search.get_imagestack().build_zeroed_times()
-            max_dt = np.max(all_times) - np.min(all_times)
+            max_dt = np.max(search.zeroed_times) - np.min(search.zeroed_times)
             logger.info(f"Prefiltering Near Duplicates (bin_width={bin_width}, max_dt={max_dt})")
             result_trjs, _ = apply_trajectory_grid_filter(result_trjs, bin_width, max_dt)
             logger.info(f"After prefiltering {len(result_trjs)} remaining.")

--- a/src/kbmod/search/pydocs/stack_search_docs.h
+++ b/src/kbmod/search/pydocs/stack_search_docs.h
@@ -6,6 +6,17 @@ static const auto DOC_StackSearch = R"doc(
   The data and configuration needed for KBMOD's core search. It is created
   using a *reference* to the ``ImageStack``. The underlying ``ImageStack``
   must exist for the life of the ``StackSearch`` object's life.
+
+  Attributes
+  ----------
+  num_images : `int`
+      The number of images (or time steps).
+  height : `int`
+      The height of each image in pixels.
+  width : `int`
+      The width of each image in pixels.
+  zeroed_times : `list`
+      The times shift so the first time is at 0.0.
   )doc";
 
 static const auto DOC_StackSearch_search = R"doc(
@@ -128,14 +139,6 @@ static const auto DOC_StackSearch_get_image_width = R"doc(
 
 static const auto DOC_StackSearch_get_image_height = R"doc(
   Returns the height of the images in pixels.
-  )doc";
-
-static const auto DOC_StackSearch_get_image_npixels = R"doc(
-  Returns the number of pixels for each image.
-  )doc";
-
-static const auto DOC_StackSearch_get_imagestack = R"doc(
-  Return the `kb.ImageStack` containing the data to search.
   )doc";
 
 static const auto DOC_StackSearch_get_all_psi_phi_curves = R"doc(

--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -61,6 +61,12 @@ StackSearch::StackSearch(ImageStack& imstack) : stack(imstack), results(0) {
 
     // Get the logger for this module.
     rs_logger = logging::getLogger("kbmod.search.run_search");
+
+    // Get the cached stats for the images.
+    width = imstack.get_width();
+    height = imstack.get_height();
+    num_imgs = imstack.img_count();
+    zeroed_times = imstack.build_zeroed_times();
 }
 
 StackSearch::~StackSearch() {
@@ -205,8 +211,8 @@ void StackSearch::search_all(std::vector<Trajectory>& search_list, bool on_gpu) 
     // Prepare the input data (psi/phi and candidate lists).
     prepare_psi_phi();
     TrajectoryList candidate_list = TrajectoryList(search_list);
-     uint64_t max_results = compute_max_results();
-    
+    uint64_t max_results = compute_max_results();
+
     DebugTimer core_timer = DebugTimer("Running batch search", rs_logger);
 
     // staple C++
@@ -241,15 +247,15 @@ void StackSearch::search_all(std::vector<Trajectory>& search_list, bool on_gpu) 
     search_timer.stop();
     uint64_t num_results = results.get_size();
     rs_logger->debug("Core search returned " + std::to_string(num_results) + " results.\n");
-    
+
     // Perform initial LH and obscount filtering.
-    
+
     DebugTimer filter_timer = DebugTimer("Filtering results by LH and min_obs", rs_logger);
     results.filter_by_likelihood(params.min_lh);
     results.filter_by_obs_count(params.min_observations);
     uint64_t new_num_results = results.get_size();
-    rs_logger->debug("After filtering by LH and min_obs " + std::to_string(new_num_results) +
-                     " results (" + std::to_string(num_results - new_num_results) + " removed).\n");
+    rs_logger->debug("After filtering by LH and min_obs " + std::to_string(new_num_results) + " results (" +
+                     std::to_string(num_results - new_num_results) + " removed).\n");
     filter_timer.stop();
 
     // Sort the results by decreasing likleihood.
@@ -326,6 +332,10 @@ static void stack_search_bindings(py::module& m) {
 
     py::class_<ks>(m, "StackSearch", pydocs::DOC_StackSearch)
             .def(py::init<is&>())
+            .def_property_readonly("num_images", &ks::num_images)
+            .def_property_readonly("height", &ks::get_image_height)
+            .def_property_readonly("width", &ks::get_image_width)
+            .def_property_readonly("zeroed_times", &ks::get_zeroed_times)
             .def("search_all", &ks::search_all, pydocs::DOC_StackSearch_search)
             .def("evaluate_single_trajectory", &ks::evaluate_single_trajectory,
                  pydocs::DOC_StackSearch_evaluate_single_trajectory)
@@ -345,9 +355,6 @@ static void stack_search_bindings(py::module& m) {
             .def("get_num_images", &ks::num_images, pydocs::DOC_StackSearch_get_num_images)
             .def("get_image_width", &ks::get_image_width, pydocs::DOC_StackSearch_get_image_width)
             .def("get_image_height", &ks::get_image_height, pydocs::DOC_StackSearch_get_image_height)
-            .def("get_image_npixels", &ks::get_image_npixels, pydocs::DOC_StackSearch_get_image_npixels)
-            .def("get_imagestack", &ks::get_imagestack, py::return_value_policy::reference_internal,
-                 pydocs::DOC_StackSearch_get_imagestack)
             .def("get_all_psi_phi_curves", &ks::get_all_psi_phi_curves,
                  pydocs::DOC_StackSearch_get_all_psi_phi_curves)
             // For testings

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -36,6 +36,7 @@ public:
     std::vector<double>& get_zeroed_times() { return zeroed_times; }
 
     // Parameter setters used to control the searches.
+    void set_default_parameters();
     void set_min_obs(int new_value);
     void set_min_lh(float new_value);
     void disable_gpu_sigmag_filter();

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -30,11 +30,10 @@ class StackSearch {
 public:
     StackSearch(ImageStack& imstack);
     uint64_t compute_max_results();
-    unsigned int num_images() const { return stack.img_count(); }
-    unsigned int get_image_width() const { return stack.get_width(); }
-    unsigned int get_image_height() const { return stack.get_height(); }
-    uint64_t get_image_npixels() const { return stack.get_npixels(); }
-    const ImageStack& get_imagestack() const { return stack; }
+    unsigned int num_images() const { return num_imgs; }
+    unsigned int get_image_width() const { return width; }
+    unsigned int get_image_height() const { return height; }
+    std::vector<double>& get_zeroed_times() { return zeroed_times; }
 
     // Parameter setters used to control the searches.
     void set_min_obs(int new_value);
@@ -72,8 +71,13 @@ public:
 protected:
     // Core data and search parameters. Note the StackSearch does not own
     // the ImageStack and it must exist for the duration of the object's life.
-    ImageStack& stack;
     SearchParameters params;
+    unsigned int height;
+    unsigned int width;
+    unsigned int num_imgs;
+    std::vector<double> zeroed_times;
+
+    ImageStack& stack;
 
     // Precomputed and cached search data
     bool psi_phi_generated;


### PR DESCRIPTION
As a small step toward being able to remove `ImageStack` from `StackSearch`, extract some statistics (height, width, times) locally and use those.   Now we only need `ImageStack` to build the psi phi data (which we can simplify in a later PR).

Also make this data available in Python as object attributes to make the interface more Pythonic.