### PR TITLE
Allow fuzzing/disordering of WorkUnit obstimes

### DIFF
--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -430,7 +430,8 @@ class WorkUnit:
         # been sorted so we do this to preserve that expectation after reordering.
         self.im_stack.sort_by_time()
 
-        # Reset the cached obstimes to use what was sorted in the ImageStack.
+        # Clear metadata and reset the cached obstimes to use what was sorted in the ImageStack.
+        self.clear_metadata()
         self._obstimes = None
 
     @classmethod
@@ -1037,6 +1038,11 @@ class WorkUnit:
         config_filename = f"{base_filename}_config.yaml"
         config_path = provenance_dir_path.joinpath(config_filename)
         self.config.to_file(config_path, overwrite)
+
+    def clear_metadata(self):
+        """Clear all WorkUnit metadata."""
+        self.org_img_meta = Table()
+        self._per_image_indices = [[i] for i in range(self.n_constituents)]
 
 
 def load_layered_image_from_shard(file_path):

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -383,7 +383,7 @@ class WorkUnit:
     def disorder_obstimes(self):
         """Reorders the timestamps in the WorkUnit to be random. Random offsets
         are chosen for each unique obstime and added to the original obstime.
-        The maximum offset is the number of time in the ImageStack or
+        The maximum offset is the number of images/times in the ImageStack or
         the difference between the maximum and minimum obstime.
 
         The offsets are applied such that images will have a shared

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -383,8 +383,8 @@ class WorkUnit:
     def disorder_obstimes(self):
         """Reorders the timestamps in the WorkUnit to be random. Random offsets
         are chosen for each unique obstime and added to the original obstime.
-        The maximum offset should not be greater than the original the maximum
-        time difference among the images in the WorkUnit.
+        The maximum offset is the number of time in the ImageStack or
+        the difference between the maximum and minimum obstime.
 
         The offsets are applied such that images will have a shared
         obstime if they did so before this method was called.
@@ -401,7 +401,9 @@ class WorkUnit:
 
         # Randomly select an offset between 0 and the max time difference
         # which can be added to the minimum time. This should be randomly
-        # sampled *without* replacement so that we don't have duplicate times
+        # sampled *without* replacement so that we don't have duplicate times. Note
+        # if the max time difference is less than the number of times in the im_stack,
+        # we will use the number of times in the im_stack as the max offset.
         max_offset = max(np.max(unique_obstimes) - np.min(unique_obstimes) + 1, self.im_stack.num_times)
         random_offsets = np.random.choice(
             np.arange(0, max_offset),

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -402,7 +402,7 @@ class WorkUnit:
         # Randomly select an offset between 0 and the max time difference
         # which can be added to the minimum time. This should be randomly
         # sampled *without* replacement so that we don't have duplicate times
-        max_offset = np.max(unique_obstimes) - np.min(unique_obstimes)
+        max_offset = max(np.max(unique_obstimes) - np.min(unique_obstimes) + 1, self.im_stack.num_times)
         random_offsets = np.random.choice(
             np.arange(0, max_offset),
             len(unique_obstimes),  # Generate an offset for each unique obstime

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -690,6 +690,47 @@ class test_work_unit(unittest.TestCase):
             np.array([1.0, 300.0]),  # time
         )
 
+    def test_disorder_obstimes(self):
+        # Check that we can disorder the obstimes.
+        work = WorkUnit(
+            im_stack=self.im_stack,
+            config=self.config,
+            wcs=self.per_image_ebd_wcs,
+            barycentric_distance=41.0,
+            org_image_meta=self.org_image_meta,
+        )
+        # Set numpy random seed
+        np.random.seed(0)
+
+        # Check that the obstimes are in order.
+        obstimes = work.get_all_obstimes()
+        # Disorder the obstimes.
+        work.disorder_obstimes()
+
+        # Check that the obstimes have changed
+        disordered_obstimes = work.get_all_obstimes()
+        self.assertNotEqual(disordered_obstimes, obstimes)
+
+        # Check that the range of obstimes is unchanged
+        self.assertGreaterEqual(min(disordered_obstimes), min(obstimes))
+        time_range = max(obstimes) - min(obstimes)
+        self.assertLessEqual(max(disordered_obstimes), max(obstimes) + time_range)
+
+        # Check that uniqueness is preserved by comparing the frequency maps of obstimes
+        disordered_obstimes_freq = {}
+        obstime_freq = {}
+        for obstime in obstimes:
+            if obstime not in obstime_freq:
+                obstime_freq[obstime] = 0
+            obstime_freq[obstime] += 1
+
+        for obstime in disordered_obstimes:
+            if obstime not in disordered_obstimes_freq:
+                disordered_obstimes_freq[obstime] = 0
+            disordered_obstimes_freq[obstime] += 1
+
+        self.assertEqual(sorted(obstime_freq.values()), sorted(disordered_obstimes_freq.values()))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -690,6 +690,34 @@ class test_work_unit(unittest.TestCase):
             np.array([1.0, 300.0]),  # time
         )
 
+    def test_clear_metadata(self):
+        """Test that we can clear the metadata from a WorkUnit."""
+        work = WorkUnit(
+            im_stack=self.im_stack,
+            config=self.config,
+            wcs=self.per_image_ebd_wcs,
+            barycentric_distance=41.0,
+            org_image_meta=self.org_image_meta,
+        )
+        # Change the per image metadata to something other than the default
+        work._per_image_indices[3] = [3, 4]
+        default_img_indices = [[i] for i in range(self.num_images)]
+
+        # Check that the metadata is present.
+        self.assertEqual(len(work.org_img_meta), self.num_images)
+
+        # Check thet the per_image_idices are not a single single mapping
+        # to the original image.
+        self.assertNotEqual(work._per_image_indices, default_img_indices)
+
+        # Clear the metadata.
+        work.clear_metadata()
+
+        # Check that the metadata has been cleared.
+        self.assertEqual(len(work.org_img_meta), 0)
+        self.assertEqual(len(work.org_img_meta.columns), 0)
+        self.assertEqual(work._per_image_indices, default_img_indices)
+
     def test_disorder_obstimes(self):
         # Check that we can disorder the obstimes.
         test_times = [
@@ -712,6 +740,9 @@ class test_work_unit(unittest.TestCase):
                 barycentric_distance=41.0,
                 org_image_meta=self.org_image_meta,
             )
+            # Change the per image metadata to something other than the default
+            work._per_image_indices[3] = [3, 4]
+
             # Set numpy random seed
             np.random.seed(0)
 
@@ -746,6 +777,11 @@ class test_work_unit(unittest.TestCase):
                 disordered_obstimes_freq[obstime] += 1
 
             self.assertEqual(sorted(obstime_freq.values()), sorted(disordered_obstimes_freq.values()))
+
+            # Check that old metadata was cleared
+            self.assertEqual(len(work.org_img_meta), 0)
+            self.assertEqual(len(work.org_img_meta.columns), 0)
+            self.assertEqual(work._per_image_indices, [[i] for i in range(self.num_images)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Applies random fuzzing to the obstimes of the WorkUnit for the purposes of generating unreasonable KBMOD search results for the purposes of ML training (AKA known negative results).

This should work on a WorkUnit whether or not it has been reflex-corrected. If there are multiple images with the same obstime, they will be mapped to the same new obstime (preserving mosaicking when later reprojected). The ImageStack is also sorted afterwards to preserve the sorted WorkUnit ordering caused by reflex-correcting/resampling.