### PR TITLE
Fix a bug with compressing NaNs in FITs

### DIFF
--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -1026,7 +1026,8 @@ def add_image_data_to_hdul(
     wcs=None,
 ):
     """Add the image data for a single time step to a fits file's HDUL as individual
-    layers for science, variance, etc.
+    layers for science, variance, etc.  Masked pixels in the science and variance
+    layers are added to the masked bits.
 
     Parameters
     ----------
@@ -1095,6 +1096,7 @@ def add_image_data_to_hdul(
 
 def read_image_data_from_hdul(hdul, idx):
     """Read the image data for a single time step to a fits file's HDUL.
+    The mask is auto-applied to the science and variance layers.
 
     Parameters
     ----------

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -1047,18 +1047,30 @@ def add_image_data_to_hdul(
     wcs : `astropy.wcs.WCS`, optional
         An optional WCS to include in the header.
     """
+    # Certain compression schemes can have trouble with NaNs. So we mask
+    # those out in science and variance and replace them with zeros.
+    sci_valid = np.isfinite(sci)
+    sci_masked = np.copy(sci)
+    sci_masked[~sci_valid] = 0.0
+
+    var_valid = np.isfinite(var)
+    var_masked = np.copy(var)
+    var_masked[~var_valid] = 0.0
+
     # Use a high quantize_level to preserve most of the image information.
     # In the tests a level of 100.0 did not add much noise, but we use
     # 500.0 here to be conservative.
-    sci_hdu = fits.CompImageHDU(sci, compression_type="RICE_1", quantize_level=500.0)
+    sci_hdu = fits.CompImageHDU(sci_masked, compression_type="RICE_1", quantize_level=500.0)
     sci_hdu.name = f"SCI_{idx}"
     sci_hdu.header["MJD"] = obstime
 
-    var_hdu = fits.CompImageHDU(var, compression_type="RICE_1", quantize_level=500.0)
+    var_hdu = fits.CompImageHDU(var_masked, compression_type="RICE_1", quantize_level=500.0)
     var_hdu.name = f"VAR_{idx}"
     var_hdu.header["MJD"] = obstime
 
-    mask_hdu = fits.ImageHDU((mask > 0).astype(np.int8))
+    # The saved mask is a binarized version of which pixels are valid.
+    mask_full = (mask > 0) | (~sci_valid) | (~var_valid)
+    mask_hdu = fits.ImageHDU(mask_full.astype(np.int8))
     mask_hdu.name = f"MSK_{idx}"
     mask_hdu.header["MJD"] = obstime
 
@@ -1116,9 +1128,12 @@ def read_image_data_from_hdul(hdul, idx):
     # Get the variance layer.
     var = hdul[f"VAR_{idx}"].data.astype(np.single)
 
-    # Allow the mask to be optional. Use an empty mask if none is present.
+    # Allow the mask to be optional. Apply the mask if it is present
+    # and use an empty mask if there is no mask layer.
     if f"MSK_{idx}" in hdul:
         mask = hdul[f"MSK_{idx}"].data.astype(np.single)
+        sci[mask > 0] = np.nan
+        var[mask > 0] = np.nan
     else:
         mask = np.zeros_like(sci)
 

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -47,8 +47,8 @@ class test_work_unit(unittest.TestCase):
             )
 
             # Include one masked pixel per time step at (10, 10 + i).
-            mask = self.images[i].mask
-            mask[10, 10 + i] = 1
+            self.images[i].mask[10, 10 + i] = 1
+            self.images[i].apply_mask(0xFFFFFF)
 
         self.im_stack = kb.ImageStack(self.images)
 


### PR DESCRIPTION
For some types of compression, we may see problems writing and then reading NaNs to fits. I don't think we have seen this in any of our runs, because we always apply the mask (and thus set pixels to nan) after reading the `WorkUnit` and before running the search. But we could run into problems in the future if we try to save a `WorkUnit` whose mask has already been applied.

This PR fixes the issue by: 
1) When writing a WorkUnit:
    a) moving all NaN pixels to bits in the mask layer
    b) replace the NaNs in the science and variance layers with 0.0
2) When writing the WorkUnit: apply masking immediately to the science and variance layers.