### PR TITLE
Allow a StackSearch to accept data from ImageStack or python lists

### DIFF
--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -67,11 +67,6 @@ def configure_kb_search_stack(search, config):
     else:
         search.disable_gpu_sigmag_filter()
 
-    # If we are using an encoded image representation on GPU, enable it and
-    # set the parameters.
-    if config["encode_num_bytes"] > 0:
-        search.enable_gpu_encoding(config["encode_num_bytes"])
-
     # Clear the cached results.
     search.clear_results()
 
@@ -310,7 +305,7 @@ class SearchRunner:
             raise ValueError("Insufficient GPU memory to conduct the search.")
 
         # Create the search object which will hold intermediate data and results.
-        search = kb.StackSearch(stack)
+        search = kb.StackSearch(stack, config["encode_num_bytes"])
         configure_kb_search_stack(search, config)
 
         # Do the actual search.
@@ -328,8 +323,9 @@ class SearchRunner:
         # Load the results.
         keep = self.load_and_filter_results(search, config)
 
-        # Force the deletion of the psi and phi data.
-        search.clear_psi_phi()
+        # Delete the search object to force the memory cleanup.
+        # Of the psi/phi images on CPU and GPU.
+        del search
 
         self._end_phase("do_core_search")
         return keep

--- a/src/kbmod/search/layered_image.cpp
+++ b/src/kbmod/search/layered_image.cpp
@@ -88,14 +88,9 @@ void LayeredImage::apply_mask(int flags) {
     }      // for c
 }
 
-Image LayeredImage::generate_psi_image() {
-    return generate_psi(science, variance, psf);
-}
+Image LayeredImage::generate_psi_image() { return generate_psi(science, variance, psf); }
 
