### PR TITLE
Cleanup installation configuration and includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,16 +56,19 @@ if(ipo_supported)
     set_property(TARGET search PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif()
 
+# Use aggressive compilation (-O3) and hidden symbol visibility.
 target_compile_options(search PRIVATE $<$<COMPILE_LANGUAGE:CXX>:
     -O3
     -fvisibility=hidden
-    -fopenmp
 >)
 
-target_link_libraries(search PRIVATE
-  -lgomp
-)
-
+# Link in the OpenMP libraries if they are found.  As of cmake 3.9, it handles setting
+# the linking flags and as of cmake 3.12 it works on MacOS (if openmp is installed).
+find_package(OpenMP)
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(search PUBLIC OpenMP::OpenMP_CXX)
+    add_definitions(-DHAVE_OPENMP=1)
+endif()
 
 # If we have CUDA, build the kernel libraries and link them in as well.
 if(HAVE_CUDA)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ kbmod-create-test-data = "kbmod_cmdline.kbmod_create_test_data:main"
 kbmod-filter = "kbmod_cmdline.kbmod_filter:main"
 kbmod-stamps = "kbmod_cmdline.kbmod_stamps:main"
 kbmod-stats = "kbmod_cmdline.kbmod_stats:main"
+kbmod-version = "kbmod_cmdline.kbmod_version:main"
 
 [project.urls]
 Documentation = "https://epyc.astro.washington.edu/~kbmod/"

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -365,11 +365,18 @@ class SearchRunner:
         keep : `Results`
             The results.
         """
-        self._start_phase("KBMOD")
+        if config["debug"]:
+            logging.basicConfig(level=logging.DEBUG)
+
+            # Output basic binary information.
+            logger.debug(f"GPU Code Enabled: {HAS_GPU}")
+            logger.debug(f"OpenMP Enabled: {HAS_OMP}")
+            logger.debug(kb.stat_gpu_memory_mb())
+            logger.debug("Config:")
+            logger.debug(str(config))
 
         # Determine how many images have at least 10% valid pixels.  Make sure
         # num_obs is no larger than 80% of the valid images.
-
         img_count = np.count_nonzero(stack.get_masked_fractions() < 0.9)
         if img_count == 0:
             raise ValueError("No valid images in input.")
@@ -377,11 +384,7 @@ class SearchRunner:
             logger.info(f"Automatically setting num_obs = {img_count} (from {config['num_obs']}).")
             config.set("num_obs", img_count)
 
-        if config["debug"]:
-            logging.basicConfig(level=logging.DEBUG)
-            logger.debug("Starting Search")
-            logger.debug(str(config))
-            logger.debug(kb.stat_gpu_memory_mb())
+        self._start_phase("KBMOD")
 
         if not config.validate():
             raise ValueError("Invalid configuration")

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -20,6 +20,7 @@ namespace py = pybind11;
 PYBIND11_MODULE(search, m) {
     m.attr("KB_NO_DATA") = pybind11::float_(search::NO_DATA);
     m.attr("HAS_GPU") = pybind11::bool_(search::HAVE_GPU);
+    m.attr("HAS_OMP") = pybind11::bool_(search::HAVE_OMP);
     py::enum_<search::StampType>(m, "StampType")
             .value("STAMP_SUM", search::StampType::STAMP_SUM)
             .value("STAMP_MEAN", search::StampType::STAMP_MEAN)

--- a/src/kbmod/search/common.h
+++ b/src/kbmod/search/common.h
@@ -15,6 +15,12 @@ constexpr bool HAVE_GPU = true;
 constexpr bool HAVE_GPU = false;
 #endif
 
+#ifdef HAVE_OPENMP
+constexpr bool HAVE_OMP = true;
+#else
+constexpr bool HAVE_OMP = false;
+#endif
+
 constexpr unsigned int MAX_KERNEL_RADIUS = 15;
 constexpr unsigned short MAX_STAMP_EDGE = 64;
 constexpr unsigned short CONV_THREAD_DIM = 32;

--- a/src/kbmod/search/cpu_search_algorithms.h
+++ b/src/kbmod/search/cpu_search_algorithms.h
@@ -10,7 +10,6 @@
 #define CPU_SEARCH_ALGOROTHMS_H_
 
 #include <cmath>
-#include <omp.h>
 #include <vector>
 
 #include "common.h"

--- a/src/kbmod/search/image_utils_cpp.h
+++ b/src/kbmod/search/image_utils_cpp.h
@@ -1,13 +1,9 @@
 #ifndef IMAGE_UTILS_CPP_H_
 #define IMAGE_UTILS_CPP_H_
 
-#include <vector>
-#include <float.h>
-#include <iostream>
-#include <stdexcept>
-#include <math.h>
-
 #include <Eigen/Core>
+#include <stdexcept>
+#include <vector>
 
 #include "common.h"
 

--- a/src/kbmod/search/psi_phi_array.cpp
+++ b/src/kbmod/search/psi_phi_array.cpp
@@ -392,7 +392,6 @@ void fill_psi_phi_array_from_image_arrays(PsiPhiArray& result_data, int num_byte
     fill_psi_phi_array(result_data, num_bytes, psi_images, phi_images, zeroed_times);
 }
 
-
 // -------------------------------------------
 // --- Python definitions --------------------
 // -------------------------------------------

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -1,17 +1,6 @@
 #ifndef KBMODSEARCH_H_
 #define KBMODSEARCH_H_
 
-#include <parallel/algorithm>
-#include <algorithm>
-#include <functional>
-#include <iostream>
-#include <fstream>
-#include <sstream>  // formatting log msgs
-#include <chrono>
-#include <stdexcept>
-#include <float.h>
-#include <omp.h>
-
 #include "logging.h"
 #include "common.h"
 #include "cpu_search_algorithms.h"

--- a/src/kbmod_cmdline/kbmod_version.py
+++ b/src/kbmod_cmdline/kbmod_version.py
@@ -1,0 +1,11 @@
+"""Display basic version and build information to standard out."""
+
+import kbmod
+from kbmod.search import HAS_GPU, HAS_OMP
+
+
+def main():
+    print(f"KBMOD\m-----n")
+    print(f"Version: {kbmod.__version__}")
+    print(f"GPU Code Enabled: {HAS_GPU}")
+    print(f"OpenMP Enabled: {HAS_OMP}")


### PR DESCRIPTION
The main cleanup is to change how cmake is accessing OpenMP as recommended [here](https://cliutils.gitlab.io/modern-cmake/chapters/packages/OpenMP.html).

PR also:
- adds a readable `HAS_OPM` flag to mirror the `HAS_GPU` one. We now export both when running a search in debug mode to record how the binary was built.
- allow the CPP code to build on a system without openmp. It's much slower, but works in more places.
- Remove unneeded includes from some of the .cpp and .h files (including omp.h which is not needed because we are just using pramas).
- Add a command-line script that will just provide basic version and build information.