### PR TITLE
Add a benchmark for WorkUnit Compression

### DIFF
--- a/notebooks/benchmarks/benchmark_saved_workunits.ipynb
+++ b/notebooks/benchmarks/benchmark_saved_workunits.ipynb
@@ -1,0 +1,189 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "de9fda35-2f5e-463e-8adb-c6cfedba1eed",
+   "metadata": {},
+   "source": [
+    "# WorkUnit Benchmarking\n",
+    "\n",
+    "This notebook compares the time and space required to save WorkUnits with different compression schemes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5c4ec99-9046-4d3c-b26a-ee881ca9dbed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import os\n",
+    "import tempfile\n",
+    "import timeit\n",
+    "\n",
+    "from kbmod.configuration import SearchConfiguration\n",
+    "from kbmod.core.image_stack_py import (\n",
+    "    image_stack_add_fake_object,\n",
+    "    make_fake_image_stack,\n",
+    "    ImageStackPy,\n",
+    ")\n",
+    "from kbmod.image_utils import image_stack_cpp_to_py\n",
+    "from kbmod.wcs_utils import make_fake_wcs\n",
+    "from kbmod.work_unit import WorkUnit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c33ff59a-ac04-460b-8655-5414563d3ff4",
+   "metadata": {},
+   "source": [
+    "We create a fake WorkUnit to use for benchmarking."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db9a4b87-ba40-4370-9cf2-af2d08768e20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rng = np.random.default_rng(seed=101)\n",
+    "\n",
+    "num_times = 10\n",
+    "height = 1200\n",
+    "width = 1000\n",
+    "times = np.arange(num_times)\n",
+    "\n",
+    "# Use a wide range of values. Science [-5000.0, 5000.0] and variance [1.0, 101.0]\n",
+    "sci = 10000.0 * (rng.random((num_times, height, width)) - 0.5)\n",
+    "var = 100.0 * rng.random((num_times, height, width)) + 1.0\n",
+    "\n",
+    "# Mask out some of the values.\n",
+    "mask = rng.random((num_times, height, width)) < 0.01\n",
+    "sci[mask] = np.nan\n",
+    "var[mask] = np.nan\n",
+    "\n",
+    "# Use a default search configuration and toy WCS.\n",
+    "config = SearchConfiguration()\n",
+    "wcs = make_fake_wcs(0.0, -15.0, height, width, deg_per_pixel=10.0 / 3600.0)\n",
+    "\n",
+    "# Build a WorkUnit.\n",
+    "stack = ImageStackPy(times, sci, var)\n",
+    "wu = WorkUnit(stack, config, wcs=wcs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70f9b9e0-03b7-4abf-8a90-57c6aeeef02f",
+   "metadata": {},
+   "source": [
+    "Create a temporary directory for the tests. Write out and stat files in different formats."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae681876-05f6-48aa-ab64-2011af23911d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tmp_dir = tempfile.TemporaryDirectory()\n",
+    "\n",
+    "compression_types = [\"NOCOMPRESS\", \"RICE_1\", \"GZIP_1\", \"GZIP_2\", \"HCOMPRESS_1\"]\n",
+    "file_name = os.path.join(tmp_dir.name, \"wu.fits\")\n",
+    "\n",
+    "print(\"--------------+----------+-----------+-----------+------------+---------|---------|--------\")\n",
+    "print(\" Compression  | Quantize | Size (MB) | Read Time | Write Time | Max Sci | Max Var |  Mask  \")\n",
+    "print(\" Type         | Level    |           | (Seconds) |  (Seconds) |  Error  |  Error  | Errors \")\n",
+    "print(\"--------------+----------+-----------+-----------+------------+---------|---------|--------\")\n",
+    "\n",
+    "r_time = 0.0\n",
+    "w_time = 0.0\n",
+    "\n",
+    "for compress in compression_types:\n",
+    "    for quantize in [100.0, 500.0, -0.1, -0.01, -0.001]:\n",
+    "        wu.to_fits(file_name, overwrite=True, compression_type=compress, quantize_level=quantize)\n",
+    "        file_size_mb = os.path.getsize(file_name) / (1024.0 * 1024.0)\n",
+    "\n",
+    "        wu2 = WorkUnit.from_fits(file_name, show_progress=False)\n",
+    "        stack2 = image_stack_cpp_to_py(wu2.im_stack)\n",
+    "\n",
+    "        # Compute the maximum error in science and variance. Count the number of\n",
+    "        # mismatched masked pixels.\n",
+    "        max_sci = 0.0\n",
+    "        max_var = 0.0\n",
+    "        mask_err = 0\n",
+    "        for i in range(num_times):\n",
+    "            max_sci = max(max_sci, np.nanmax(np.abs(stack.sci[i] - stack2.sci[i])))\n",
+    "            max_var = max(max_var, np.nanmax(np.abs(stack.var[i] - stack2.var[i])))\n",
+    "            mask_err += np.count_nonzero(mask[i] != np.isnan(stack2.sci[i]))\n",
+    "\n",
+    "        # Run the timings.\n",
+    "        w_time = (\n",
+    "            timeit.timeit(\n",
+    "                \"wu.to_fits(file_name, overwrite=True, compression_type=compress, quantize_level=quantize)\",\n",
+    "                globals=globals(),\n",
+    "                number=10,\n",
+    "            )\n",
+    "            / 10.0\n",
+    "        )\n",
+    "        r_time = (\n",
+    "            timeit.timeit(\n",
+    "                \"_ = WorkUnit.from_fits(file_name, show_progress=False)\",\n",
+    "                globals=globals(),\n",
+    "                number=10,\n",
+    "            )\n",
+    "            / 10.0\n",
+    "        )\n",
+    "\n",
+    "        print(\n",
+    "            f\" {compress:12} | {quantize:8.3f} | {file_size_mb:8.2f}  \"\n",
+    "            f\"|  {r_time:8.4f} |   {w_time:8.4f} | {max_sci:7.3f} \"\n",
+    "            f\"| {max_var:7.3f} | {mask_err:5} \"\n",
+    "        )\n",
+    "\n",
+    "print(\"--------------+----------+-----------+-----------+------------+---------|---------|--------\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7747c577-0109-47f7-afc3-cc4cb8863381",
+   "metadata": {},
+   "source": [
+    "Clean up the temporary directory and files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d77ede2a-94bf-4a63-90a1-944d90b443b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tmp_dir.cleanup()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Jeremy's KBMOD",
+   "language": "python",
+   "name": "kbmod_jk"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Add a benchmark for different types of compression and different quantization levels.

```
--------------+----------+-----------+-----------+------------+---------|---------|--------
 Compression  | Quantize | Size (MB) | Read Time | Write Time | Max Sci | Max Var |  Mask  
 Type         | Level    |           | (Seconds) |  (Seconds) |  Error  |  Error  | Errors 
--------------+----------+-----------+-----------+------------+---------|---------|--------
 NOCOMPRESS   |  100.000 |   103.95  |    0.8452 |     3.0536 |  17.994 |   0.178 |     0 
 NOCOMPRESS   |  500.000 |   103.95  |    0.8408 |     2.9914 |   3.594 |   0.035 |     0 
 NOCOMPRESS   |   -0.100 |   103.95  |    0.8416 |     2.2446 |   0.050 |   0.050 |     0 
 NOCOMPRESS   |   -0.010 |   103.95  |    0.8406 |     2.2410 |   0.005 |   0.005 |     0 
 NOCOMPRESS   |   -0.001 |   103.95  |    0.8415 |     2.2440 |   0.001 |   0.001 |     0 
 RICE_1       |  100.000 |    57.72  |    0.9827 |     3.1728 |  17.994 |   0.178 |     0 
 RICE_1       |  500.000 |    62.54  |    0.9864 |     3.1946 |   3.594 |   0.035 |     0 
 RICE_1       |   -0.100 |    67.87  |    0.9883 |     2.4371 |   0.050 |   0.050 |     0 
 RICE_1       |   -0.010 |    74.68  |    0.9953 |     2.4655 |   0.005 |   0.005 |     0 
 RICE_1       |   -0.001 |    81.52  |    0.9988 |     2.4654 |   0.001 |   0.001 |     0 
 GZIP_1       |  100.000 |    51.97  |    1.3726 |    13.6305 |  17.994 |   0.178 |     0 
 GZIP_1       |  500.000 |    62.27  |    1.4596 |     8.8051 |   3.594 |   0.035 |     0 
 GZIP_1       |   -0.100 |    68.88  |    1.4747 |     7.3151 |   0.050 |   0.050 |     0 
 GZIP_1       |   -0.010 |    78.01  |    1.4809 |     5.4219 |   0.005 |   0.005 |     0 
 GZIP_1       |   -0.001 |    84.81  |    1.4718 |     4.9184 |   0.001 |   0.001 |     0 
 GZIP_2       |  100.000 |    42.36  |    1.7115 |    14.6821 |  17.994 |   0.178 |     0 
 GZIP_2       |  500.000 |    51.29  |    2.0297 |     6.3471 |   3.594 |   0.035 |     0 
 GZIP_2       |   -0.100 |    57.51  |    1.9972 |     7.9322 |   0.050 |   0.050 |     0 
 GZIP_2       |   -0.010 |    67.89  |    2.0571 |     4.9943 |   0.005 |   0.005 |     0 
 GZIP_2       |   -0.001 |    74.97  |    2.0382 |     7.4156 |   0.001 |   0.001 |     0 
 HCOMPRESS_1  |  100.000 |    50.71  |    1.6902 |     2.2530 |  15.917 |   0.159 |     0 
 HCOMPRESS_1  |  500.000 |    56.13  |    1.6958 |     2.3064 |   3.184 |   0.032 |     0 
 HCOMPRESS_1  |   -0.100 |    62.15  |    1.7530 |     1.6461 |   0.050 |   0.050 |     0 
 HCOMPRESS_1  |   -0.010 |    69.77  |    1.8391 |     1.7204 |   0.005 |   0.005 |     0 
 HCOMPRESS_1  |   -0.001 |    77.43  |    1.8866 |     1.7956 |   0.001 |   0.001 |     0 
--------------+----------+-----------+-----------+------------+---------|---------|--------
```