### PR TITLE
Allow compiling on systems without GPU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,7 @@ project(search LANGUAGES CXX)
 include(CheckLanguage)
 check_language(CUDA)
 
-set(CPU_ONLY OFF CACHE BOOL "Build without GPU support?")
-
-if(CMAKE_CUDA_COMPILER AND NOT CPU_ONLY)
+if(CMAKE_CUDA_COMPILER)
   set(HAVE_CUDA 1)
   enable_language(CUDA)
   add_definitions(-DHAVE_CUDA=1)
@@ -24,7 +22,6 @@ if(CMAKE_CUDA_COMPILER AND NOT CPU_ONLY)
 else()
   message(STATUS "Not building for GPU.")
   message(STATUS "CMAKE_CUDA_COMPILER = ${CMAKE_CUDA_COMPILER}")
-  message(STATUS "CPU only = ${CPU_ONLY}")
 endif()
 
 include(CheckIPOSupported)

--- a/setup.py
+++ b/setup.py
@@ -128,14 +128,6 @@ class CMakeBuild(build_ext):
             if archs:
                 cmake_args += ["-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
 
-        # Check if we have GPU support.
-        try:
-            subprocess.check_output('nvidia-smi')
-            cmake_args += ["-DCPU_ONLY=OFF"]
-        except Exception:
-            cmake_args += ["-DCPU_ONLY=ON"]
-            print("WARNING: No GPU Found. Building with CPU only mode.")
-
         # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level
         # across all generators.
         if "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:

--- a/src/kbmod/__init__.py
+++ b/src/kbmod/__init__.py
@@ -27,7 +27,7 @@ def is_interactive():
     mode : `bool`
         `True` when in interactive mode.
     """
-    global KBM_INTERACTIVE_MODE
+    global KB_INTERACTIVE_MODE
     return KB_INTERACTIVE_MODE
 
 

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -369,7 +369,7 @@ class SearchRunner:
             logging.basicConfig(level=logging.DEBUG)
 
             # Output basic binary information.
-            logger.debug(f"GPU Code Enabled: {HAS_GPU}")
+            logger.debug(f"GPU Code Enabled: {HAS_CUDA}")
             logger.debug(f"OpenMP Enabled: {HAS_OMP}")
             logger.debug(kb.stat_gpu_memory_mb())
             logger.debug("Config:")
@@ -389,7 +389,7 @@ class SearchRunner:
         if not config.validate():
             raise ValueError("Invalid configuration")
 
-        if not kb.HAS_GPU:
+        if not kb.HAS_CUDA:
             logger.warning("Code was compiled without GPU using CPU only.")
             config.set("cpu_only", True)
 

--- a/src/kbmod/search/bindings.cpp
+++ b/src/kbmod/search/bindings.cpp
@@ -19,7 +19,7 @@ namespace py = pybind11;
 
 PYBIND11_MODULE(search, m) {
     m.attr("KB_NO_DATA") = pybind11::float_(search::NO_DATA);
-    m.attr("HAS_GPU") = pybind11::bool_(search::HAVE_GPU);
+    m.attr("HAS_CUDA") = pybind11::bool_(search::HAVE_CUDA_LIB);
     m.attr("HAS_OMP") = pybind11::bool_(search::HAVE_OMP);
     py::enum_<search::StampType>(m, "StampType")
             .value("STAMP_SUM", search::StampType::STAMP_SUM)
@@ -35,8 +35,7 @@ PYBIND11_MODULE(search, m) {
     search::psi_phi_array_binding(m);
     search::debug_timer_binding(m);
     search::trajectory_list_binding(m);
-    // Helper function from common.h
-    m.def("pixel_value_valid", &search::pixel_value_valid);
-    search::kernel_helper_bindings(m);  // Functions from kernel_helpers.cpp
+    m.def("pixel_value_valid", &search::pixel_value_valid);  // Helper function from common.h
+    search::kernel_helper_bindings(m);
     search::image_utils_cpp(m);
 }

--- a/src/kbmod/search/common.h
+++ b/src/kbmod/search/common.h
@@ -10,9 +10,9 @@
 
 namespace search {
 #ifdef HAVE_CUDA
-constexpr bool HAVE_GPU = true;
+constexpr bool HAVE_CUDA_LIB = true;
 #else
-constexpr bool HAVE_GPU = false;
+constexpr bool HAVE_CUDA_LIB = false;
 #endif
 
 #ifdef HAVE_OPENMP

--- a/src/kbmod/search/image_utils_cpp.cpp
+++ b/src/kbmod/search/image_utils_cpp.cpp
@@ -1,7 +1,6 @@
 /* Helper functions for testing functions in the .cu files from Python. */
 
 #include "image_utils_cpp.h"
-#include "logging.h"
 #include "pydocs/image_utils_cpp_docs.h"
 
 namespace search {

--- a/src/kbmod/search/kernel_helpers.cpp
+++ b/src/kbmod/search/kernel_helpers.cpp
@@ -6,20 +6,34 @@
 #include <vector>
 
 #include "kernel_helpers.h"
-#include "logging.h"
 #include "pydocs/kernel_helper_docs.h"
+
+// Declaration of CUDA functions that will be linked in.
+#ifdef HAVE_CUDA
+#include "kernels/kernel_memory.h"
+#endif
+
 
 namespace search {
 #ifdef HAVE_CUDA
-void cuda_print_stats();
-size_t gpu_total_memory();
-size_t gpu_free_memory();
-bool cuda_check_gpu(size_t req_memory);
-
-/* The kenerls.cu functions. */
+/* The kernels.cu functions. */
 extern "C" void SigmaGFilteredIndicesCU(float *values, int num_values, float sgl0, float sgl1, float sg_coeff,
                                         float width, int *idx_array, int *min_keep_idx, int *max_keep_idx);
 #endif
+
+
+inline bool has_gpu() {
+#ifdef HAVE_CUDA
+    return cude_device_count() > 0;
+#else
+    return false;
+#endif
+}
+
+
+// --------------------------
+// --- GPU Stat functions ---
+// --------------------------
 
 void print_cuda_stats() {
 #ifdef HAVE_CUDA
@@ -96,6 +110,7 @@ std::vector<int> sigmaGFilteredIndices(std::vector<float> values, float sgl0, fl
 
 #ifdef Py_PYTHON_H
 static void kernel_helper_bindings(py::module &m) {
+    m.def("has_gpu", &has_gpu, "Check if GPU is available");
     m.def("sigmag_filtered_indices", &search::sigmaGFilteredIndices);
     m.def("print_cuda_stats", &search::print_cuda_stats, pydocs::DOC_print_cuda_stats);
     m.def("get_gpu_total_memory", &search::get_gpu_total_memory, pydocs::DOC_get_gpu_total_memory);

--- a/src/kbmod/search/kernel_helpers.cpp
+++ b/src/kbmod/search/kernel_helpers.cpp
@@ -110,7 +110,7 @@ std::vector<int> sigmaGFilteredIndices(std::vector<float> values, float sgl0, fl
 
 #ifdef Py_PYTHON_H
 static void kernel_helper_bindings(py::module &m) {
-    m.def("has_gpu", &has_gpu, "Check if GPU is available");
+    m.def("kb_has_gpu", &has_gpu, "Check if GPU is available");
     m.def("sigmag_filtered_indices", &search::sigmaGFilteredIndices);
     m.def("print_cuda_stats", &search::print_cuda_stats, pydocs::DOC_print_cuda_stats);
     m.def("get_gpu_total_memory", &search::get_gpu_total_memory, pydocs::DOC_get_gpu_total_memory);

--- a/src/kbmod/search/kernel_helpers.cpp
+++ b/src/kbmod/search/kernel_helpers.cpp
@@ -22,7 +22,7 @@ extern "C" void SigmaGFilteredIndicesCU(float *values, int num_values, float sgl
 
 inline bool has_gpu() {
 #ifdef HAVE_CUDA
-    return cude_device_count() > 0;
+    return cuda_device_count() > 0;
 #else
     return false;
 #endif

--- a/src/kbmod/search/kernel_helpers.cpp
+++ b/src/kbmod/search/kernel_helpers.cpp
@@ -13,14 +13,12 @@
 #include "kernels/kernel_memory.h"
 #endif
 
-
 namespace search {
 #ifdef HAVE_CUDA
 /* The kernels.cu functions. */
 extern "C" void SigmaGFilteredIndicesCU(float *values, int num_values, float sgl0, float sgl1, float sg_coeff,
                                         float width, int *idx_array, int *min_keep_idx, int *max_keep_idx);
 #endif
-
 
 inline bool has_gpu() {
 #ifdef HAVE_CUDA
@@ -29,7 +27,6 @@ inline bool has_gpu() {
     return false;
 #endif
 }
-
 
 // --------------------------
 // --- GPU Stat functions ---

--- a/src/kbmod/search/kernel_helpers.h
+++ b/src/kbmod/search/kernel_helpers.h
@@ -8,7 +8,6 @@
 
 #include <string>
 
-
 namespace search {
 
 // Check that the package was built with CUDA support and there is a GPU available.

--- a/src/kbmod/search/kernel_helpers.h
+++ b/src/kbmod/search/kernel_helpers.h
@@ -8,23 +8,17 @@
 
 #include <string>
 
-#include "logging.h"
-
-// Declaration of CUDA functions that will be linked in.
-#ifdef HAVE_CUDA
-#include "kernels/kernel_memory.h"
-#endif
 
 namespace search {
 
+// Check that the package was built with CUDA support and there is a GPU available.
+inline bool has_gpu();
+
+// GPU Stat functions. The produces reasonable defaults when CUDA is not enabled.
 void print_cuda_stats();
-
 size_t get_gpu_total_memory();
-
 size_t get_gpu_free_memory();
-
 std::string stat_gpu_memory_mb();
-
 bool validate_gpu(size_t req_memory = 0);
 
 } /* namespace search */

--- a/src/kbmod/search/kernels/kernel_memory.cu
+++ b/src/kbmod/search/kernels/kernel_memory.cu
@@ -12,6 +12,16 @@
 
 namespace search {
 
+int cude_device_count() {
+    int device_count = 0;
+    unsigned int res = static_cast<unsigned int>(cudaGetDeviceCount(&device_count));
+    if (res != 0) {
+        std::cout << "Unable to query GPU devices. Error code = " << res << "\n";
+        return -1;
+    }
+    return device_count;
+}
+
 // Helpful debugging stats for when something crashes in the GPU.
 void cuda_print_stats() {
     std::cout << "\n----- CUDA Debugging Log -----\n";

--- a/src/kbmod/search/kernels/kernel_memory.cu
+++ b/src/kbmod/search/kernels/kernel_memory.cu
@@ -12,7 +12,7 @@
 
 namespace search {
 
-int cude_device_count() {
+int cuda_device_count() {
     int device_count = 0;
     unsigned int res = static_cast<unsigned int>(cudaGetDeviceCount(&device_count));
     if (res != 0) {

--- a/src/kbmod/search/kernels/kernel_memory.cu
+++ b/src/kbmod/search/kernels/kernel_memory.cu
@@ -16,8 +16,7 @@ int cude_device_count() {
     int device_count = 0;
     unsigned int res = static_cast<unsigned int>(cudaGetDeviceCount(&device_count));
     if (res != 0) {
-        std::cout << "Unable to query GPU devices. Error code = " << res << "\n";
-        return -1;
+        return 0;
     }
     return device_count;
 }

--- a/src/kbmod/search/kernels/kernel_memory.h
+++ b/src/kbmod/search/kernels/kernel_memory.h
@@ -14,6 +14,7 @@
 
 namespace search {
 
+int cude_device_count();
 void cuda_print_stats();
 
 size_t gpu_total_memory();

--- a/src/kbmod/search/kernels/kernel_memory.h
+++ b/src/kbmod/search/kernels/kernel_memory.h
@@ -14,7 +14,7 @@
 
 namespace search {
 
-int cude_device_count();
+int cuda_device_count();
 void cuda_print_stats();
 
 size_t gpu_total_memory();

--- a/src/kbmod/search/stack_search.h
+++ b/src/kbmod/search/stack_search.h
@@ -6,6 +6,7 @@
 #include "cpu_search_algorithms.h"
 #include "debug_timer.h"
 #include "image_utils_cpp.h"
+#include "kernel_helpers.h"
 #include "psi_phi_array_ds.h"
 #include "psi_phi_array_utils.h"
 #include "pydocs/stack_search_docs.h"

--- a/src/kbmod/search/trajectory_list.cpp
+++ b/src/kbmod/search/trajectory_list.cpp
@@ -1,5 +1,5 @@
+#include "kernel_helpers.h"
 #include "logging.h"
-
 #include "trajectory_list.h"
 #include "pydocs/trajectory_list_docs.h"
 
@@ -104,6 +104,7 @@ void TrajectoryList::filter_by_obs_count(int min_obs_count) {
 
 void TrajectoryList::move_to_gpu() {
     if (data_on_gpu) return;  // Nothing to do.
+    if (!has_gpu()) throw std::runtime_error("GPU not available for TrajectoryList");
 
     logging::getLogger("kbmod.search.trajectory_list")
             ->debug("Moving TrajectoryList to GPU. " + gpu_array.stats_string());

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,15 +1,16 @@
 import math
 import numpy as np
 import unittest
+import warnings
 
-from kbmod.search import HAS_CUDA, Trajectory, pixel_value_valid
+from kbmod.search import kb_has_gpu, Trajectory, pixel_value_valid
 
 
 class test_common(unittest.TestCase):
-    @unittest.skipIf(HAS_CUDA, "Skipping test (GPU detected)")
+    @unittest.skipIf(kb_has_gpu(), "Skipping test (GPU detected)")
     def test_warning_no_GPU(self):
         """Throw a loud warning if you are running tests without GPU."""
-        print("\n\n*** WARNING: SKIPPING GPU TESTS ***\n\n")
+        warnings.warn("\n\n*** WARNING: SKIPPING GPU TESTS ***\n\n")
 
     def test_pixel_value_valid(self):
         self.assertTrue(pixel_value_valid(1.0))

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,11 +2,11 @@ import math
 import numpy as np
 import unittest
 
-from kbmod.search import HAS_GPU, Trajectory, pixel_value_valid
+from kbmod.search import HAS_CUDA, Trajectory, pixel_value_valid
 
 
 class test_common(unittest.TestCase):
-    @unittest.skipIf(HAS_GPU, "Skipping test (GPU detected)")
+    @unittest.skipIf(HAS_CUDA, "Skipping test (GPU detected)")
     def test_warning_no_GPU(self):
         """Throw a loud warning if you are running tests without GPU."""
         print("\n\n*** WARNING: SKIPPING GPU TESTS ***\n\n")

--- a/tests/test_core_search_exact.py
+++ b/tests/test_core_search_exact.py
@@ -11,7 +11,7 @@ from kbmod.search import *
 from kbmod.trajectory_generator import VelocityGridSearch
 
 
-@unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+@unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
 class test_search_exact(unittest.TestCase):
     def test_core_search_exact(self):
         # image properties

--- a/tests/test_core_search_exact.py
+++ b/tests/test_core_search_exact.py
@@ -11,7 +11,7 @@ from kbmod.search import *
 from kbmod.trajectory_generator import VelocityGridSearch
 
 
-@unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+@unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
 class test_search_exact(unittest.TestCase):
     def test_core_search_exact(self):
         # image properties

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -9,12 +9,12 @@ import warnings
 
 from kbmod.fake_data.demo_helper import make_demo_data
 from kbmod.run_search import SearchRunner
-from kbmod.search import HAS_GPU
+from kbmod.search import HAS_CUDA
 from kbmod.work_unit import WorkUnit
 
 
 class test_end_to_end(unittest.TestCase):
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_demo_defaults(self):
         with tempfile.TemporaryDirectory() as dir_name:
             # Create a fake data file.
@@ -35,7 +35,7 @@ class test_end_to_end(unittest.TestCase):
             self.assertEqual(keep["stamp"][0].shape, (21, 21))
             self.assertEqual(keep["coadd_mean"][0].shape, (21, 21))
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_demo_stamp_size(self):
         with tempfile.TemporaryDirectory() as dir_name:
             # Create a fake data file.
@@ -66,7 +66,7 @@ class test_end_to_end(unittest.TestCase):
             for s in keep["all_stamps"][0]:
                 self.assertEqual(s.shape, (31, 31))
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_demo_output_files(self):
         with tempfile.TemporaryDirectory() as dir_name:
             # Create a fake data file.

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -9,12 +9,12 @@ import warnings
 
 from kbmod.fake_data.demo_helper import make_demo_data
 from kbmod.run_search import SearchRunner
-from kbmod.search import HAS_CUDA
+from kbmod.search import kb_has_gpu
 from kbmod.work_unit import WorkUnit
 
 
 class test_end_to_end(unittest.TestCase):
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_demo_defaults(self):
         with tempfile.TemporaryDirectory() as dir_name:
             # Create a fake data file.
@@ -35,7 +35,7 @@ class test_end_to_end(unittest.TestCase):
             self.assertEqual(keep["stamp"][0].shape, (21, 21))
             self.assertEqual(keep["coadd_mean"][0].shape, (21, 21))
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_demo_stamp_size(self):
         with tempfile.TemporaryDirectory() as dir_name:
             # Create a fake data file.
@@ -66,7 +66,7 @@ class test_end_to_end(unittest.TestCase):
             for s in keep["all_stamps"][0]:
                 self.assertEqual(s.shape, (31, 31))
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_demo_output_files(self):
         with tempfile.TemporaryDirectory() as dir_name:
             # Create a fake data file.

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -4,14 +4,14 @@ from kbmod.search import *
 
 
 class test_kernels_wrappers(unittest.TestCase):
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_sigmag_filtered_indices_same(self):
         # With everything the same, nothing should be filtered.
         values = [1.0 for _ in range(20)]
         inds = sigmag_filtered_indices(values, 0.25, 0.75, 0.7413, 2.0)
         self.assertEqual(len(inds), 20)
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_sigmag_filtered_indices_no_outliers(self):
         # Try with a median of 1.0 and a percentile range of 3.0 (2.0 - -1.0).
         # It should filter any values outside [-3.45, 5.45]
@@ -19,7 +19,7 @@ class test_kernels_wrappers(unittest.TestCase):
         inds = sigmag_filtered_indices(values, 0.25, 0.75, 0.7413, 2.0)
         self.assertEqual(len(inds), len(values))
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_sigmag_filtered_indices_one_outlier(self):
         # Try with a median of 1.0 and a percentile range of 3.0 (2.0 - -1.0).
         # It should filter any values outside [-3.45, 5.45]
@@ -36,7 +36,7 @@ class test_kernels_wrappers(unittest.TestCase):
         inds = sigmag_filtered_indices(values, 0.25, 0.75, 0.7413, 3.0)
         self.assertEqual(len(inds), len(values))
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_sigmag_filtered_indices_other_bounds(self):
         # Do the filtering of test_sigmag_filtered_indices_one_outlier
         # with wider bounds [-1.8944, 3.8944].
@@ -58,7 +58,7 @@ class test_kernels_wrappers(unittest.TestCase):
         for i in range(1, 9):
             self.assertTrue(i in inds)
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_sigmag_filtered_indices_two_outliers(self):
         # Try with a median of 0.0 and a percentile range of 1.1 (1.0 - -0.1).
         # It should filter any values outside [-1.631, 1.631].
@@ -73,7 +73,7 @@ class test_kernels_wrappers(unittest.TestCase):
         inds = sigmag_filtered_indices(values, 0.25, 0.75, 0.7413, 20.0)
         self.assertEqual(len(inds), len(values) - 1)
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_sigmag_filtered_indices_three_outliers(self):
         # Try with a median of 5.0 and a percentile range of 4.0 (7.0-3.0).
         # It should filter any values outside [-0.93, 10.93].
@@ -94,7 +94,7 @@ class test_kernels_wrappers(unittest.TestCase):
             valid = i != 13 and i != 14 and i != 27
             self.assertEqual(i in inds, valid)
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_sigmag_filtered_empty(self):
         # We do not crash if we try to filter an empty array.
         inds = sigmag_filtered_indices([], 0.25, 0.75, 0.7413, 2.0)

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,17 +1,20 @@
 import unittest
 
-from kbmod.search import *
+from kbmod.search import HAS_CUDA, sigmag_filtered_indices
 
 
 class test_kernels_wrappers(unittest.TestCase):
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    # Note that these tests only require the code is compiled with CUDA libraries.
+    # The actual tests do not need a GPU to run.
+
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (built without CUDA libraries)")
     def test_sigmag_filtered_indices_same(self):
         # With everything the same, nothing should be filtered.
         values = [1.0 for _ in range(20)]
         inds = sigmag_filtered_indices(values, 0.25, 0.75, 0.7413, 2.0)
         self.assertEqual(len(inds), 20)
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (built without CUDA libraries)")
     def test_sigmag_filtered_indices_no_outliers(self):
         # Try with a median of 1.0 and a percentile range of 3.0 (2.0 - -1.0).
         # It should filter any values outside [-3.45, 5.45]
@@ -19,7 +22,7 @@ class test_kernels_wrappers(unittest.TestCase):
         inds = sigmag_filtered_indices(values, 0.25, 0.75, 0.7413, 2.0)
         self.assertEqual(len(inds), len(values))
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (built without CUDA libraries)")
     def test_sigmag_filtered_indices_one_outlier(self):
         # Try with a median of 1.0 and a percentile range of 3.0 (2.0 - -1.0).
         # It should filter any values outside [-3.45, 5.45]
@@ -36,7 +39,7 @@ class test_kernels_wrappers(unittest.TestCase):
         inds = sigmag_filtered_indices(values, 0.25, 0.75, 0.7413, 3.0)
         self.assertEqual(len(inds), len(values))
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (built without CUDA libraries)")
     def test_sigmag_filtered_indices_other_bounds(self):
         # Do the filtering of test_sigmag_filtered_indices_one_outlier
         # with wider bounds [-1.8944, 3.8944].
@@ -58,7 +61,7 @@ class test_kernels_wrappers(unittest.TestCase):
         for i in range(1, 9):
             self.assertTrue(i in inds)
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (built without CUDA libraries)")
     def test_sigmag_filtered_indices_two_outliers(self):
         # Try with a median of 0.0 and a percentile range of 1.1 (1.0 - -0.1).
         # It should filter any values outside [-1.631, 1.631].
@@ -73,7 +76,7 @@ class test_kernels_wrappers(unittest.TestCase):
         inds = sigmag_filtered_indices(values, 0.25, 0.75, 0.7413, 20.0)
         self.assertEqual(len(inds), len(values) - 1)
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (built without CUDA libraries)")
     def test_sigmag_filtered_indices_three_outliers(self):
         # Try with a median of 5.0 and a percentile range of 4.0 (7.0-3.0).
         # It should filter any values outside [-0.93, 10.93].
@@ -94,7 +97,7 @@ class test_kernels_wrappers(unittest.TestCase):
             valid = i != 13 and i != 14 and i != 27
             self.assertEqual(i in inds, valid)
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (built without CUDA libraries)")
     def test_sigmag_filtered_empty(self):
         # We do not crash if we try to filter an empty array.
         inds = sigmag_filtered_indices([], 0.25, 0.75, 0.7413, 2.0)

--- a/tests/test_gpu_helpers.py
+++ b/tests/test_gpu_helpers.py
@@ -2,18 +2,18 @@
 
 import unittest
 
-from kbmod.search import HAS_GPU, print_cuda_stats, validate_gpu
+from kbmod.search import HAS_CUDA, print_cuda_stats, validate_gpu
 
 
 class test_gpu_helpers(unittest.TestCase):
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_validate_gpu_true(self):
         self.assertTrue(validate_gpu(0))
 
         # Add a memory test that will fail on all known GPUs (1 exobyte of memory).
         self.assertFalse(validate_gpu(1152921504606846976))
 
-    @unittest.skipIf(HAS_GPU, "Skipping test (GPU detected)")
+    @unittest.skipIf(HAS_CUDA, "Skipping test (GPU detected)")
     def test_validate_gpu_false(self):
         # We should always fail if there is no GPU.
         self.assertFalse(validate_gpu(0))

--- a/tests/test_gpu_helpers.py
+++ b/tests/test_gpu_helpers.py
@@ -2,18 +2,18 @@
 
 import unittest
 
-from kbmod.search import HAS_CUDA, print_cuda_stats, validate_gpu
+from kbmod.search import kb_has_gpu, print_cuda_stats, validate_gpu
 
 
 class test_gpu_helpers(unittest.TestCase):
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_validate_gpu_true(self):
         self.assertTrue(validate_gpu(0))
 
         # Add a memory test that will fail on all known GPUs (1 exobyte of memory).
         self.assertFalse(validate_gpu(1152921504606846976))
 
-    @unittest.skipIf(HAS_CUDA, "Skipping test (GPU detected)")
+    @unittest.skipIf(kb_has_gpu(), "Skipping test (GPU detected)")
     def test_validate_gpu_false(self):
         # We should always fail if there is no GPU.
         self.assertFalse(validate_gpu(0))

--- a/tests/test_image_utils_cpp.py
+++ b/tests/test_image_utils_cpp.py
@@ -4,7 +4,7 @@ import unittest
 
 from kbmod.core.psf import PSF
 from kbmod.search import (
-    HAS_GPU,
+    HAS_CUDA,
     KB_NO_DATA,
     convolve_image_cpu,
     convolve_image_gpu,
@@ -30,7 +30,7 @@ class test_image_utils_cpp(unittest.TestCase):
         result = convolve_image_cpu(self.array, psf_data)
         self.assertTrue(np.allclose(self.array, result, 0.0001))
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_convolve_psf_identity_gpu(self):
         """Test convolution with a identity kernel on CPU"""
         psf_data = np.zeros((3, 3), dtype=np.single)
@@ -59,7 +59,7 @@ class test_image_utils_cpp(unittest.TestCase):
                 else:
                     self.assertTrue(np.isfinite(result[y, x]))
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_convolve_psf_mask_gpu(self):
         """Test masked convolution with a identity kernel on CPU"""
         p = PSF.make_gaussian_kernel(1.0)
@@ -97,7 +97,7 @@ class test_image_utils_cpp(unittest.TestCase):
                 else:
                     self.assertTrue(np.isfinite(result[y, x]))
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_convolve_psf_nan_gpu(self):
         p = PSF.make_gaussian_kernel(1.0)
 
@@ -156,7 +156,7 @@ class test_image_utils_cpp(unittest.TestCase):
                 else:
                     self.assertAlmostEqual(result[y, x], ave, delta=0.001)
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_convolve_psf_average_gpu(self):
         """Test convolution on GPU produces expected values."""
         # Mask out a single pixel.
@@ -220,7 +220,7 @@ class test_image_utils_cpp(unittest.TestCase):
                 # Compute the manually computed result with the convolution.
                 self.assertAlmostEqual(result[y, x], ave, delta=0.001)
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_convolve_psf_orientation_gpu(self):
         """Test convolution on GPU with a non-symmetric PSF"""
         # Set up a non-symmetric psf where orientation matters.

--- a/tests/test_image_utils_cpp.py
+++ b/tests/test_image_utils_cpp.py
@@ -4,7 +4,7 @@ import unittest
 
 from kbmod.core.psf import PSF
 from kbmod.search import (
-    HAS_CUDA,
+    kb_has_gpu,
     KB_NO_DATA,
     convolve_image_cpu,
     convolve_image_gpu,
@@ -30,7 +30,7 @@ class test_image_utils_cpp(unittest.TestCase):
         result = convolve_image_cpu(self.array, psf_data)
         self.assertTrue(np.allclose(self.array, result, 0.0001))
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_convolve_psf_identity_gpu(self):
         """Test convolution with a identity kernel on CPU"""
         psf_data = np.zeros((3, 3), dtype=np.single)
@@ -59,7 +59,7 @@ class test_image_utils_cpp(unittest.TestCase):
                 else:
                     self.assertTrue(np.isfinite(result[y, x]))
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_convolve_psf_mask_gpu(self):
         """Test masked convolution with a identity kernel on CPU"""
         p = PSF.make_gaussian_kernel(1.0)
@@ -97,7 +97,7 @@ class test_image_utils_cpp(unittest.TestCase):
                 else:
                     self.assertTrue(np.isfinite(result[y, x]))
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_convolve_psf_nan_gpu(self):
         p = PSF.make_gaussian_kernel(1.0)
 
@@ -156,7 +156,7 @@ class test_image_utils_cpp(unittest.TestCase):
                 else:
                     self.assertAlmostEqual(result[y, x], ave, delta=0.001)
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_convolve_psf_average_gpu(self):
         """Test convolution on GPU produces expected values."""
         # Mask out a single pixel.
@@ -220,7 +220,7 @@ class test_image_utils_cpp(unittest.TestCase):
                 # Compute the manually computed result with the convolution.
                 self.assertAlmostEqual(result[y, x], ave, delta=0.001)
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_convolve_psf_orientation_gpu(self):
         """Test convolution on GPU with a non-symmetric PSF"""
         # Set up a non-symmetric psf where orientation matters.

--- a/tests/test_psi_phi_array.py
+++ b/tests/test_psi_phi_array.py
@@ -4,7 +4,7 @@ import unittest
 
 from kbmod.fake_data.fake_data_creator import make_fake_image_stack
 from kbmod.search import (
-    HAS_CUDA,
+    kb_has_gpu,
     KB_NO_DATA,
     PsiPhiArray,
     compute_scale_params_from_image_vect,
@@ -155,7 +155,7 @@ class test_psi_phi_array(unittest.TestCase):
 
             # If the test has a GPU move the data to the GPU and confirm it got there.
             # Then clear it and make sure it is freed.
-            if HAS_CUDA:
+            if kb_has_gpu():
                 arr.move_to_gpu()
                 self.assertTrue(arr.on_gpu)
                 self.assertTrue(arr.gpu_array_allocated)
@@ -212,7 +212,7 @@ class test_psi_phi_array(unittest.TestCase):
         self.assertFalse(arr.on_gpu)
         self.assertFalse(arr.gpu_array_allocated)
 
-        if HAS_CUDA:
+        if kb_has_gpu():
             arr.move_to_gpu()
             self.assertTrue(arr.on_gpu)
             self.assertTrue(arr.gpu_array_allocated)

--- a/tests/test_psi_phi_array.py
+++ b/tests/test_psi_phi_array.py
@@ -4,7 +4,7 @@ import unittest
 
 from kbmod.fake_data.fake_data_creator import make_fake_image_stack
 from kbmod.search import (
-    HAS_GPU,
+    HAS_CUDA,
     KB_NO_DATA,
     PsiPhiArray,
     compute_scale_params_from_image_vect,
@@ -155,7 +155,7 @@ class test_psi_phi_array(unittest.TestCase):
 
             # If the test has a GPU move the data to the GPU and confirm it got there.
             # Then clear it and make sure it is freed.
-            if HAS_GPU:
+            if HAS_CUDA:
                 arr.move_to_gpu()
                 self.assertTrue(arr.on_gpu)
                 self.assertTrue(arr.gpu_array_allocated)
@@ -212,7 +212,7 @@ class test_psi_phi_array(unittest.TestCase):
         self.assertFalse(arr.on_gpu)
         self.assertFalse(arr.gpu_array_allocated)
 
-        if HAS_GPU:
+        if HAS_CUDA:
             arr.move_to_gpu()
             self.assertTrue(arr.on_gpu)
             self.assertTrue(arr.gpu_array_allocated)

--- a/tests/test_readme_example.py
+++ b/tests/test_readme_example.py
@@ -1,12 +1,12 @@
 import unittest
 
-from kbmod.search import HAS_GPU, StackSearch, Trajectory
+from kbmod.search import HAS_CUDA, StackSearch, Trajectory
 from kbmod.trajectory_generator import KBMODV1Search
 from kbmod.fake_data.fake_data_creator import *
 
 
 class test_readme_example(unittest.TestCase):
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_make_and_copy(self):
         fake_times = create_fake_times(10, t0=57130.2)
         ds = FakeDataSet(512, 512, fake_times)

--- a/tests/test_readme_example.py
+++ b/tests/test_readme_example.py
@@ -1,12 +1,12 @@
 import unittest
 
-from kbmod.search import HAS_CUDA, StackSearch, Trajectory
+from kbmod.search import kb_has_gpu, StackSearch, Trajectory
 from kbmod.trajectory_generator import KBMODV1Search
 from kbmod.fake_data.fake_data_creator import *
 
 
 class test_readme_example(unittest.TestCase):
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_make_and_copy(self):
         fake_times = create_fake_times(10, t0=57130.2)
         ds = FakeDataSet(512, 512, fake_times)

--- a/tests/test_regression_test.py
+++ b/tests/test_regression_test.py
@@ -232,7 +232,7 @@ def run_full_test():
 
 # The unit test runner
 class test_regression_test(unittest.TestCase):
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_run_test(self):
         self.assertTrue(run_full_test())
 

--- a/tests/test_regression_test.py
+++ b/tests/test_regression_test.py
@@ -232,7 +232,7 @@ def run_full_test():
 
 # The unit test runner
 class test_regression_test(unittest.TestCase):
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_run_test(self):
         self.assertTrue(run_full_test())
 

--- a/tests/test_run_search.py
+++ b/tests/test_run_search.py
@@ -25,7 +25,7 @@ from kbmod.work_unit import WorkUnit
 
 
 class test_run_search(unittest.TestCase):
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_run_search_bad_config(self):
         """Test cases where the search configuration is bad."""
         num_times = 20
@@ -382,7 +382,7 @@ class test_run_search(unittest.TestCase):
         self.assertAlmostEqual(keep["vx"][0], 21.0)
         self.assertAlmostEqual(keep["vy"][0], 16.0)
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_core_search_gpu(self):
         # Create a very small fake data set.
         num_times = 20

--- a/tests/test_run_search.py
+++ b/tests/test_run_search.py
@@ -25,7 +25,7 @@ from kbmod.work_unit import WorkUnit
 
 
 class test_run_search(unittest.TestCase):
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_run_search_bad_config(self):
         """Test cases where the search configuration is bad."""
         num_times = 20
@@ -382,7 +382,7 @@ class test_run_search(unittest.TestCase):
         self.assertAlmostEqual(keep["vx"][0], 21.0)
         self.assertAlmostEqual(keep["vy"][0], 16.0)
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_core_search_gpu(self):
         # Create a very small fake data set.
         num_times = 20

--- a/tests/test_run_search.py
+++ b/tests/test_run_search.py
@@ -57,6 +57,7 @@ class test_run_search(unittest.TestCase):
         # Re-enable warnings.
         logging.disable(logging.NOTSET)
 
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_run_search_auto_config(self):
         """Test that if we set num_obs to high, we down scale it."""
         num_times = 10

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -144,7 +144,7 @@ class test_search(unittest.TestCase):
         self.assertAlmostEqual(best.vy / self.vyel, 1, delta=self.velocity_error)
         self.assertAlmostEqual(best.flux / self.object_flux, 1, delta=self.flux_error)
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_results_gpu(self):
         candidates = [trj for trj in self.trj_gen]
         self.search.search_all(candidates, True)
@@ -165,7 +165,7 @@ class test_search(unittest.TestCase):
         self.assertAlmostEqual(best.vy / self.vyel, 1, delta=self.velocity_error)
         self.assertAlmostEqual(best.flux / self.object_flux, 1, delta=self.flux_error)
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_results_extended_bounds(self):
         self.search.set_results_per_pixel(5)
         self.search.set_start_bounds_x(-10, self.dim_x + 10)
@@ -193,7 +193,7 @@ class test_search(unittest.TestCase):
         self.assertAlmostEqual(best.vy / self.vyel, 1, delta=self.velocity_error)
         self.assertAlmostEqual(best.flux / self.object_flux, 1, delta=self.flux_error)
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_results_reduced_bounds(self):
         self.search.set_results_per_pixel(10)
         self.search.set_start_bounds_x(5, self.dim_x - 5)
@@ -230,7 +230,7 @@ class test_search(unittest.TestCase):
         self.assertRaises(RuntimeError, self.search.enable_gpu_sigmag_filter, [0.75, 1.10], 0.5, 1.0)
         self.assertRaises(RuntimeError, self.search.enable_gpu_sigmag_filter, [0.25, 0.75], -0.5, 1.0)
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_results_off_chip(self):
         trj = Trajectory(x=-3, y=12, vx=25.0, vy=10.0)
 
@@ -276,7 +276,7 @@ class test_search(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.search.set_min_obs(self.img_count + 1)
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_search_too_many_images(self):
         # Create a very large image stack.
         width = 10

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -144,7 +144,7 @@ class test_search(unittest.TestCase):
         self.assertAlmostEqual(best.vy / self.vyel, 1, delta=self.velocity_error)
         self.assertAlmostEqual(best.flux / self.object_flux, 1, delta=self.flux_error)
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_results_gpu(self):
         candidates = [trj for trj in self.trj_gen]
         self.search.search_all(candidates, True)
@@ -165,7 +165,7 @@ class test_search(unittest.TestCase):
         self.assertAlmostEqual(best.vy / self.vyel, 1, delta=self.velocity_error)
         self.assertAlmostEqual(best.flux / self.object_flux, 1, delta=self.flux_error)
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_results_extended_bounds(self):
         self.search.set_results_per_pixel(5)
         self.search.set_start_bounds_x(-10, self.dim_x + 10)
@@ -193,7 +193,7 @@ class test_search(unittest.TestCase):
         self.assertAlmostEqual(best.vy / self.vyel, 1, delta=self.velocity_error)
         self.assertAlmostEqual(best.flux / self.object_flux, 1, delta=self.flux_error)
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_results_reduced_bounds(self):
         self.search.set_results_per_pixel(10)
         self.search.set_start_bounds_x(5, self.dim_x - 5)
@@ -230,7 +230,7 @@ class test_search(unittest.TestCase):
         self.assertRaises(RuntimeError, self.search.enable_gpu_sigmag_filter, [0.75, 1.10], 0.5, 1.0)
         self.assertRaises(RuntimeError, self.search.enable_gpu_sigmag_filter, [0.25, 0.75], -0.5, 1.0)
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_results_off_chip(self):
         trj = Trajectory(x=-3, y=12, vx=25.0, vy=10.0)
 
@@ -276,7 +276,7 @@ class test_search(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.search.set_min_obs(self.img_count + 1)
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_search_too_many_images(self):
         # Create a very large image stack.
         width = 10

--- a/tests/test_search_encode.py
+++ b/tests/test_search_encode.py
@@ -64,7 +64,7 @@ class test_search_filter(unittest.TestCase):
             self.max_angle,
         )
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_different_encodings(self):
         for encoding_bytes in [-1, 1, 2]:
             with self.subTest(i=encoding_bytes):

--- a/tests/test_search_encode.py
+++ b/tests/test_search_encode.py
@@ -64,7 +64,7 @@ class test_search_filter(unittest.TestCase):
             self.max_angle,
         )
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_different_encodings(self):
         for encoding_bytes in [-1, 1, 2]:
             with self.subTest(i=encoding_bytes):

--- a/tests/test_trajectory_explorer.py
+++ b/tests/test_trajectory_explorer.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from kbmod.configuration import SearchConfiguration
 from kbmod.fake_data.fake_data_creator import FakeDataSet
-from kbmod.search import HAS_GPU, Trajectory
+from kbmod.search import HAS_CUDA, Trajectory
 from kbmod.trajectory_explorer import TrajectoryExplorer
 
 
@@ -80,7 +80,7 @@ class test_trajectory_explorer(unittest.TestCase):
         self.explorer.apply_sigma_g(result)
         self.assertFalse(result["obs_valid"][0][10])
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_evaluate_trajectory_parity(self):
         """Test that we get the same results with GPU or CPU-only code."""
         config = SearchConfiguration()
@@ -100,7 +100,7 @@ class test_trajectory_explorer(unittest.TestCase):
         self.assertAlmostEqual(result1["flux"][0], result2["flux"][0])
         self.assertAlmostEqual(result1["obs_count"][0], result2["obs_count"][0])
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_evaluate_around_linear_trajectory(self):
         radius = 3
         edge_length = 2 * radius + 1

--- a/tests/test_trajectory_explorer.py
+++ b/tests/test_trajectory_explorer.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from kbmod.configuration import SearchConfiguration
 from kbmod.fake_data.fake_data_creator import FakeDataSet
-from kbmod.search import HAS_CUDA, Trajectory
+from kbmod.search import kb_has_gpu, Trajectory
 from kbmod.trajectory_explorer import TrajectoryExplorer
 
 
@@ -80,7 +80,7 @@ class test_trajectory_explorer(unittest.TestCase):
         self.explorer.apply_sigma_g(result)
         self.assertFalse(result["obs_valid"][0][10])
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_evaluate_trajectory_parity(self):
         """Test that we get the same results with GPU or CPU-only code."""
         config = SearchConfiguration()
@@ -100,7 +100,7 @@ class test_trajectory_explorer(unittest.TestCase):
         self.assertAlmostEqual(result1["flux"][0], result2["flux"][0])
         self.assertAlmostEqual(result1["obs_count"][0], result2["obs_count"][0])
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_evaluate_around_linear_trajectory(self):
         radius = 3
         edge_length = 2 * radius + 1

--- a/tests/test_trajectory_list.py
+++ b/tests/test_trajectory_list.py
@@ -9,7 +9,7 @@ from kbmod.search import (
     extract_all_trajectory_vy,
     extract_all_trajectory_x,
     extract_all_trajectory_y,
-    HAS_GPU,
+    HAS_CUDA,
     Trajectory,
     TrajectoryList,
 )
@@ -135,7 +135,7 @@ class test_trajectory_list(unittest.TestCase):
         self.assertEqual(len(trjs), 4)
         self.assertEqual(set([trjs.get_trajectory(i).x for i in range(4)]), set([0, 1, 2, 5]))
 
-    @unittest.skipIf(not HAS_GPU, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
     def test_move_to_from_gpu(self):
         for i in range(self.max_size):
             self.trj_list.set_trajectory(i, Trajectory(x=i))

--- a/tests/test_trajectory_list.py
+++ b/tests/test_trajectory_list.py
@@ -9,7 +9,7 @@ from kbmod.search import (
     extract_all_trajectory_vy,
     extract_all_trajectory_x,
     extract_all_trajectory_y,
-    HAS_CUDA,
+    kb_has_gpu,
     Trajectory,
     TrajectoryList,
 )
@@ -135,7 +135,7 @@ class test_trajectory_list(unittest.TestCase):
         self.assertEqual(len(trjs), 4)
         self.assertEqual(set([trjs.get_trajectory(i).x for i in range(4)]), set([0, 1, 2, 5]))
 
-    @unittest.skipIf(not HAS_CUDA, "Skipping test (no GPU detected)")
+    @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_move_to_from_gpu(self):
         for i in range(self.max_size):
             self.trj_list.set_trajectory(i, Trajectory(x=i))


### PR DESCRIPTION
Allow KBMOD to be pip installed, including building the CUDA functions, even if the system does not have a GPU. As long as the CUDA libraries are present and can be linked, this should work.

As part of this, cleaned up the GPU logic:
- Compilation no longer checks if the system has a GPU (setup.py and CMakeLists.txt)
- Renamed the Python variable `HAS_GPU` to `HAS_CUDA` to reflex what it is actually checking.  The internal C++ variable is renamed from `HAS_GPU` to `HAS_CUDA_LIB` in common.h and bindings.cpp.
- Add a C++ function `has_gpu` and a corresponding Python `kb_has_gpu()` that checks that both the CUDA libraries are linked in AND the current system has a GPU.  This is what we want to check before executing most code.
- Add a C++ wrapper `cuda_device_count()` to check that there is at least one GPU (this is used in `has_gpu()`)
- Changes as much code as possible from `#ifdef` guards to the more flexible `has_gpu()` which will check both the libraries and the existence of a GPU on the current system.  We can't remove all the `#ifdef` guards since we still need them in cases where the code is calling a function defined in a `.cu` file.

In addition:
- Remove some unneeded includes of `logging.h`
- Fix a type on `__init__.py`

I tested this PR by building on Baldur (with GPU) and running the tests on both Baldur and Epyc (no GPU). Then building on Epyc (no GPU) and running on both Baldur and Epyc.  All four combinations worked.

Closes #503 