### PR TITLE
Clean up ImageStackPy masking helpers

### DIFF
--- a/docs/source/user_manual/input_files.rst
+++ b/docs/source/user_manual/input_files.rst
@@ -27,6 +27,6 @@ If loading data from raw FITS files, these must be Vera C. Rubin Science Pipelin
 * variance image, representing per-pixel noise levels, and a
 * pixel bitmask
 
-stored in 1st, 2nd and 3rd header extension/plane respectively. The zeroth header extension is expected to contain the image metadata. A single FITS file can be loaded with the :py:meth:`~kbmod.util_functions.load_deccam_layered_image` function, which takes the file name and a :py:class:`~kbmod.search.PSF` object and produces a :py:class:`~kbmod.search.LayeredImage`.
+stored in 1st, 2nd and 3rd header extension/plane respectively. The zeroth header extension is expected to contain the image metadata. A single FITS file can be loaded with the :py:meth:`~kbmod.util_functions.load_deccam_layered_image` function, which takes the file name and an optional numpy array of the PSF kernel and produces a :py:class:`~kbmod.core.image_stack_py.LayeredImagePy`.
 
 To build an :py:class:`~kbmod.image_collection.ImageCollection` from multiple FITS files, use the class's :py:meth:`~kbmod.image_collection.ImageCollection.fromDir()` function. The images within a single run are expected to be warped, i.e. geometrically transformed to a set of images with a consistent and uniform relationship between sky coordinates and image pixels on a shared pixel grid. 

--- a/src/kbmod/analysis/analyze_fakes.py
+++ b/src/kbmod/analysis/analyze_fakes.py
@@ -28,7 +28,7 @@ class FakeInfo:
         The name of the object.
     image_inds : `np.ndarray`
         For each observation of the fake the corresponding image index in the
-        WorkUnit's ImageStack.
+        WorkUnit's image stack.
         Initially None until join_with_workunit() is called.
     x_pos_fakes : `np.ndarray`
         The x pixel position of the fakes.

--- a/src/kbmod/analysis/plotting.py
+++ b/src/kbmod/analysis/plotting.py
@@ -7,14 +7,13 @@ import astropy.units as u
 from astropy.wcs import WCS
 from astropy.nddata.utils import Cutout2D
 from astropy.utils.exceptions import AstropyWarning
-from astropy.visualization import simple_norm, ZScaleInterval, AsinhStretch, ImageNormalize
+from astropy.visualization import ZScaleInterval, AsinhStretch, ImageNormalize
 
 import matplotlib.pyplot as plt
 
+from kbmod.core.image_stack_py import ImageStackPy, LayeredImagePy
 from kbmod.reprojection_utils import correct_parallax_geometrically_vectorized
 from kbmod.search import ImageStack, LayeredImage
