### PR TITLE
Replace the fake data generation with the Python ImageStackPy

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,40 +92,17 @@ A short example injecting a simulated object into a stack of images, and then re
 ```python
 
 import kbmod.search as kb
-from kbmod.candidate_generator import KBMODV1Search
-import numpy as np
-
-# Create a point spread function
-psf = kb.PSF(1.5)
+from kbmod.trajectory_generator import KBMODV1Search
+from kbmod.fake_data.fake_data_creator import *
 
 # Create fake data with ten 512x512 pixel images and starting at MJD of 57130.2.
-from kbmod.fake_data.fake_data_creator import *
 fake_times = create_fake_times(10, t0=57130.2)
 ds = FakeDataSet(512, 512, fake_times)
-imgs = ds.stack.get_images()
 
-# Get the timestamp of the first image.
-t0 = imgs[0].get_obstime()
-print(f"Image times start at {t0}.")
-
-# Specify an artificial object
-flux = 275.0
-position = (10.7, 15.3)
-velocity = (2, 0)
-
-# Inject object into images
-for im in imgs:
-    dt = im.get_obstime() - t0
-    add_fake_object(
-        im,
-        position[0] + dt * velocity[0],
-        position[1] + dt * velocity[1],
-        flux,
-        psf,
-    )
-
-# Create a new image stack with the inserted object.
-stack = kb.ImageStack(imgs)
+# Insert an artificial object with starting position x=2, y=0,
+# velocity vx=10.7, vy=15.3, and flux = 275.0.
+trj = kb.Trajectory(x=2, y=0, vx=10.7, vy=15.3, flux=275.0)
+ds.insert_object(trj)
 
 # Generate a set of trajectories to test from each pixel.
 gen = KBMODV1Search(
@@ -138,8 +115,14 @@ gen = KBMODV1Search(
 )
 candidates = [trj for trj in gen]
 
-# Do the actual search (on CPU).
-search = kb.StackSearch(stack)
+# Do the actual search (on CPU).  This requires passing in the science
+# images, the variance images, the PSF information, and the times.
+search = kb.StackSearch(
+    ds.stack_py.sci,
+    ds.stack_py.var,
+    ds.stack_py.psfs,
+    ds.stack_py.zeroed_times,
+)
 search.set_min_obs(7)
 search.search_all(candidates, False)
 

--- a/notebooks/TrajectoryExplorer.ipynb
+++ b/notebooks/TrajectoryExplorer.ipynb
@@ -63,7 +63,7 @@
     "fake_ds.insert_object(fake_trj)\n",
     "\n",
     "# Display the image from the first time step.\n",
-    "img = fake_ds.stack.get_single_image(0).sci\n",
+    "img = fake_ds.stack_py.sci[0]\n",
     "plt.imshow(img, cmap=\"gray\")"
    ]
   },
@@ -85,12 +85,12 @@
     "pred_x = int(50 + 5.0 * dt)\n",
     "pred_y = int(60 - 2.0 * dt)\n",
     "\n",
-    "sci_t6 = fake_ds.stack.get_single_image(6).sci\n",
+    "sci_t6 = fake_ds.stack_py.sci[6]\n",
     "for dy in [-2, -1, 0, 1, 2]:\n",
     "    for dx in [-2, -1, 0, 1, 2]:\n",
     "        sci_t6[pred_y + dy, pred_x + dx] = 0.00001\n",
     "\n",
-    "img = fake_ds.stack.get_single_image(6).sci\n",
+    "img = fake_ds.stack_py.sci[6]\n",
     "plt.imshow(img, cmap=\"gray\")"
    ]
   },
@@ -111,7 +111,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "explorer = TrajectoryExplorer(fake_ds.stack)\n",
+    "explorer = TrajectoryExplorer(fake_ds.stack_py)\n",
     "\n",
     "result = explorer.evaluate_linear_trajectory(50, 60, 5.0, -2.0, use_kernel=True)\n",
     "print(result)"

--- a/notebooks/create_fake_data.ipynb
+++ b/notebooks/create_fake_data.ipynb
@@ -78,9 +78,9 @@
    "outputs": [],
    "source": [
     "# Check the object was inserted correctly.\n",
-    "t0 = ds.stack.get_single_image(0).time\n",
-    "for i in range(ds.stack.num_times):\n",
-    "    ti = ds.stack.get_single_image(i).time\n",
+    "t0 = ds.stack_py.times[0]\n",
+    "for i in range(ds.stack_py.num_times):\n",
+    "    ti = ds.stack_py.times[i]\n",
     "    dt = ti - t0\n",
     "    px = int(trj.x + dt * trj.vx + 0.5)\n",
     "    py = int(trj.y + dt * trj.vy + 0.5)\n",
@@ -118,7 +118,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.imshow(ds.stack.get_single_image(0).sci)"
+    "plt.imshow(ds.stack_py.sci[0])"
    ]
   },
   {
@@ -127,7 +127,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.imshow(ds.stack.get_single_image(num_times - 1).sci)"
+    "plt.imshow(ds.stack_py.sci[num_times - 1])"
    ]
   },
   {

--- a/notebooks/kbmod_evaluate_clustering.ipynb
+++ b/notebooks/kbmod_evaluate_clustering.ipynb
@@ -130,6 +130,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "63cec295-9118-4ed4-b25e-4839d174c360",
+   "metadata": {},
+   "source": [
+    "We convert the image stack to a C++ object (this is temporary while we finish removing the C++ ob jects).  TODO: Remove this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01ebf097-e135-4d23-a94b-334831436438",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from kbmod.image_utils import image_stack_py_to_cpp\n",
+    "stack = image_stack_py_to_cpp(fake_ds.stack_py)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "849af398-eb57-457a-9b36-a529febe6233",
    "metadata": {},
    "source": [
@@ -169,7 +188,7 @@
     "\n",
     "# Do the actual search.\n",
     "search = SearchRunner()\n",
-    "results = search.do_gpu_search(config, fake_ds.stack, trj_generator)\n",
+    "results = search.do_core_search(config, stack, trj_generator)\n",
     "print(f\"Ran search and generated {len(results)} results.\")"
    ]
   },

--- a/notebooks/kbmod_evaluate_clustering.ipynb
+++ b/notebooks/kbmod_evaluate_clustering.ipynb
@@ -144,6 +144,7 @@
    "outputs": [],
    "source": [
     "from kbmod.image_utils import image_stack_py_to_cpp\n",
+    "\n",
     "stack = image_stack_py_to_cpp(fake_ds.stack_py)"
    ]
   },

--- a/src/kbmod/core/image_stack_py.py
+++ b/src/kbmod/core/image_stack_py.py
@@ -538,7 +538,7 @@ class ImageStackPy:
         return is_valid
 
 
-def make_fake_image_stack(height, width, times, noise_level=2.0, psf_val=0.5, rng=None):
+def make_fake_image_stack(height, width, times, noise_level=2.0, psf_val=0.5, psfs=None, rng=None):
     """Create a fake ImageStack for testing.
 
     Parameters
@@ -553,8 +553,10 @@ def make_fake_image_stack(height, width, times, noise_level=2.0, psf_val=0.5, rn
         The level of the background noise.
         Default: 2.0
     psf_val : float
-        The value of the default PSF.
+        The value of the default PSF.  Used if individual psfs are not specified.
         Default: 0.5
+    psfs : `list` of `numpy.ndarray`, optional
+        A list of PSF kernels. If none, Gaussian PSFs from with std=psf_val are used.
     rng : np.random.Generator
         The random number generator to use. If None creates a new random generator.
         Default: None
@@ -568,8 +570,11 @@ def make_fake_image_stack(height, width, times, noise_level=2.0, psf_val=0.5, rn
     var = [np.full((height, width), noise_level**2).astype(np.float32) for i in range(len(times))]
 
     # Create the PSF information.
-    psf_kernel = PSF.make_gaussian_kernel(psf_val)
-    psfs = [psf_kernel for i in range(len(times))]
+    if psfs is None:
+        psf_kernel = PSF.make_gaussian_kernel(psf_val)
+        psfs = [psf_kernel for i in range(len(times))]
+    elif len(psfs) != len(times):
+        raise ValueError(f"The number of PSFs ({len(psfs)}) must be the same as times ({len(times)}).")
 
     return ImageStackPy(times, sci, var, psfs=psfs)
 

--- a/src/kbmod/core/image_stack_py.py
+++ b/src/kbmod/core/image_stack_py.py
@@ -193,6 +193,26 @@ class ImageStackPy:
     def __len__(self):
         return self.num_times
 
+    def __eq__(self, other):
+        if self.num_times != other.num_times:
+            return False
+        if self.height != other.height or self.width != other.width:
+            return False
+        if not np.allclose(self.times, other.times):
+            return False
+        if not np.allclose(self.zeroed_times, other.zeroed_times):
+            return False
+
+        # Check the image data at each time.
+        for i in range(self.num_times):
+            if not np.allclose(self.sci[i], other.sci[i]):
+                return False
+            if not np.allclose(self.var[i], other.var[i]):
+                return False
+            if not np.allclose(self.psfs[i], other.psfs[i]):
+                return False
+        return True
+
     @property
     def npixels(self):
         """Return the number of pixels in each image."""
@@ -228,6 +248,17 @@ class ImageStackPy:
         if index < 0 or index >= self.num_times:
             raise IndexError(f"Index {index} out of range for ImageStack.")
         return self.times[index]
+
+    def copy(self):
+        """Make a deep copy of the image stack."""
+        new_stack = ImageStackPy(
+            times=[self.times[i] for i in range(self.num_times)],
+            sci=[np.copy(self.sci[i]) for i in range(self.num_times)],
+            var=[np.copy(self.var[i]) for i in range(self.num_times)],
+            mask=None,
+            psfs=[np.copy(self.psfs[i]) for i in range(self.num_times)],
+        )
+        return new_stack
 
     def num_masked_pixels(self):
         """Compute the number of masked pixels."""

--- a/src/kbmod/fake_data/demo_helper.py
+++ b/src/kbmod/fake_data/demo_helper.py
@@ -52,7 +52,7 @@ def make_demo_data(filename=None):
     config = SearchConfiguration.from_dict(settings)
 
     # Create a WorkUnit and save it if needed.
-    work = WorkUnit(im_stack=ds.stack, config=config, wcs=ds.fake_wcs)
+    work = WorkUnit(im_stack=ds.stack_py, config=config, wcs=ds.fake_wcs)
     if filename is not None:
         work.to_fits(filename)
     return work

--- a/src/kbmod/fake_data/fake_data_creator.py
+++ b/src/kbmod/fake_data/fake_data_creator.py
@@ -13,6 +13,10 @@ import numpy as np
 from astropy.io import fits
 
 from kbmod.configuration import SearchConfiguration
+from kbmod.core.image_stack_py import (
+    make_fake_image_stack,
+    image_stack_add_fake_object,
+)
 from kbmod.core.psf import PSF
 from kbmod.search import *
 from kbmod.work_unit import WorkUnit
@@ -75,49 +79,6 @@ def make_fake_layered_image(
     return img
 
 
-def add_fake_object(img, x, y, flux, psf=None):
-    """Add a fake object to a LayeredImage or numpy array.
-
-    Parameters
-    ----------
-    img : `LayeredImage` or `np.ndarray`
-        The image to modify.
-    x : `int` or `float`
-        The x pixel location of the fake object.
-    y : `int` or `float`
-        The y pixel location of the fake object.
-    flux : `float`
-        The flux value.
-    psf : `numpy.ndarray`
-            The PSF's kernel for the image.
-    """
-    if type(img) is LayeredImage:
-        sci = img.sci
-    elif type(img) is np.ndarray:
-        sci = img
-    else:
-        raise TypeError("Expected a LayeredImage or np.ndarray")
-
-    # Explicitly cast to float because the indexing uses different order
-    # float integer and float.
-    x = int(x)
-    y = int(y)
-
-    if psf is None:
-        if (x >= 0) and (y >= 0) and (x < sci.shape[1]) and (y < sci.shape[0]):
-            sci[y, x] = flux + sci[y, x]
-    else:
-        radius = int((psf.shape[0] - 1) / 2)
-        initial_x = int(x - radius)
-        initial_y = int(y - radius)
-        for i in range(psf.shape[0]):
-            for j in range(psf.shape[0]):
-                xp = initial_x + i
-                yp = initial_y + j
-                if (xp >= 0) and (yp >= 0) and (xp < sci.shape[1]) and (yp < sci.shape[0]):
-                    sci[yp, xp] = flux * psf[i, j] + sci[yp, xp]
-
-
 def create_fake_times(num_times, t0=0.0, obs_per_day=1, intra_night_gap=0.01, inter_night_gap=1):
     """Create a list of times based on a cluster of ``obs_per_day`` observations
     each night spaced out ``intra_night_gap`` within a night and ``inter_night_gap`` data between
@@ -160,7 +121,7 @@ def create_fake_times(num_times, t0=0.0, obs_per_day=1, intra_night_gap=0.01, in
 class FakeDataSet:
     """This class creates fake data sets for testing and demo notebooks."""
 
-    def __init__(self, width, height, times, noise_level=2.0, psf_val=0.5, use_seed=False):
+    def __init__(self, width, height, times, noise_level=2.0, psf_val=0.5, psfs=None, use_seed=False):
         """The constructor.
 
         Parameters
@@ -173,8 +134,12 @@ class FakeDataSet:
             A list of time stamps, such as produced by ``create_fake_times``.
         noise_level : `float`
             The level of the background noise.
+            Default: 2.0
         psf_val : `float`
-            The value of the default PSF std.
+            The value of the default PSF std.  Used if individual psfs are not specified.
+            Default: 0.5
+        psfs : `list` of `numpy.ndarray`, optional
+            A list of PSF kernels. If none, Gaussian PSFs from with std=psf_val are used.
         use_seed : `bool`
             Use a deterministic seed to avoid flaky tests.
         """
@@ -187,9 +152,22 @@ class FakeDataSet:
         self.trajectories = []
         self.times = times
         self.fake_wcs = None
+        
+        if use_seed:
+            rng = np.random.default_rng(101)
+        else:
+            rng = np.random.default_rng()
 
         # Make the image stack.
-        self.stack = self.make_fake_ImageStack()
+        self.stack_py = make_fake_image_stack(
+            height,
+            width,
+            times,
+            noise_level=noise_level,
+            psf_val=psf_val,
+            psfs=psfs,
+            rng=rng,
+        )
 
     def set_wcs(self, new_wcs):
         """Set a new fake WCS to be used for this data.
@@ -201,28 +179,6 @@ class FakeDataSet:
         """
         self.fake_wcs = new_wcs
 
-    def make_fake_ImageStack(self):
-        """Make a stack of fake layered images.
-
-        Returns
-        -------
-        stack : `ImageStack`
-        """
-        p = PSF.make_gaussian_kernel(self.psf_val)
-        stack = ImageStack()
-        for i in range(self.num_times):
-            img = make_fake_layered_image(
-                self.width,
-                self.height,
-                self.noise_level,
-                self.noise_level**2,
-                self.times[i],
-                p,
-                i if self.use_seed else -1,
-            )
-            stack.append_image(img, force_move=True)
-        return stack
-
     def insert_object(self, trj):
         """Insert a fake object given the trajectory.
 
@@ -231,18 +187,15 @@ class FakeDataSet:
         trj : `Trajectory`
             The trajectory of the fake object to insert.
         """
-        t0 = self.times[0]
-
-        for i in range(self.num_times):
-            dt = self.times[i] - t0
-            px = trj.get_x_pos(dt)
-            py = trj.get_y_pos(dt)
-
-            # Get the image for the timestep, add the object, and
-            # re-set the image. This last step needs to be done
-            # explicitly because of how pybind handles references.
-            current = self.stack.get_single_image(i)
-            add_fake_object(current, px, py, trj.flux, current.get_psf())
+        # Insert the object into the images.
+        image_stack_add_fake_object(
+            self.stack_py,
+            trj.x,
+            trj.y,
+            trj.vx,
+            trj.vy,
+            trj.flux,
+        )
 
         # Save the trajectory into the internal list.
         self.trajectories.append(trj)
@@ -290,7 +243,7 @@ class FakeDataSet:
         """
         if config is None:
             config = SearchConfiguration()
-        work = WorkUnit(im_stack=self.stack, config=config, wcs=self.fake_wcs)
+        work = WorkUnit(im_stack=self.stack_py, config=config, wcs=self.fake_wcs)
         return work
     
     def save_fake_data_to_work_unit(self, filename, config=None):

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -19,7 +19,7 @@ from tqdm import tqdm
 from kbmod import is_interactive
 from kbmod.configuration import SearchConfiguration
 from kbmod.core.image_stack_py import ImageStackPy
-from kbmod.image_utils import image_stack_from_components, stat_image_stack, validate_image_stack
+from kbmod.image_utils import image_stack_py_to_cpp, stat_image_stack, validate_image_stack
 from kbmod.reprojection_utils import invert_correct_parallax
 from kbmod.search import ImageStack, LayeredImage, Logging, Trajectory
 from kbmod.util_functions import get_matched_obstimes
@@ -132,12 +132,7 @@ class WorkUnit:
         # Add a temporary bridge to convert the Python ImageStackPy into the C++
         # version. This uses force_move and destroys the original im_stack.
         if isinstance(im_stack, ImageStackPy):
-            im_stack = image_stack_from_components(
-                im_stack.times,
-                im_stack.sci,
-                im_stack.var,
-                psfs=im_stack.psfs,
-            )
+            im_stack = image_stack_py_to_cpp(im_stack)
 
         # Assign the core components.
         self.im_stack = im_stack

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -1021,7 +1021,8 @@ def add_image_data_to_hdul(
     wcs=None,
 ):
     """Add the image data for a single time step to a fits file's HDUL as individual
-    layers for science, variance, etc.
+    layers for science, variance, etc.  Masked pixels in the science and variance
+    layers are added to the masked bits.
 
     Parameters
     ----------
@@ -1042,18 +1043,30 @@ def add_image_data_to_hdul(
     wcs : `astropy.wcs.WCS`, optional
         An optional WCS to include in the header.
     """
+    # Certain compression schemes can have trouble with NaNs. So we mask
+    # those out in science and variance and replace them with zeros.
+    sci_valid = np.isfinite(sci)
+    sci_masked = np.copy(sci)
+    sci_masked[~sci_valid] = 0.0
+
+    var_valid = np.isfinite(var)
+    var_masked = np.copy(var)
+    var_masked[~var_valid] = 0.0
+
     # Use a high quantize_level to preserve most of the image information.
     # In the tests a level of 100.0 did not add much noise, but we use
     # 500.0 here to be conservative.
-    sci_hdu = fits.CompImageHDU(sci, compression_type="RICE_1", quantize_level=500.0)
+    sci_hdu = fits.CompImageHDU(sci_masked, compression_type="RICE_1", quantize_level=500.0)
     sci_hdu.name = f"SCI_{idx}"
     sci_hdu.header["MJD"] = obstime
 
-    var_hdu = fits.CompImageHDU(var, compression_type="RICE_1", quantize_level=500.0)
+    var_hdu = fits.CompImageHDU(var_masked, compression_type="RICE_1", quantize_level=500.0)
     var_hdu.name = f"VAR_{idx}"
     var_hdu.header["MJD"] = obstime
 
-    mask_hdu = fits.ImageHDU((mask > 0).astype(np.int8))
+    # The saved mask is a binarized version of which pixels are valid.
+    mask_full = (mask > 0) | (~sci_valid) | (~var_valid)
+    mask_hdu = fits.ImageHDU(mask_full.astype(np.int8))
     mask_hdu.name = f"MSK_{idx}"
     mask_hdu.header["MJD"] = obstime
 
@@ -1078,6 +1091,7 @@ def add_image_data_to_hdul(
 
 def read_image_data_from_hdul(hdul, idx):
     """Read the image data for a single time step to a fits file's HDUL.
+    The mask is auto-applied to the science and variance layers.
 
     Parameters
     ----------
@@ -1111,9 +1125,12 @@ def read_image_data_from_hdul(hdul, idx):
     # Get the variance layer.
     var = hdul[f"VAR_{idx}"].data.astype(np.single)
 
-    # Allow the mask to be optional. Use an empty mask if none is present.
+    # Allow the mask to be optional. Apply the mask if it is present
+    # and use an empty mask if there is no mask layer.
     if f"MSK_{idx}" in hdul:
         mask = hdul[f"MSK_{idx}"].data.astype(np.single)
+        sci[mask > 0] = np.nan
+        var[mask > 0] = np.nan
     else:
         mask = np.zeros_like(sci)
 

--- a/tests/test_cpu_search_algorithms.py
+++ b/tests/test_cpu_search_algorithms.py
@@ -5,7 +5,7 @@ import numpy as np
 from kbmod.fake_data.fake_data_creator import create_fake_times, FakeDataSet
 from kbmod.search import (
     evaluate_trajectory_cpu,
-    fill_psi_phi_array_from_image_stack,
+    fill_psi_phi_array_from_image_arrays,
     search_cpu_only,
     PsiPhiArray,
     SearchParameters,
@@ -30,7 +30,14 @@ class test_cpu_search_algorithms(unittest.TestCase):
 
         # Create the phi and psi data.
         self.psi_phi = PsiPhiArray()
-        fill_psi_phi_array_from_image_stack(self.psi_phi, self.fake_ds.stack, 4)
+        fill_psi_phi_array_from_image_arrays(
+            self.psi_phi,
+            4,
+            self.fake_ds.stack_py.sci,
+            self.fake_ds.stack_py.var,
+            self.fake_ds.stack_py.psfs,
+            self.fake_ds.stack_py.zeroed_times,
+        )
 
     def test_evaluate_trajectory_cpu(self):
         candidate = Trajectory(

--- a/tests/test_image_stack.py
+++ b/tests/test_image_stack.py
@@ -1,7 +1,7 @@
 import unittest
 
 from kbmod.core.psf import PSF
-from kbmod.fake_data.fake_data_creator import add_fake_object, make_fake_layered_image
+from kbmod.fake_data.fake_data_creator import make_fake_layered_image
 from kbmod.search import *
 
 
@@ -96,18 +96,6 @@ class test_ImageStack(unittest.TestCase):
         self.assertEqual(len(times), self.num_images)
         for i in range(self.num_images):
             self.assertEqual(times[i], 2.0 * i)
-
-    def test_different_psfs(self):
-        # Add a stationary fake object to each image. Then test that
-        # the flux at each time is monotonically increasing (because
-        # the PSF is getting tighter).
-        last_val = -100.0
-        for i in range(self.num_images):
-            img = self.im_stack.get_single_image(i)
-            add_fake_object(img, 10, 20, 500.0, self.p[i])
-            pix_val = img.sci[20, 10]
-            self.assertGreater(pix_val, last_val)
-            last_val = pix_val
 
     def test_sort_by_time(self):
         local_psf = PSF.make_gaussian_kernel(1.0)

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -5,7 +5,7 @@ import unittest
 from kbmod.core.image_stack_py import ImageStackPy
 from kbmod.core.psf import PSF
 from kbmod.fake_data.fake_data_creator import create_fake_times, FakeDataSet
-from kbmod.search import Trajectory
+from kbmod.search import ImageStack, LayeredImage, Trajectory
 
 from kbmod.image_utils import (
     count_valid_images,
@@ -25,10 +25,20 @@ class test_image_utils(unittest.TestCase):
         width = 10
         height = 12
 
-        fake_times = np.arange(num_times)
-        fake_ds = FakeDataSet(width, height, fake_times, use_seed=True)
+        img_list = []
+        for i in range(num_times):
+            img = LayeredImage(
+                np.random.normal(0.0, 0.5, (height, width)).astype(np.float32),
+                np.full((height, width), 0.1).astype(np.float32),
+                np.zeros((height, width)).astype(np.float32),
+                np.array([[1.0]]),
+                float(i),
+            )
+            img_list.append(img)
+        im_stack = ImageStack(img_list)
 
-        image_stack_py = image_stack_cpp_to_py(fake_ds.stack)
+        # Do the conversion.
+        image_stack_py = image_stack_cpp_to_py(im_stack)
 
         # Check that we extracted the layers for each image.
         for idx in range(num_times):
@@ -39,12 +49,10 @@ class test_image_utils(unittest.TestCase):
             self.assertEqual(var_array.shape, (height, width))
 
             # Compare to the C++ version.
-            img = fake_ds.stack.get_single_image(idx)
+            img = im_stack.get_single_image(idx)
             self.assertTrue(np.allclose(sci_array, img.sci))
             self.assertTrue(np.allclose(var_array, img.var))
             self.assertTrue(np.allclose(psf_array, img.get_psf()))
-
-            self.assertAlmostEqual(image_stack_py.times[idx], fake_times[idx])
 
     def test_image_stack_from_components(self):
         """Tests that we can transform numpy arrays into an ImageStack."""
@@ -184,60 +192,47 @@ class test_image_utils(unittest.TestCase):
             25,  # width
             35,  # height
             fake_times,  # time stamps
-            1.0,  # noise level
-            0.5,  # psf value
-            True,  # Use a fixed seed for testing
+            noise_level=1.0,  # noise level
+            psf_val=0.5,  # psf value
+            use_seed=True,  # Use a fixed seed for testing
         )
 
         # Insert a single fake object with known parameters.
         trj = Trajectory(8, 7, 2.0, 1.0, flux=250.0)
         fake_ds.insert_object(trj)
 
-        # Create a Python version of the image stack.
-        stack_py = image_stack_cpp_to_py(fake_ds.stack)
-
         # Create stamps from the fake data set and Trajectory.
-        stamps = create_stamps_from_image_stack(fake_ds.stack, trj, 1)
-        stamps_py = create_stamps_from_image_stack(stack_py, trj, 1)
+        stamps = create_stamps_from_image_stack(fake_ds.stack_py, trj, 1)
         self.assertEqual(len(stamps), num_times)
-        self.assertEqual(len(stamps_py), num_times)
         for i in range(num_times):
             self.assertEqual(stamps[i].shape, (3, 3))
-            self.assertEqual(stamps_py[i].shape, (3, 3))
 
             # Compare to the (manually computed) trajectory location.
             xp = 8 + 2 * i
             yp = 7 + i
             if xp < 25 and yp < 35:
-                center_val = fake_ds.stack.get_single_image(i).sci[yp, xp]
+                center_val = fake_ds.stack_py.sci[i][yp, xp]
                 self.assertAlmostEqual(center_val, stamps[i][1, 1])
-                self.assertAlmostEqual(center_val, stamps_py[i][1, 1])
             else:
                 self.assertTrue(np.isnan(stamps[i][1, 1]))
-                self.assertTrue(np.isnan(stamps_py[i][1, 1]))
 
         # Check that we can set use_indices to produce only some stamps.
         use_times = [False, True, False, True, True, False, False, False, True, False]
-        stamps = create_stamps_from_image_stack(fake_ds.stack, trj, 1, use_times)
-        stamps_py = create_stamps_from_image_stack(stack_py, trj, 1, use_times)
+        stamps = create_stamps_from_image_stack(fake_ds.stack_py, trj, 1, to_include=use_times)
         self.assertEqual(len(stamps), np.count_nonzero(use_times))
-        self.assertEqual(len(stamps_py), np.count_nonzero(use_times))
 
         stamp_count = 0
         for i in range(num_times):
             if use_times[i]:
                 self.assertEqual(stamps[stamp_count].shape, (3, 3))
-                self.assertEqual(stamps_py[stamp_count].shape, (3, 3))
 
                 xp = 8 + 2 * i
                 yp = 7 + i
                 if xp < 25 and yp < 35:
-                    center_val = fake_ds.stack.get_single_image(i).sci[yp, xp]
-                    self.assertAlmostEqual(center_val, stamps[stamp_count][1, 1])
+                    center_val = fake_ds.stack_py.sci[i][yp, xp]
                     self.assertAlmostEqual(center_val, stamps[stamp_count][1, 1])
                 else:
-                    self.assertTrue(np.isnan(stamps_py[stamp_count][1, 1]))
-                    self.assertTrue(np.isnan(stamps_py[stamp_count][1, 1]))
+                    self.assertTrue(np.isnan(stamps[stamp_count][1, 1]))
 
                 stamp_count += 1
 
@@ -249,60 +244,47 @@ class test_image_utils(unittest.TestCase):
             25,  # width
             35,  # height
             fake_times,  # time stamps
-            1.0,  # noise level
-            0.5,  # psf value
-            True,  # Use a fixed seed for testing
+            noise_level=1.0,  # noise level
+            psf_val=0.5,  # psf value
+            use_seed=True,  # Use a fixed seed for testing
         )
 
         # Insert a single fake object with known parameters.
         trj = Trajectory(8, 7, 2.0, 1.0, flux=250.0)
         fake_ds.insert_object(trj)
 
-        # Create a Python version of the image stack.
-        stack_py = image_stack_cpp_to_py(fake_ds.stack)
-
-        zeroed_times = np.array(fake_ds.stack.zeroed_times)
+        zeroed_times = np.array(fake_ds.stack_py.zeroed_times)
         xvals = (trj.x + trj.vx * zeroed_times + 0.5).astype(int)
         yvals = (trj.y + trj.vy * zeroed_times + 0.5).astype(int)
-        stamps = create_stamps_from_image_stack_xy(fake_ds.stack, 1, xvals, yvals)
-        stamps_py = create_stamps_from_image_stack_xy(stack_py, 1, xvals, yvals)
+        stamps = create_stamps_from_image_stack_xy(fake_ds.stack_py, 1, xvals, yvals)
         self.assertEqual(len(stamps), num_times)
-        self.assertEqual(len(stamps_py), num_times)
         for i in range(num_times):
             self.assertEqual(stamps[i].shape, (3, 3))
-            self.assertEqual(stamps_py[i].shape, (3, 3))
 
             # Compare to the (manually computed) trajectory location.
             xp = 8 + 2 * i
             yp = 7 + i
             if xp < 25 and yp < 35:
-                center_val = fake_ds.stack.get_single_image(i).sci[yp, xp]
+                center_val = fake_ds.stack_py.sci[i][yp, xp]
                 self.assertAlmostEqual(center_val, stamps[i][1, 1])
-                self.assertAlmostEqual(center_val, stamps_py[i][1, 1])
             else:
                 self.assertTrue(np.isnan(stamps[i][1, 1]))
-                self.assertTrue(np.isnan(stamps_py[i][1, 1]))
 
         # Check that we can set use_indices to produce only some stamps.
         use_inds = np.array([1, 2, 3, 5, 6])
-        stamps = create_stamps_from_image_stack_xy(fake_ds.stack, 1, xvals, yvals, to_include=use_inds)
-        stamps_py = create_stamps_from_image_stack_xy(stack_py, 1, xvals, yvals, to_include=use_inds)
+        stamps = create_stamps_from_image_stack_xy(fake_ds.stack_py, 1, xvals, yvals, to_include=use_inds)
         self.assertEqual(len(stamps), len(use_inds))
-        self.assertEqual(len(stamps_py), len(use_inds))
 
         for stamp_i, image_i in enumerate(use_inds):
             self.assertEqual(stamps[stamp_i].shape, (3, 3))
-            self.assertEqual(stamps_py[stamp_i].shape, (3, 3))
 
             xp = 8 + 2 * image_i
             yp = 7 + image_i
             if xp < 25 and yp < 35:
-                center_val = fake_ds.stack.get_single_image(image_i).sci[yp, xp]
+                center_val = fake_ds.stack_py.sci[image_i][yp, xp]
                 self.assertAlmostEqual(center_val, stamps[stamp_i][1, 1])
-                self.assertAlmostEqual(center_val, stamps_py[stamp_i][1, 1])
             else:
                 self.assertTrue(np.isnan(stamps[stamp_i][1, 1]))
-                self.assertTrue(np.isnan(stamps_py[stamp_i][1, 1]))
 
 
 if __name__ == "__main__":

--- a/tests/test_psi_phi_array.py
+++ b/tests/test_psi_phi_array.py
@@ -290,15 +290,22 @@ class test_psi_phi_array(unittest.TestCase):
         num_times = 5
         width = 10
         height = 12
-        fake_ds = FakeDataSet(width, height, np.arange(num_times))
+        times = 2.0 * np.arange(num_times)
+        im_stack = make_fake_image_stack(height, width, times)
 
         # Set all pixels in one of the images to NO_DATA.
-        science = fake_ds.stack.get_single_image(1).sci
-        science[:, :] = KB_NO_DATA
+        science = im_stack.sci[1][:, :] = KB_NO_DATA
 
-        # Create the PsiPhiArray from the ImageStack and 2 byte encoding.
+        # Create the PsiPhiArray from the ImageStack.
         arr = PsiPhiArray()
-        fill_psi_phi_array_from_image_stack(arr, fake_ds.stack, 2)
+        fill_psi_phi_array_from_image_arrays(
+            arr,
+            2,  # num_bytes
+            im_stack.sci,
+            im_stack.var,
+            im_stack.psfs,
+            im_stack.zeroed_times,
+        )
 
         # Check the meta data.
         self.assertEqual(arr.num_times, num_times)

--- a/tests/test_psi_phi_array.py
+++ b/tests/test_psi_phi_array.py
@@ -187,7 +187,6 @@ class test_psi_phi_array(unittest.TestCase):
         num_times = 5
         width = 21
         height = 15
-        im_stack = make_fake_layered_image
         images = [None] * num_times
         p = PSF.make_gaussian_kernel(1.0)
         for i in range(num_times):

--- a/tests/test_python_parity.py
+++ b/tests/test_python_parity.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from kbmod.core.psf import convolve_psf_and_image, PSF
 from kbmod.fake_data.fake_data_creator import FakeDataSet
+from kbmod.image_utils import image_stack_py_to_cpp
 from kbmod.search import (
     convolve_image,
     fill_psi_phi_array,
@@ -101,16 +102,17 @@ class test_python_parity(unittest.TestCase):
         height = 300
         times = np.arange(num_times)
         fake_ds = FakeDataSet(width, height, times)
+        im_stack = image_stack_py_to_cpp(fake_ds.stack_py)
 
         # Create the PsiPhiArray from the ImageStack.
         arr_c = PsiPhiArray()
-        fill_psi_phi_array_from_image_stack(arr_c, fake_ds.stack, 2)
+        fill_psi_phi_array_from_image_stack(arr_c, im_stack, 2)
 
         # Process the images using the Python functions.
         psi_arr = []
         phi_arr = []
         for idx in range(num_times):
-            layered_img = fake_ds.stack.get_single_image(idx)
+            layered_img = im_stack.get_single_image(idx)
             psi, phi = generate_psi_phi_images(
                 layered_img.sci,
                 layered_img.var,

--- a/tests/test_regression_test.py
+++ b/tests/test_regression_test.py
@@ -11,8 +11,9 @@ import unittest
 import numpy as np
 
 from kbmod.configuration import SearchConfiguration
+from kbmod.core.image_stack_py import image_stack_add_fake_object, make_fake_image_stack
 from kbmod.core.psf import PSF
-from kbmod.fake_data.fake_data_creator import add_fake_object, make_fake_layered_image
+from kbmod.image_utils import image_stack_py_to_cpp
 from kbmod.results import Results
 from kbmod.run_search import SearchRunner
 from kbmod.search import *
@@ -22,7 +23,7 @@ from kbmod.work_unit import WorkUnit
 logger = logging.getLogger(__name__)
 
 
-def make_fake_ImageStack(times, trjs, psf_vals):
+def make_fake_images(times, trjs, psf_vals):
     """Make a stack of fake layered images.
 
     Parameters
@@ -42,23 +43,15 @@ def make_fake_ImageStack(times, trjs, psf_vals):
     t0 = times[0]
     dim_x = 512
     dim_y = 1024
-    noise_level = 4.0
-    variance = noise_level**2
 
-    imlist = []
-    for i in range(imCount):
-        p = PSF.make_gaussian_kernel(psf_vals[i])
-        time = times[i] - t0
+    # Create the array of PSF kernels.
+    psfs = [PSF.make_gaussian_kernel(psf_vals[i]) for i in range(imCount)]
 
-        img = make_fake_layered_image(dim_x, dim_y, noise_level, variance, times[i], p, seed=i)
-
-        for trj in trjs:
-            px = trj.x + time * trj.vx + 0.5
-            py = trj.y + time * trj.vy + 0.5
-            add_fake_object(img, px, py, trj.flux, p)
-
-        imlist.append(img)
-    stack = ImageStack(imlist)
+    # Create the data, including fake objects.
+    rng = np.random.default_rng(1001)
+    stack = make_fake_image_stack(dim_y, dim_x, times, noise_level=4.0, psfs=psfs, rng=rng)
+    for trj in trjs:
+        image_stack_add_fake_object(stack, trj.x, trj.y, trj.vx, trj.vy, trj.flux)
     return stack
 
 
@@ -189,7 +182,8 @@ def run_full_test():
             # Set PSF values between +/- 0.1 around the default value.
             psf_vals.append(default_psf - 0.1 + 0.1 * (i % 3))
 
-        stack = make_fake_ImageStack(times, trjs, psf_vals)
+        stack_py = make_fake_images(times, trjs, psf_vals)
+        stack = image_stack_py_to_cpp(stack_py)
 
         # Do the search.
         result_filename = os.path.join(dir_name, "results.ecsv")

--- a/tests/test_search_encode.py
+++ b/tests/test_search_encode.py
@@ -53,7 +53,7 @@ class test_search_filter(unittest.TestCase):
             use_seed=True,
         )
         fake_ds.insert_object(self.trj)
-        self.stack = fake_ds.stack
+        self.stack = fake_ds.stack_py
 
         self.trj_gen = KBMODV1Search(
             self.velocity_steps,
@@ -68,7 +68,13 @@ class test_search_filter(unittest.TestCase):
     def test_different_encodings(self):
         for encoding_bytes in [-1, 1, 2]:
             with self.subTest(i=encoding_bytes):
-                search = StackSearch(self.stack, encoding_bytes)
+                search = StackSearch(
+                    self.stack.sci,
+                    self.stack.var,
+                    self.stack.psfs,
+                    self.stack.zeroed_times,
+                    encoding_bytes,
+                )
                 search.set_min_obs(int(self.img_count / 2))
                 candidates = [trj for trj in self.trj_gen]
                 search.search_all(candidates, True)

--- a/tests/test_stack_search_results.py
+++ b/tests/test_stack_search_results.py
@@ -20,7 +20,12 @@ class test_search(unittest.TestCase):
         for _ in range(self.num_objs):
             self.fake_ds.insert_random_object(500)
 
-        self.search = StackSearch(self.fake_ds.stack)
+        self.search = StackSearch(
+            self.fake_ds.stack_py.sci,
+            self.fake_ds.stack_py.var,
+            self.fake_ds.stack_py.psfs,
+            self.fake_ds.stack_py.zeroed_times,
+        )
         self.fake_trjs = self.fake_ds.trajectories
 
     def test_set_get_results(self):
@@ -127,7 +132,12 @@ class test_search(unittest.TestCase):
             fake_ds.insert_object(trj)
 
         # Create the stack search and insert the fake results.
-        search = StackSearch(fake_ds.stack)
+        search = StackSearch(
+            fake_ds.stack_py.sci,
+            fake_ds.stack_py.var,
+            fake_ds.stack_py.psfs,
+            fake_ds.stack_py.zeroed_times,
+        )
         search.set_results(trjs)
 
         # Do the loading and filtering.

--- a/tests/test_stamp_filters.py
+++ b/tests/test_stamp_filters.py
@@ -20,15 +20,13 @@ class test_stamp_filters(unittest.TestCase):
             self.fake_times,  # time stamps
             1.0,  # noise level
             0.5,  # psf value
-            True,  # Use a fixed seed for testing
+            psfs=None,  # No per-image PSFs
+            use_seed=True,  # Use a fixed seed for testing
         )
 
         # Insert a single fake object with known parameters.
         self.trj = Trajectory(8, 7, 2.0, 1.0, flux=250.0)
         self.ds.insert_object(self.trj)
-
-        # Create a Python version of the image stack.
-        self.stack_py = image_stack_cpp_to_py(self.ds.stack)
 
         current_dir = pathlib.Path(__file__).parent.resolve()
         self.model_path = pathlib.Path(current_dir, "data/test_model.keras")
@@ -47,30 +45,19 @@ class test_stamp_filters(unittest.TestCase):
 
         # Make the stamps.
         coadd_types = ["mean"]
-        append_coadds(keep, self.ds.stack, coadd_types, 5)
+        append_coadds(keep, self.ds.stack_py, coadd_types, 5)
 
         # We do not filter, so everything should be saved.
         self.assertTrue("coadd_mean" in keep.colnames)
         self.assertEqual(len(keep), 4)
         self.assertEqual(keep["coadd_mean"][0].shape, (11, 11))
 
-        # Check that we get the same coadd values if we use a Python image stack.
-        keep2 = Results.from_trajectories(trj_list)
-        append_coadds(keep2, self.stack_py, coadd_types, 5)
-        self.assertTrue("coadd_mean" in keep2.colnames)
-        self.assertEqual(len(keep2), 4)
-        self.assertEqual(keep2["coadd_mean"][0].shape, (11, 11))
-
-        # Check that the coadd values are the same.
-        for i in range(len(keep)):
-            np.testing.assert_allclose(keep["coadd_mean"][i], keep2["coadd_mean"][i])
-
     def test_get_coadds_and_filter_with_invalid(self):
         valid1 = [True] * self.image_count
         valid2 = [True] * self.image_count
         # Completely mess up some of the images.
         for i in [1, 3, 6, 7, 9]:
-            self.ds.stack.get_single_image(i).sci[:, :] = 1000.0
+            self.ds.stack_py.sci[i][:, :] = 1000.0
             valid2[i] = False
 
         # Create the Results with nearly identical trajectories,
@@ -80,16 +67,9 @@ class test_stamp_filters(unittest.TestCase):
         keep.update_obs_valid(np.array([valid1, valid2]))
 
         # Make the stamps and check that there were saved.
-        append_coadds(keep, self.ds.stack, ["mean"], 5)
+        append_coadds(keep, self.ds.stack_py, ["mean"], 5)
         self.assertTrue("coadd_mean" in keep.colnames)
         self.assertEqual(len(keep), 2)
-
-        # Check that we get the coadd values if we use a Python image stack.
-        keep2 = Results.from_trajectories([self.trj, trj2])
-        keep2.update_obs_valid(np.array([valid1, valid2]))
-        append_coadds(keep2, self.stack_py, ["mean"], 5)
-        self.assertTrue("coadd_mean" in keep2.colnames)
-        self.assertEqual(len(keep2), 2)
 
     def test_append_coadds(self):
         # Create trajectories to test: 0) known good, 1) completely wrong
@@ -110,7 +90,7 @@ class test_stamp_filters(unittest.TestCase):
         self.assertFalse("stamp" in keep.colnames)
 
         # Adding nothing does nothing.
-        append_coadds(keep, self.ds.stack, [], 3)
+        append_coadds(keep, self.ds.stack_py, [], 3)
         self.assertFalse("coadd_sum" in keep.colnames)
         self.assertFalse("coadd_mean" in keep.colnames)
         self.assertFalse("coadd_median" in keep.colnames)
@@ -118,7 +98,7 @@ class test_stamp_filters(unittest.TestCase):
         self.assertFalse("stamp" in keep.colnames)
 
         # Adding "mean" and "median" does only those.
-        append_coadds(keep, self.ds.stack, ["median", "mean"], 3)
+        append_coadds(keep, self.ds.stack_py, ["median", "mean"], 3)
         self.assertFalse("coadd_sum" in keep.colnames)
         self.assertTrue("coadd_mean" in keep.colnames)
         self.assertTrue("coadd_median" in keep.colnames)
@@ -126,7 +106,7 @@ class test_stamp_filters(unittest.TestCase):
         self.assertFalse("stamp" in keep.colnames)
 
         # We can add "weighted" later.
-        append_coadds(keep, self.ds.stack, ["weighted"], 3)
+        append_coadds(keep, self.ds.stack_py, ["weighted"], 3)
         self.assertFalse("coadd_sum" in keep.colnames)
         self.assertTrue("coadd_mean" in keep.colnames)
         self.assertTrue("coadd_median" in keep.colnames)
@@ -148,7 +128,7 @@ class test_stamp_filters(unittest.TestCase):
         keep = Results.from_trajectories(trj_list)
         self.assertFalse("all_stamps" in keep.colnames)
 
-        append_all_stamps(keep, self.ds.stack, 5)
+        append_all_stamps(keep, self.ds.stack_py, 5)
         self.assertTrue("all_stamps" in keep.colnames)
         for i in range(len(keep)):
             stamps_array = keep["all_stamps"][i]
@@ -158,18 +138,8 @@ class test_stamp_filters(unittest.TestCase):
 
         # Check that everything works if the results are empty.
         keep2 = Results.from_trajectories([])
-        append_all_stamps(keep2, self.ds.stack, 5)
+        append_all_stamps(keep2, self.ds.stack_py, 5)
         self.assertTrue("all_stamps" in keep2.colnames)
-
-        # Check that everything works with a Python image stack.
-        keep3 = Results.from_trajectories(trj_list)
-        append_all_stamps(keep3, self.stack_py, 5)
-        self.assertTrue("all_stamps" in keep3.colnames)
-        for i in range(len(keep3)):
-            stamps_array = keep3["all_stamps"][i]
-            self.assertEqual(stamps_array.shape[0], self.image_count)
-            self.assertEqual(stamps_array.shape[1], 11)
-            self.assertEqual(stamps_array.shape[2], 11)
 
     def test_filter_stamps_by_cnn(self):
         trj_list = [
@@ -178,7 +148,7 @@ class test_stamp_filters(unittest.TestCase):
             Trajectory(self.trj.x + 2, self.trj.y + 2, self.trj.vx, self.trj.vy),
         ]
         keep = Results.from_trajectories(trj_list)
-        append_coadds(keep, self.ds.stack, ["mean"], 3)
+        append_coadds(keep, self.ds.stack_py, ["mean"], 3)
 
         filter_stamps_by_cnn(
             keep,

--- a/tests/test_stamp_filters.py
+++ b/tests/test_stamp_filters.py
@@ -2,9 +2,8 @@ import numpy as np
 import pathlib
 import unittest
 
-from kbmod.core.image_stack_py import ImageStackPy
 from kbmod.fake_data.fake_data_creator import create_fake_times, FakeDataSet
-from kbmod.image_utils import extract_sci_images_from_stack, extract_var_images_from_stack
+from kbmod.image_utils import image_stack_cpp_to_py
 from kbmod.filters.stamp_filters import *
 from kbmod.results import Results
 from kbmod.search import *
@@ -29,11 +28,7 @@ class test_stamp_filters(unittest.TestCase):
         self.ds.insert_object(self.trj)
 
         # Create a Python version of the image stack.
-        self.stack_py = ImageStackPy(
-            times=self.fake_times,
-            sci=extract_sci_images_from_stack(self.ds.stack),
-            var=extract_var_images_from_stack(self.ds.stack),
-        )
+        self.stack_py = image_stack_cpp_to_py(self.ds.stack)
 
         current_dir = pathlib.Path(__file__).parent.resolve()
         self.model_path = pathlib.Path(current_dir, "data/test_model.keras")

--- a/tests/test_trajectory_explorer.py
+++ b/tests/test_trajectory_explorer.py
@@ -37,12 +37,12 @@ class test_trajectory_explorer(unittest.TestCase):
         # Remove at least one observation from the trajectory.
         pred_x = self.trj.get_x_index(fake_times[10])
         pred_y = self.trj.get_y_index(fake_times[10])
-        sci_t10 = self.fake_ds.stack.get_single_image(10).sci
+        sci_t10 = self.fake_ds.stack_py.sci[10]
         for dy in [-1, 0, 1]:
             for dx in [-1, 0, 1]:
                 sci_t10[pred_y + dy, pred_x + dx] = 0.0001
 
-        self.explorer = TrajectoryExplorer(self.fake_ds.stack)
+        self.explorer = TrajectoryExplorer(self.fake_ds.stack_py)
 
     def test_evaluate_trajectory(self):
         result = self.explorer.evaluate_linear_trajectory(self.x0, self.y0, self.vx, self.vy, False)
@@ -85,7 +85,7 @@ class test_trajectory_explorer(unittest.TestCase):
         """Test that we get the same results with GPU or CPU-only code."""
         config = SearchConfiguration()
         config.set("gpu_filter", False)
-        explorer2 = TrajectoryExplorer(self.fake_ds.stack, config=config)
+        explorer2 = TrajectoryExplorer(self.fake_ds.stack_py, config=config)
         result1 = explorer2.evaluate_linear_trajectory(self.x0, self.y0, self.vx, self.vy, True)
         result2 = explorer2.evaluate_linear_trajectory(self.x0, self.y0, self.vx, self.vy, False)
 

--- a/tests/test_trajectory_generator.py
+++ b/tests/test_trajectory_generator.py
@@ -197,7 +197,7 @@ class test_trajectory_generator(unittest.TestCase):
 
         fake_data = FakeDataSet(10, 10, [0.0])
         base_config = SearchConfiguration()
-        fake_work = WorkUnit(im_stack=fake_data.stack, config=base_config, wcs=fake_wcs)
+        fake_work = WorkUnit(im_stack=fake_data.stack_py, config=base_config, wcs=fake_wcs)
         fake_ecliptic = fake_work.compute_ecliptic_angle()
         self.assertGreater(fake_ecliptic, 1.0)
 

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -32,16 +32,17 @@ class test_work_unit(unittest.TestCase):
         self.width = 50
         self.height = 70
         self.images = [None] * self.num_images
-        self.p = [None] * self.num_images
+        self.psfs = [PSF.make_gaussian_kernel(5.0 / float(2 * i + 1)) for i in range(self.num_images)]
+        self.times = [59000.0 + (2.0 * i + 1.0) for i in range(self.num_images)]
+
         for i in range(self.num_images):
-            self.p[i] = PSF.make_gaussian_kernel(5.0 / float(2 * i + 1))
             self.images[i] = make_fake_layered_image(
                 self.width,
                 self.height,
                 2.0,  # noise_level
                 4.0,  # variance
-                59000.0 + (2.0 * i + 1.0),  # time
-                self.p[i],
+                self.times[i],
+                self.psfs[i],
             )
 
             # Include one masked pixel per time step at (10, 10 + i).
@@ -247,7 +248,7 @@ class test_work_unit(unittest.TestCase):
                 self.assertTrue(np.allclose(li.mask, li_org.mask, atol=0.001, equal_nan=True))
 
                 # Check the PSF layer matches.
-                p1 = self.p[i]
+                p1 = self.psfs[i]
                 p2 = li.get_psf()
                 npt.assert_array_almost_equal(p1, p2, decimal=3)
 
@@ -307,7 +308,7 @@ class test_work_unit(unittest.TestCase):
                 self.assertTrue(np.allclose(li.mask, li_org.mask, atol=0.001, equal_nan=True))
 
                 # Check the PSF layer matches.
-                p1 = self.p[i]
+                p1 = self.psfs[i]
                 p2 = li.get_psf()
                 npt.assert_array_almost_equal(p1, p2, decimal=3)
 

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -46,7 +46,8 @@ class test_work_unit(unittest.TestCase):
             rng=rng,
         )
 
-        # Mask one of the pixels in each image.
+        # Mask one of the pixels in each image.  This is done directly to the science
+        # and variance layers since ImageStackPy does not have a separate mask layer.
         for i in range(self.num_images):
             self.im_stack_py.sci[i][10, 10 + i] = np.nan
             self.im_stack_py.var[i][10, 10 + i] = np.nan

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -59,7 +59,7 @@ class test_work_unit(unittest.TestCase):
 
         # Create a fake WCS
         self.wcs = make_fake_wcs(200.6145, -7.7888, 500, 700, 0.00027)
-        self.per_image_wcs = per_image_wcs = [self.wcs for i in range(self.num_images)]
+        self.per_image_wcs = [self.wcs for i in range(self.num_images)]
 
         self.diff_wcs = []
         for i in range(self.num_images):

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -58,7 +58,7 @@ class test_work_unit(unittest.TestCase):
         # Manually set the mask layer to be the same as the science and variance layers.
         # We use this for testing loaded WorkUnits.
         for i in range(self.num_images):
-            self.im_stack.mask[i][10, 10 + i] = 1
+            self.im_stack.get_single_image(i).mask[10, 10 + i] = 1
 
         self.config = SearchConfiguration()
         self.config.set("result_filename", "Here")

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -25,8 +25,6 @@ from kbmod.work_unit import (
     WorkUnit,
 )
 
-import numpy.testing as npt
-
 
 class test_work_unit(unittest.TestCase):
     def setUp(self):
@@ -37,12 +35,14 @@ class test_work_unit(unittest.TestCase):
         self.psfs = [PSF.make_gaussian_kernel(5.0 / float(2 * i + 1)) for i in range(self.num_images)]
         self.times = [59000.0 + (2.0 * i + 1.0) for i in range(self.num_images)]
 
+        rng = np.random.default_rng(1002)
         self.im_stack = make_fake_image_stack(
             self.height,
             self.width,
             self.times,
             noise_level=2.0,
             psfs=self.psfs,
+            rng=rng,
         )
 
         # Mask one of the pixels in each image.

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -46,6 +46,11 @@ class test_work_unit(unittest.TestCase):
             rng=rng,
         )
 
+        # Mask one of the pixels in each image.
+        for i in range(self.num_images):
+            self.im_stack_py.sci[i][10, 10 + i] = np.nan
+            self.im_stack_py.var[i][10, 10 + i] = np.nan
+
         # Create a C++ image stack using a copy of the Python image stack.
         self.im_stack = image_stack_py_to_cpp(self.im_stack_py.copy())
 

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -13,8 +13,8 @@ import unittest
 import warnings
 
 from kbmod.configuration import SearchConfiguration
-from kbmod.core.image_stack_py import make_fake_image_stack
 from kbmod.core.psf import PSF
+from kbmod.fake_data.fake_data_creator import make_fake_layered_image
 import kbmod.search as kb
 from kbmod.reprojection_utils import fit_barycentric_wcs
 from kbmod.wcs_utils import make_fake_wcs, wcs_fits_equal
@@ -31,24 +31,24 @@ class test_work_unit(unittest.TestCase):
         self.num_images = 5
         self.width = 50
         self.height = 70
-
-        self.psfs = [PSF.make_gaussian_kernel(5.0 / float(2 * i + 1)) for i in range(self.num_images)]
-        self.times = [59000.0 + (2.0 * i + 1.0) for i in range(self.num_images)]
-
-        rng = np.random.default_rng(1002)
-        self.im_stack = make_fake_image_stack(
-            self.height,
-            self.width,
-            self.times,
-            noise_level=2.0,
-            psfs=self.psfs,
-            rng=rng,
-        )
-
-        # Mask one of the pixels in each image.
+        self.images = [None] * self.num_images
+        self.p = [None] * self.num_images
         for i in range(self.num_images):
-            self.im_stack.sci[i][10, 10 + i] = np.nan
-            self.im_stack.var[i][10, 10 + i] = np.nan
+            self.p[i] = PSF.make_gaussian_kernel(5.0 / float(2 * i + 1))
+            self.images[i] = make_fake_layered_image(
+                self.width,
+                self.height,
+                2.0,  # noise_level
+                4.0,  # variance
+                59000.0 + (2.0 * i + 1.0),  # time
+                self.p[i],
+            )
+
+            # Include one masked pixel per time step at (10, 10 + i).
+            mask = self.images[i].mask
+            mask[10, 10 + i] = 1
+
+        self.im_stack = kb.ImageStack(self.images)
 
         self.config = SearchConfiguration()
         self.config.set("result_filename", "Here")
@@ -247,7 +247,7 @@ class test_work_unit(unittest.TestCase):
                 self.assertTrue(np.allclose(li.mask, li_org.mask, atol=0.001, equal_nan=True))
 
                 # Check the PSF layer matches.
-                p1 = self.psfs[i]
+                p1 = self.p[i]
                 p2 = li.get_psf()
                 npt.assert_array_almost_equal(p1, p2, decimal=3)
 
@@ -307,7 +307,7 @@ class test_work_unit(unittest.TestCase):
                 self.assertTrue(np.allclose(li.mask, li_org.mask, atol=0.001, equal_nan=True))
 
                 # Check the PSF layer matches.
-                p1 = self.psfs[i]
+                p1 = self.p[i]
                 p2 = li.get_psf()
                 npt.assert_array_almost_equal(p1, p2, decimal=3)
 

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -55,6 +55,11 @@ class test_work_unit(unittest.TestCase):
         # Create a C++ image stack using a copy of the Python image stack.
         self.im_stack = image_stack_py_to_cpp(self.im_stack_py.copy())
 
+        # Manually set the mask layer to be the same as the science and variance layers.
+        # We use this for testing loaded WorkUnits.
+        for i in range(self.num_images):
+            self.im_stack.mask[i][10, 10 + i] = 1
+
         self.config = SearchConfiguration()
         self.config.set("result_filename", "Here")
         self.config.set("num_obs", self.num_images)


### PR DESCRIPTION
This PR removes the C++ `ImageStack` from (most of) the fake data generation tools and tests.  The `FakeDataSet` now creates an `ImageStackPy` for the data and inserts the objects into that. To make any changes clearer, the name of the attribute was changed from `stack` to `stack_py` (which made it much easier to find places where I hadn't changed the code yet).

The PR also adds a bunch of helper functionality to make this change easier including:
- Allow `make_fake_image_stack()` to take a list of PSF kernels.
- Add functions to convert between the C++ and Python image stack types.
- Allow `TrajectoryExplorer` to take either type of image stack.