-Image LayeredImage::generate_phi_image() {
-    return generate_phi(variance, psf);
-}
-
+Image LayeredImage::generate_phi_image() { return generate_phi(variance, psf); }
 
 #ifdef Py_PYTHON_H
 static void layered_image_bindings(py::module& m) {

--- a/src/kbmod/search/psi_phi_array.cpp
+++ b/src/kbmod/search/psi_phi_array.cpp
@@ -355,10 +355,8 @@ void fill_psi_phi_array(PsiPhiArray& result_data, int num_bytes, const std::vect
     result_data.set_time_array(zeroed_times);
 }
 
-
 void fill_psi_phi_array_from_image_arrays(PsiPhiArray& result_data, int num_bytes,
-                                          std::vector<Image>& sci_imgs,
-                                          std::vector<Image>& var_imgs,
+                                          std::vector<Image>& sci_imgs, std::vector<Image>& var_imgs,
                                           std::vector<Image>& psf_kernels,
                                           std::vector<double>& zeroed_times) {
     const uint64_t num_images = sci_imgs.size();
@@ -373,9 +371,9 @@ void fill_psi_phi_array_from_image_arrays(PsiPhiArray& result_data, int num_byte
     const uint64_t total_bytes = 2 * height * width * num_images * sizeof(float);
 
     logging::getLogger("kbmod.search.psi_phi_array")
-            ->info("Building " + std::to_string(num_images * 2) + " temporary " +
-                   std::to_string(height) + " by " + std::to_string(width) +
-                   " images, requiring " + std::to_string(total_bytes) + " bytes.");     
+            ->info("Building " + std::to_string(num_images * 2) + " temporary " + std::to_string(height) +
+                   " by " + std::to_string(width) + " images, requiring " + std::to_string(total_bytes) +
+                   " bytes.");
 
     // Build the psi and phi images first.
     std::vector<Image> psi_images;
@@ -384,7 +382,7 @@ void fill_psi_phi_array_from_image_arrays(PsiPhiArray& result_data, int num_byte
         Image& sci = sci_imgs[i];
         Image& var = var_imgs[i];
         Image& psf = psf_kernels[i];
- 
+
         psi_images.push_back(generate_psi(sci, var, psf));
         phi_images.push_back(generate_phi(var, psf));
     }
@@ -393,7 +391,6 @@ void fill_psi_phi_array_from_image_arrays(PsiPhiArray& result_data, int num_byte
     // encoding can compute the bounds of each array.
     fill_psi_phi_array(result_data, num_bytes, psi_images, phi_images, zeroed_times);
 }
-
 
 void fill_psi_phi_array_from_image_stack(PsiPhiArray& result_data, ImageStack& stack, int num_bytes) {
     // Compute Phi and Psi from convolved images while leaving masked pixels alone

--- a/src/kbmod/search/psi_phi_array_utils.h
+++ b/src/kbmod/search/psi_phi_array_utils.h
@@ -29,8 +29,9 @@ std::array<float, 3> compute_scale_params_from_image_vect(const std::vector<Imag
 void fill_psi_phi_array(PsiPhiArray& result_data, int num_bytes, const std::vector<Image>& psi_imgs,
                         const std::vector<Image>& phi_imgs, const std::vector<double> zeroed_times);
 
-void fill_psi_phi_array_from_sci_var(PsiPhiArray& result_data, int num_bytes, const std::vector<Image>& sci_imgs,
-                                    const std::vector<Image>& var_imgs, const std::vector<double> zeroed_times);
+void fill_psi_phi_array_from_image_arrays(PsiPhiArray& result_data, int num_bytes,
+                                          std::vector<Image>& sci_imgs, std::vector<Image>& var_imgs,
+                                          std::vector<Image>& psf_kernels, std::vector<double>& zeroed_times);
 
 void fill_psi_phi_array_from_image_stack(PsiPhiArray& result_data, ImageStack& stack, int num_bytes);
 

--- a/src/kbmod/search/pydocs/stack_search_docs.h
+++ b/src/kbmod/search/pydocs/stack_search_docs.h
@@ -17,6 +17,16 @@ static const auto DOC_StackSearch = R"doc(
       The width of each image in pixels.
   zeroed_times : `list`
       The times shift so the first time is at 0.0.
+
+  Parameters
+  ----------
+  imstack : `ImageStack`
+      The image stack to search.
+  num_bytes : `int`
+      The number of bytes to use for encoding the data. This is used
+      to set the encoding level for the data copied to the GPU. The
+      default value is -1, which means no encoding is done.
+      The other options are 1 (uint8), 2 (uint16), and 4 (float).
   )doc";
 
 static const auto DOC_StackSearch_search = R"doc(
@@ -70,18 +80,6 @@ static const auto DOC_StackSearch_enable_gpu_sigmag_filter = R"doc(
   Raises
   ------
   Raises a ``RunTimeError`` if invalid values are provided.
-  )doc";
-
-static const auto DOC_StackSearch_enable_gpu_encoding = R"doc(
-  Set the encoding level for the data copied to the GPU.
-      1 = uint8
-      2 = uint16
-      4 or -1 = float
-
-  Parameters
-  ----------
-  encode_num_bytes : `int`
-      The number of bytes to use for encoding the data.
   )doc";
 
 static const auto DOC_StackSearch_set_start_bounds_x = R"doc(
@@ -157,14 +155,6 @@ static const auto DOC_StackSearch_get_all_psi_phi_curves = R"doc(
      A shape (R, 2T) matrix where R is the number of trajectories and
      T is the number of time steps. The first T columns contain the psi
      values and the second T columns contain the phi columns.
-  )doc";
-
-static const auto DOC_StackSearch_clear_psi_phi = R"doc(
-  Clear the pre-computed psi and phi data.
-  )doc";
-
-static const auto DOC_StackSearch_prepare_psi_phi = R"doc(
-  Compute the cached psi and phi data.
   )doc";
 
 static const auto DOC_StackSearch_get_number_total_results = R"doc(