-from kbmod.results import Results
-from kbmod.trajectory_generator import TrajectoryGenerator
 
 __all__ = [
     "iter_over_obj",
@@ -358,7 +357,7 @@ def plot_image(img, ax=None, figure=None, norm=True, title=None, show_counts=Tru
 
     Parameters
     ----------
-    img : `np.ndarray` or `LayeredImage`
+    img : `np.ndarray`, `LayeredImage`, or `LayeredImagePy`
         The image data.
     ax : `matplotlib.pyplot.Axes` or `None`
         Axes, `None` by default.
@@ -394,7 +393,9 @@ def plot_image(img, ax=None, figure=None, norm=True, title=None, show_counts=Tru
         pass
 
     # Check the image's type and convert to an numpy array.
-    if type(img) is LayeredImage:
+    if isinstance(img, LayeredImage):
+        img = img.sci
+    elif isinstance(img, LayeredImagePy):
         img = img.sci
 
     # If the image array is 1-dimensional, see if it can be unpacked into a square
@@ -437,7 +438,7 @@ def plot_multiple_images(images, figure=None, columns=3, labels=None, norm=False
 
     Parameters
     ----------
-    images : a `list`, `numpy.ndarray`, or `ImageStack` of images.
+    images : a `list`, `numpy.ndarray`, `ImageStack`, or `ImageStackPy` of images.
         The series of images to plot.
     figure : `matplotlib.pyplot.Figure` or `None`
         Figure, ``None`` by default.
@@ -454,12 +455,17 @@ def plot_multiple_images(images, figure=None, columns=3, labels=None, norm=False
     clim: `tuple` or `list(tuple)` or `None`
         The minimum and maximum values for the colormap (vmin, vmax).
     """
-    # Automatically unpack an ImageStack.
-    if type(images) is ImageStack:
+    # Automatically unpack an ImageStack and ImageStackPy.
+    if isinstance(images, ImageStack):
         num_imgs = images.num_times
         if labels is None:
             labels = [f"{images.get_obstime(i)}" for i in range(num_imgs)]
         images = [images.get_single_image(i).sci for i in range(num_imgs)]
+    elif isinstance(images, ImageStackPy):
+        num_imgs = images.num_times
+        if labels is None:
+            labels = [f"{images.times[i]}" for i in range(num_imgs)]
+        images = images.sci
 
     num_imgs = len(images)
     num_rows = math.ceil(num_imgs / columns)

--- a/src/kbmod/core/image_stack_py.py
+++ b/src/kbmod/core/image_stack_py.py
@@ -261,11 +261,29 @@ class ImageStackPy:
         return new_stack
 
     def num_masked_pixels(self):
-        """Compute the number of masked pixels."""
-        total = 0
-        for img in self.sci:
-            total += np.sum(np.isnan(img))
-        return total
+        """Compute the number of masked pixels at each time step.
+
+        Returns
+        -------
+        num_masked : `np.ndarray`
+            The count of masked pixels at each time step.
+        """
+        num_masked = np.zeros(self.num_times)
+        for idx in range(self.num_times):
+            num_masked[idx] = np.count_nonzero(np.isnan(self.sci[idx]) | np.isnan(self.var[idx]))
+        return num_masked
+
+    def get_masked_fractions(self):
+        """Compute the fraction of masked pixels for each image.
+
+        Returns
+        -------
+        masked_fraction : np.ndarray
+            An array of the fraction of pixels that are masked.
+        """
+        total_pixels = float(self.width * self.height)
+        num_masked = self.num_masked_pixels()
+        return num_masked / total_pixels
 
     def get_mask(self, index):
         """Get the mask for a given time step.  Creates the mask on the fly.
@@ -368,23 +386,6 @@ class ImageStackPy:
             self.zeroed_times = self.times - self.times[0]
         else:
             self.zeroed_times = []
-
-    def get_masked_fractions(self):
-        """Compute the fraction of masked pixels for each image.
-
-        Returns
-        -------
-        masked_fraction : np.ndarray
-            An array of the fraction of pixels that are masked.
-        """
-        masked_fraction = np.zeros(self.num_times)
-        total_pixels = float(self.width * self.height)
-
-        # Iterate through the list checking each image.
-        for idx in range(self.num_times):
-            is_masked = np.isnan(self.sci[idx]) | np.isnan(self.var[idx])
-            masked_fraction[idx] = np.count_nonzero(is_masked) / total_pixels
-        return masked_fraction
 
     def mask_by_science_bounds(self, min_val=-1e20, max_val=1e20):
         """Mask pixels whose value in the science layer lies outside the given bounds.

--- a/src/kbmod/core/image_stack_py.py
+++ b/src/kbmod/core/image_stack_py.py
@@ -267,6 +267,23 @@ class ImageStackPy:
             total += np.sum(np.isnan(img))
         return total
 
+    def get_mask(self, index):
+        """Get the mask for a given time step.  Creates the mask on the fly.
+
+        Parameters
+        ----------
+        index : int
+            The index of the image.
+
+        Returns
+        -------
+        mask : np.array
+            The mask for the image.
+        """
+        if index < 0 or index >= self.num_times:
+            raise IndexError(f"Index {index} out of range for image stack.")
+        return np.isnan(self.sci[index]) | np.isnan(self.var[index])
+
     def append_image(self, time, sci, var, mask=None, psf=None):
         """Append an image onto the back of the stack.
 

--- a/src/kbmod/fake_data/demo_helper.py
+++ b/src/kbmod/fake_data/demo_helper.py
@@ -4,7 +4,7 @@ and some of the tests.
 
 from kbmod.configuration import SearchConfiguration
 from kbmod.fake_data.fake_data_creator import *
-from kbmod.search import *
+from kbmod.search import Trajectory
 
 def make_demo_data(filename=None):
     """Make the fake demo data.

--- a/src/kbmod/image_collection.py
+++ b/src/kbmod/image_collection.py
@@ -1048,12 +1048,12 @@ class ImageCollection:
 
         logger.info("Building WorkUnit from ImageCollection")
 
-        # Extract data from each standardizer and each LayeredImage within
+        # Extract data from each standardizer and each LayeredImagePy within
         # that standardizer.
-        layeredImages = []
+        layered_images = []
         for std in self.get_standardizers(**kwargs):
             for img in std["std"].toLayeredImage():
-                layeredImages.append(img)
+                layered_images.append(img)
 
         # Extract all of the relevant metadata from the ImageCollection.
         metadata = Table(self.toBinTableHDU().data)
@@ -1062,7 +1062,7 @@ class ImageCollection:
 
         # Create the basic WorkUnit from the ImageStackPy.
         imgstack = ImageStackPy()
-        for layimg in layeredImages:
+        for layimg in layered_images:
             imgstack.append_layered_image(layimg)
         work = WorkUnit(imgstack, search_config, org_image_meta=metadata)
 

--- a/src/kbmod/reprojection.py
+++ b/src/kbmod/reprojection.py
@@ -2,7 +2,6 @@ import numpy as np
 import concurrent.futures
 import reproject
 from astropy.nddata import CCDData
-from astropy.wcs import WCS
 from tqdm.asyncio import tqdm
 
 from kbmod import is_interactive
@@ -12,7 +11,6 @@ from kbmod.work_unit import (
     read_image_data_from_hdul,
     WorkUnit,
 )
-from kbmod.wcs_utils import append_wcs_to_hdu_header
 from astropy.io import fits
 import os
 from copy import copy

--- a/src/kbmod/search/cpu_search_algorithms.cpp
+++ b/src/kbmod/search/cpu_search_algorithms.cpp
@@ -93,18 +93,18 @@ void search_cpu_only(PsiPhiArray& psi_phi_array, SearchParameters params, Trajec
     uint64_t total_results = params.results_per_pixel * search_height * search_width;
     results.resize(total_results);
 
-    // Test each pixel using a giant nested loop.  Allow omp to dynamically
-    // thread the computations.
-    #pragma omp parallel for collapse(2) schedule(dynamic)
+// Test each pixel using a giant nested loop.  Allow omp to dynamically
+// thread the computations.
+#pragma omp parallel for collapse(2) schedule(dynamic)
     for (int y_i = 0; y_i < search_height; ++y_i) {
         for (int x_i = 0; x_i < search_width; ++x_i) {
             std::vector<Trajectory> pixel_res =
                     evaluate_single_pixel(y_i + params.y_start_min, x_i + params.x_start_min, psi_phi_array,
                                           trj_to_search, params.results_per_pixel);
 
-            // We restrict the writing of results to a single thread.  The batch of results
-            // is inserted into a specific location within the full results list.
-            #pragma omp critical
+// We restrict the writing of results to a single thread.  The batch of results
+// is inserted into a specific location within the full results list.
+#pragma omp critical
             {
                 uint64_t start_ind = (y_i * search_width + x_i) * params.results_per_pixel;
                 for (uint64_t i = 0; i < params.results_per_pixel; ++i) {

--- a/src/kbmod/search/pydocs/stack_search_docs.h
+++ b/src/kbmod/search/pydocs/stack_search_docs.h
@@ -3,9 +3,8 @@
 
 namespace pydocs {
 static const auto DOC_StackSearch = R"doc(
-  The data and configuration needed for KBMOD's core search. It is created
-  using a *reference* to the ``ImageStack``. The underlying ``ImageStack``
-  must exist for the life of the ``StackSearch`` object's life.
+  The data and configuration needed for KBMOD's core search. It is created using either
+  a *reference* to the ``ImageStack`` or lists of science, variance, and PSF information.
 
   Attributes
   ----------

--- a/src/kbmod/util_functions.py
+++ b/src/kbmod/util_functions.py
@@ -7,7 +7,7 @@ from astropy.io import fits
 from astropy.time import Time
 from itertools import product
 
-from kbmod.search import LayeredImage
+from kbmod.core.image_stack_py import LayeredImagePy
 
 
 def get_matched_obstimes(obs_times, query_times, threshold=0.0007):
@@ -71,12 +71,12 @@ def load_deccam_layered_image(filename, psf):
     ----------
     filename : `str`
         The name of the file to load.
-    psf : `np.ndarray`
+    psf : `np.ndarray`, optional
         The PSF to use for the image.
 
     Returns
     -------
-    img : `LayeredImage`
+    img : `LayeredImagePy`
         The loaded image.
 
     Raises
@@ -105,12 +105,12 @@ def load_deccam_layered_image(filename, psf):
                     obstime = Time(value, scale=timesys).mjd
                     break
 
-        img = LayeredImage(
+        img = LayeredImagePy(
             hdul[1].data.astype(np.float32),  # Science
             hdul[3].data.astype(np.float32),  # Variance
-            hdul[2].data.astype(np.float32),  # Mask
-            psf,
-            obstime,
+            mask=hdul[2].data.astype(np.float32),  # Mask
+            time=obstime,
+            psf=psf,
         )
 
     return img

--- a/tests/test_image_stack_py.py
+++ b/tests/test_image_stack_py.py
@@ -47,7 +47,7 @@ class test_image_stack_py(unittest.TestCase):
         self.assertEqual(stack.height, height)
         self.assertEqual(stack.npixels, height * width)
         self.assertEqual(stack.total_pixels, num_times * height * width)
-        self.assertEqual(stack.num_masked_pixels(), 0)
+        self.assertTrue(np.all(stack.num_masked_pixels() == 0))
 
         self.assertTrue(np.allclose(stack.times, times))
         self.assertTrue(np.allclose(stack.zeroed_times, np.arange(num_times)))
@@ -125,7 +125,7 @@ class test_image_stack_py(unittest.TestCase):
         self.assertEqual(stack.npixels, height * width)
         self.assertEqual(stack.total_pixels, num_times * height * width)
         self.assertEqual(stack.get_total_pixels(), num_times * height * width)
-        self.assertEqual(stack.num_masked_pixels(), 0)
+        self.assertTrue(np.all(stack.num_masked_pixels() == 0))
 
         self.assertTrue(np.allclose(stack.times, times))
         self.assertTrue(np.allclose(stack.zeroed_times, np.arange(num_times)))
@@ -155,7 +155,7 @@ class test_image_stack_py(unittest.TestCase):
         self.assertEqual(stack.height, height)
         self.assertEqual(stack.npixels, height * width)
         self.assertEqual(stack.total_pixels, num_times * height * width)
-        self.assertEqual(stack.num_masked_pixels(), 3)
+        self.assertTrue(np.array_equal(stack.num_masked_pixels(), [2, 0, 1, 0, 0]))
 
         self.assertTrue(np.allclose(stack.times, times))
         self.assertTrue(np.allclose(stack.zeroed_times, np.arange(num_times)))
@@ -300,7 +300,7 @@ class test_image_stack_py(unittest.TestCase):
         self.assertEqual(fake_stack.height, 200)
         self.assertEqual(fake_stack.npixels, 200 * 300)
         self.assertEqual(fake_stack.total_pixels, 10 * 200 * 300)
-        self.assertEqual(fake_stack.num_masked_pixels(), 0)
+        self.assertTrue(np.all(fake_stack.num_masked_pixels() == 0))
         self.assertEqual(len(fake_stack.sci), 10)
         self.assertEqual(len(fake_stack.var), 10)
         for idx in range(10):

--- a/tests/test_image_stack_py.py
+++ b/tests/test_image_stack_py.py
@@ -161,6 +161,7 @@ class test_image_stack_py(unittest.TestCase):
         self.assertTrue(np.allclose(stack.zeroed_times, np.arange(num_times)))
 
         for idx in range(num_times):
+            img_mask = stack.get_mask(idx)
             mask_mask = mask[idx] > 0
 
             self.assertTrue(np.all(stack.sci[idx][~mask_mask] == 1.0))
@@ -168,6 +169,8 @@ class test_image_stack_py(unittest.TestCase):
 
             self.assertTrue(np.all(stack.var[idx][~mask_mask] == 0.1))
             self.assertTrue(np.all(np.isnan(stack.var[idx][mask_mask])))
+
+            self.assertTrue(np.array_equal(img_mask, mask_mask))
 
     def test_get_set_image_stack_py(self):
         """Test that we can get and set the data at a single time step of ImageStackPy"""

--- a/tests/test_stack_search_results.py
+++ b/tests/test_stack_search_results.py
@@ -5,7 +5,7 @@ import numpy as np
 from kbmod.configuration import SearchConfiguration
 from kbmod.fake_data.fake_data_creator import create_fake_times, FakeDataSet
 from kbmod.run_search import SearchRunner
-from kbmod.search import ImageStack, LayeredImage, StackSearch, Trajectory
+from kbmod.search import StackSearch, Trajectory
 
 
 class test_search(unittest.TestCase):
@@ -81,23 +81,27 @@ class test_search(unittest.TestCase):
         width = 4
         num_times = 5
 
-        images = []
+        times = np.arange(num_times, dtype=np.float32)
+        sci_imgs = []
+        var_imgs = []
+        psf = []
         expected_psi = []
         expected_phi = []
+
         for i in range(num_times):
-            img = LayeredImage(
-                np.full((height, width), float(i), dtype=np.float32),  # sci
-                np.full((height, width), 0.1, dtype=np.float32),  # var
-                np.zeros((height, width), dtype=np.float32),  # mask
-                np.array([[1.0]], dtype=np.float32),  # no-op PSF
-                float(i),
-            )
-            images.append(img)
+            sci_imgs.append(np.full((height, width), float(i), dtype=np.float32))
+            var_imgs.append(np.full((height, width), 0.1, dtype=np.float32))
+            psf.append(np.array([[1.0]], dtype=np.float32))  # no-op PSF
+
             expected_psi.append(float(i) / 0.1)
             expected_phi.append(1.0 / 0.1)
 
-        stack = ImageStack(images)
-        search = StackSearch(stack)
+        search = StackSearch(
+            sci_imgs,
+            var_imgs,
+            psf,
+            times - times[0],  # zeroed times
+        )
 
         trj = Trajectory(x=2, y=2, vx=0.0, vy=0.0)
         psi_phi = search.get_all_psi_phi_curves([trj])

--- a/tests/test_standardizer.py
+++ b/tests/test_standardizer.py
@@ -334,7 +334,7 @@ class TestKBMODV1(unittest.TestCase):
         self.assertNotEqual(std2.config, std.config)
 
     def test_to_layered_image(self):
-        """Test that KBMODV1 standardizer can create LayeredImages."""
+        """Test that KBMODV1 standardizer can create LayeredImagePys."""
         conf = KBMODV1Config({"greedy_export": True})
         std = Standardizer.get(self.fits, force=KBMODV1, config=conf)
         self.assertIsInstance(std, KBMODV1)

--- a/tests/test_util_functions.py
+++ b/tests/test_util_functions.py
@@ -3,8 +3,8 @@ import unittest
 
 from pathlib import Path
 
+from kbmod.core.image_stack_py import LayeredImagePy
 from kbmod.core.psf import PSF
-from kbmod.search import LayeredImage
 from kbmod.util_functions import (
     get_matched_obstimes,
     load_deccam_layered_image,
@@ -30,7 +30,7 @@ class test_util_functions(unittest.TestCase):
         img_path = base_path / "data" / "demo_image.fits"
         img = load_deccam_layered_image(img_path, PSF.make_gaussian_kernel(1.0))
 
-        self.assertTrue(isinstance(img, LayeredImage))
+        self.assertTrue(isinstance(img, LayeredImagePy))
         self.assertGreater(img.width, 0)
         self.assertGreater(img.height, 0)
 


### PR DESCRIPTION
This PR has a bunch of small clean ups, including:
- Add a function to `ImageStackPy` that creates a mask image.
- Removing duplicate code between counting number and fraction of masked pixels.
- Change `load_deccam_layered_image` to produce a `LayeredImagePy`
- Clean up some comments that talk about C++ data structures to make them either talk about the python version or just generic "image stack".