--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -34,9 +34,7 @@ std::vector<float> extract_joint_psi_phi_curve(const PsiPhiArray& psi_phi, const
 // StackSearch
 // --------------------------------------------
 
-StackSearch::StackSearch(ImageStack& imstack) : stack(imstack), results(0) {
-    psi_phi_generated = false;
-
+StackSearch::StackSearch(ImageStack& imstack, int num_bytes) : results(0) {
     // Get the logger for this module.
     rs_logger = logging::getLogger("kbmod.search.run_search");
 
@@ -46,12 +44,25 @@ StackSearch::StackSearch(ImageStack& imstack) : stack(imstack), results(0) {
     num_imgs = imstack.img_count();
     zeroed_times = imstack.build_zeroed_times();
 
+    // Set the parameters for the search.
     set_default_parameters();
+    if (num_bytes == 1 || num_bytes == 2) {
+        params.encode_num_bytes = num_bytes;
+    } else if (num_bytes == -1 || num_bytes == 4) {
+        params.encode_num_bytes = -1;
+    } else {
+        throw std::runtime_error("Invalid encoding size. Must be -1, 1, 2 or 4.");
+    }
+
+    // Compute the psi/phi array.
+    DebugTimer timer = DebugTimer("preparing Psi and Phi images", rs_logger);
+    fill_psi_phi_array_from_image_stack(psi_phi_array, imstack, params.encode_num_bytes);
+    timer.stop();
 }
 
 StackSearch::~StackSearch() {
     // Clear the memory allocated for psi and phi.
-    clear_psi_phi();
+    psi_phi_array.clear();
 }
 
 // --------------------------------------------
@@ -115,21 +126,6 @@ void StackSearch::enable_gpu_sigmag_filter(std::vector<float> percentiles, float
 
 void StackSearch::disable_gpu_sigmag_filter() { params.do_sigmag_filter = false; }
 
-void StackSearch::enable_gpu_encoding(int encode_num_bytes) {
-    // If changing a setting that would impact the search data encoding, clear the cached values.
-    if (params.encode_num_bytes != encode_num_bytes) {
-        clear_psi_phi();
-    }
-
-    // Make sure the encoding is one of the supported options.
-    // Otherwise use default float (aka no encoding).
-    if (encode_num_bytes == 1 || encode_num_bytes == 2) {
-        params.encode_num_bytes = encode_num_bytes;
-    } else {
-        params.encode_num_bytes = -1;
-    }
-}
-
 void StackSearch::set_start_bounds_x(int x_min, int x_max) {
     if (x_min >= x_max) {
         throw std::runtime_error("Invalid search bounds for the x pixel [" + std::to_string(x_min) + ", " +
@@ -148,40 +144,12 @@ void StackSearch::set_start_bounds_y(int y_min, int y_max) {
     params.y_start_max = y_max;
 }
 
-// --------------------------------------------
-// Data precomputation functions
-// --------------------------------------------
-
-void StackSearch::prepare_psi_phi() {
-    if (!psi_phi_generated) {
-        DebugTimer timer = DebugTimer("preparing Psi and Phi images", rs_logger);
-        fill_psi_phi_array_from_image_stack(psi_phi_array, stack, params.encode_num_bytes);
-        timer.stop();
-        psi_phi_generated = true;
-    }
-
-    // Perform additional error checking that the arrays are allocated (checked even if
-    // using the cached values).
-    if (!psi_phi_array.cpu_array_allocated()) {
-        throw std::runtime_error("PsiPhiArray array unallocated after prepare_psi_phi_array.");
-    }
-}
-
-void StackSearch::clear_psi_phi() {
-    if (psi_phi_generated) {
-        psi_phi_array.clear();
-        psi_phi_generated = false;
-    }
-}
 
 // --------------------------------------------
 // Core search functions
 // --------------------------------------------
 
 void StackSearch::evaluate_single_trajectory(Trajectory& trj, bool use_kernel) {
-    prepare_psi_phi();
-    if (!psi_phi_array.cpu_array_allocated()) std::runtime_error("Data not allocated.");
-
     if (!use_kernel) {
         evaluate_trajectory_cpu(psi_phi_array, trj);
     } else {
@@ -213,7 +181,6 @@ Trajectory StackSearch::search_linear_trajectory(int x, int y, float vx, float v
 
 void StackSearch::search_all(std::vector<Trajectory>& search_list, bool on_gpu) {
     // Prepare the input data (psi/phi and candidate lists).
-    prepare_psi_phi();
     TrajectoryList candidate_list = TrajectoryList(search_list);
     uint64_t max_results = compute_max_results();
 
@@ -291,8 +258,6 @@ Image StackSearch::get_all_psi_phi_curves(const std::vector<Trajectory>& traject
     const unsigned int num_trj = trajectories.size();
     Image results = Image::Zero(num_trj, 2 * num_imgs);
 
-    prepare_psi_phi();
-
 #pragma omp parallel for schedule(dynamic)
     for (int i = 0; i < num_trj; ++i) {
         std::vector<float> curve = extract_joint_psi_phi_curve(psi_phi_array, trajectories[i]);
@@ -333,7 +298,7 @@ static void stack_search_bindings(py::module& m) {
     using ks = search::StackSearch;
 
     py::class_<ks>(m, "StackSearch", pydocs::DOC_StackSearch)
-            .def(py::init<is&>())
+            .def(py::init<is&, int>(), py::arg("imstack"), py::arg("num_bytes") = -1)
             .def_property_readonly("num_images", &ks::num_images)
             .def_property_readonly("height", &ks::get_image_height)
             .def_property_readonly("width", &ks::get_image_width)
@@ -351,7 +316,6 @@ static void stack_search_bindings(py::module& m) {
                  pydocs::DOC_StackSearch_disable_gpu_sigmag_filter)
             .def("enable_gpu_sigmag_filter", &ks::enable_gpu_sigmag_filter,
                  pydocs::DOC_StackSearch_enable_gpu_sigmag_filter)
-            .def("enable_gpu_encoding", &ks::enable_gpu_encoding, pydocs::DOC_StackSearch_enable_gpu_encoding)
             .def("set_start_bounds_x", &ks::set_start_bounds_x, pydocs::DOC_StackSearch_set_start_bounds_x)
             .def("set_start_bounds_y", &ks::set_start_bounds_y, pydocs::DOC_StackSearch_set_start_bounds_y)
             .def("get_num_images", &ks::num_images, pydocs::DOC_StackSearch_get_num_images)
@@ -360,8 +324,6 @@ static void stack_search_bindings(py::module& m) {
             .def("get_all_psi_phi_curves", &ks::get_all_psi_phi_curves,
                  pydocs::DOC_StackSearch_get_all_psi_phi_curves)
             // For testings
-            .def("prepare_psi_phi", &ks::prepare_psi_phi, pydocs::DOC_StackSearch_prepare_psi_phi)
-            .def("clear_psi_phi", &ks::clear_psi_phi, pydocs::DOC_StackSearch_clear_psi_phi)
             .def("get_number_total_results", &ks::get_number_total_results,
                  pydocs::DOC_StackSearch_get_number_total_results)
             .def("get_results", &ks::get_results, pydocs::DOC_StackSearch_get_results)

--- a/src/kbmod/search/stack_search.cpp
+++ b/src/kbmod/search/stack_search.cpp
@@ -54,8 +54,8 @@ StackSearch::StackSearch(ImageStack& imstack, int num_bytes) : results(0) {
 }
 
 StackSearch::StackSearch(std::vector<Image>& sci_imgs, std::vector<Image>& var_imgs,
-                         std::vector<Image>& psf_kernels, std::vector<double>& zeroed_times,
-                         int num_bytes) : results(0), zeroed_times(zeroed_times) {
+                         std::vector<Image>& psf_kernels, std::vector<double>& zeroed_times, int num_bytes)
+        : results(0), zeroed_times(zeroed_times) {
     // Get the logger for this module.
     rs_logger = logging::getLogger("kbmod.search.run_search");
 
@@ -73,15 +73,16 @@ StackSearch::StackSearch(std::vector<Image>& sci_imgs, std::vector<Image>& var_i
     if (sci_imgs.size() != zeroed_times.size()) {
         throw std::runtime_error("The number of science images and zeroed times do not match.");
     }
-    width = sci_imgs[0].get_width();
-    height = sci_imgs[0].get_height();
+    width = sci_imgs[0].cols();
+    height = sci_imgs[0].rows();
 
     // Set the parameters for the search.
     set_default_parameters(num_bytes);
 
     // Compute the psi/phi array.
     DebugTimer timer = DebugTimer("preparing Psi and Phi images", rs_logger);
-    fill_psi_phi_array_from_sci_var(psi_phi_array, num_bytes, sci_imgs, var_imgs, zeroed_times);
+    fill_psi_phi_array_from_image_arrays(psi_phi_array, num_bytes, sci_imgs, var_imgs, psf_kernels,
+                                         zeroed_times);
     timer.stop();
 }
 
@@ -174,7 +175,6 @@ void StackSearch::set_start_bounds_y(int y_min, int y_max) {
     params.y_start_min = y_min;
     params.y_start_max = y_max;
 }
-
 
 // --------------------------------------------
 // Core search functions
@@ -332,7 +332,7 @@ static void stack_search_bindings(py::module& m) {
 
     py::class_<ks>(m, "StackSearch", pydocs::DOC_StackSearch)
             .def(py::init<is&, int>(), py::arg("imstack"), py::arg("num_bytes") = -1)
-            .def(py::init<iv&, iv&, iv&, dv&, int>(), py::arg("sci_imgs"), py::arg("var_imgs"), 
+            .def(py::init<iv&, iv&, iv&, dv&, int>(), py::arg("sci_imgs"), py::arg("var_imgs"),
                  py::arg("psf_kernels"), py::arg("zeroed_times"), py::arg("num_bytes") = -1)
             .def_property_readonly("num_images", &ks::num_images)
             .def_property_readonly("height", &ks::get_image_height)

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -28,6 +28,9 @@ using Image = search::Image;
 class StackSearch {
 public:
     StackSearch(ImageStack& imstack, int num_bytes = -1);
+    StackSearch(std::vector<Image>& sci_imgs, std::vector<Image>& var_imgs,
+                std::vector<Image>& psf_kernels, std::vector<double>& zeroed_times,
+                int num_bytes = -1);
 
     // Getters
     uint64_t compute_max_results();
@@ -37,7 +40,7 @@ public:
     std::vector<double>& get_zeroed_times() { return zeroed_times; }
 
     // Parameter setters used to control the searches.
-    void set_default_parameters();
+    void set_default_parameters(int num_bytes = -1);
     void set_min_obs(int new_value);
     void set_min_lh(float new_value);
     void disable_gpu_sigmag_filter();

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -28,9 +28,8 @@ using Image = search::Image;
 class StackSearch {
 public:
     StackSearch(ImageStack& imstack, int num_bytes = -1);
-    StackSearch(std::vector<Image>& sci_imgs, std::vector<Image>& var_imgs,
-                std::vector<Image>& psf_kernels, std::vector<double>& zeroed_times,
-                int num_bytes = -1);
+    StackSearch(std::vector<Image>& sci_imgs, std::vector<Image>& var_imgs, std::vector<Image>& psf_kernels,
+                std::vector<double>& zeroed_times, int num_bytes = -1);
 
     // Getters
     uint64_t compute_max_results();

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -27,7 +27,9 @@ using Image = search::Image;
 
 class StackSearch {
 public:
-    StackSearch(ImageStack& imstack);
+    StackSearch(ImageStack& imstack, int num_bytes = -1);
+
+    // Getters
     uint64_t compute_max_results();
     unsigned int num_images() const { return num_imgs; }
     unsigned int get_image_width() const { return width; }
@@ -40,7 +42,6 @@ public:
     void set_min_lh(float new_value);
     void disable_gpu_sigmag_filter();
     void enable_gpu_sigmag_filter(std::vector<float> percentiles, float sigmag_coeff, float min_lh);
-    void enable_gpu_encoding(int num_bytes);
     void set_start_bounds_x(int x_min, int x_max);
     void set_start_bounds_y(int y_min, int y_max);
     void set_results_per_pixel(int new_value);
@@ -59,10 +60,6 @@ public:
     // Getters for the Psi and Phi data.
     Image get_all_psi_phi_curves(const std::vector<Trajectory>& trajectories);
 
-    // Helper functions for computing Psi and Phi
-    void prepare_psi_phi();
-    void clear_psi_phi();
-
     // Helper functions for testing
     void set_results(const std::vector<Trajectory>& new_results);
 
@@ -77,10 +74,7 @@ protected:
     unsigned int num_imgs;
     std::vector<double> zeroed_times;
 
-    ImageStack& stack;
-
     // Precomputed and cached search data
-    bool psi_phi_generated;
     PsiPhiArray psi_phi_array;
 
     // Results from the grid search.

--- a/src/kbmod/trajectory_explorer.py
+++ b/src/kbmod/trajectory_explorer.py
@@ -65,21 +65,15 @@ class TrajectoryExplorer:
             config = self.config
 
         if self._data_initalized:
-            # Always reapply the configuration parameters if in case we used custom
-            # ones on a previous search.
+            # Always reapply the configuration parameters (except image encoding)
+            # in case we used different parameters on a previous search.
             configure_kb_search_stack(self.search, config)
 
             # Nothing else to do
             return
 
-        # If we are using an encoded image representation on GPU, enable it and
-        # set the parameters.
-        if self.config["encode_num_bytes"] > 0:
-            self.search.enable_gpu_encoding(self.config["encode_num_bytes"])
-            logger.debug(f"Setting encoding = {self.config['encode_num_bytes']}")
-
         # Allocate the search structure.
-        self.search = StackSearch(self.im_stack)
+        self.search = StackSearch(self.im_stack, self.config["encode_num_bytes"])
         configure_kb_search_stack(self.search, config)
 
         self._data_initalized = True

--- a/tests/test_search_encode.py
+++ b/tests/test_search_encode.py
@@ -68,8 +68,7 @@ class test_search_filter(unittest.TestCase):
     def test_different_encodings(self):
         for encoding_bytes in [-1, 1, 2]:
             with self.subTest(i=encoding_bytes):
-                search = StackSearch(self.stack)
-                search.enable_gpu_encoding(encoding_bytes)
+                search = StackSearch(self.stack, encoding_bytes)
                 search.set_min_obs(int(self.img_count / 2))
                 candidates = [trj for trj in self.trj_gen]
                 search.search_all(candidates, True)


### PR DESCRIPTION
Allow a StackSearch to accept data from the C++ `ImageStack` or python lists (from the Python `ImageStackPy`) object.  This is a step toward removing the C++ `ImageStack` and `LayeredImage`.

As a consequence of this, we no longer have the `StackSearck` keep a reference to the `ImageStack`. Instead we build the `PsiPhiArray` immediately. The main consequence of this is that we can no longer change the number of bytes used for encoding (it needs to be specified up front), which we never did in the code anyway.  We use a default of 4 bytes (input value of -1).  This change also simplifies the interface a bit by removing the need for prepare and clear. The data is prepared when the object is created and cleared when the object is deleted.