### PR TITLE
Silence more expected warnings

### DIFF
--- a/tests/test_imagecollection.py
+++ b/tests/test_imagecollection.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 import tempfile
@@ -157,10 +158,16 @@ class TestImageCollection(unittest.TestCase):
         # no config was given even though its an optional.
         from kbmod.configuration import SearchConfiguration
 
+        # Disable the warnings because the fitFactory will generate empty layers.
+        logging.disable(logging.CRITICAL)
+
         data = self.fitsFactory.get_n(3, spoof_data=True)
         ic = ImageCollection.fromTargets(data)
         wu = ic.toWorkUnit(search_config=SearchConfiguration())
         self.assertEqual(len(wu), 3)
+
+        # Re-enable the warnings.
+        logging.disable(logging.NOTSET)
 
         # We can retrieve the meta data from the WorkUnit.
         filter_info = wu.get_constituent_meta("visit")

--- a/tests/test_trajectory_explorer.py
+++ b/tests/test_trajectory_explorer.py
@@ -23,7 +23,7 @@ class test_trajectory_explorer(unittest.TestCase):
         self.trj = Trajectory(self.x0, self.y0, self.vx, self.vy, flux=500.0)
 
         # create image set with single moving object
-        fake_times = [i / self.img_count for i in range(self.img_count)]
+        fake_times = np.array([59000.0 + i / self.img_count for i in range(self.img_count)])
         self.fake_ds = FakeDataSet(
             self.dim_x,
             self.dim_y,
@@ -35,8 +35,9 @@ class test_trajectory_explorer(unittest.TestCase):
         self.fake_ds.insert_object(self.trj)
 
         # Remove at least one observation from the trajectory.
-        pred_x = self.trj.get_x_index(fake_times[10])
-        pred_y = self.trj.get_y_index(fake_times[10])
+        zeroed_times = fake_times - fake_times[0]
+        pred_x = self.trj.get_x_index(zeroed_times[10])
+        pred_y = self.trj.get_y_index(zeroed_times[10])
         sci_t10 = self.fake_ds.stack_py.sci[10]
         for dy in [-1, 0, 1]:
             for dx in [-1, 0, 1]:

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -3,6 +3,7 @@ from astropy.wcs import WCS
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.time import Time
 
+import logging
 import numpy as np
 import numpy.testing as npt
 import os
@@ -464,10 +465,14 @@ class test_work_unit(unittest.TestCase):
         self.assertAlmostEqual(work.compute_ecliptic_angle(), -0.38154, 4)
 
         # If we do not have a WCS, we get None for the ecliptic angle.
+        # Silence the logged warning during compute_ecliptic_angle and the
+        # warning when creating the WorkUnit.
+        logging.disable(logging.CRITICAL)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             work2 = WorkUnit(self.im_stack_py, self.config, None, None)
             self.assertIsNone(work2.compute_ecliptic_angle())
+        logging.disable(logging.NOTSET)
 
     def test_image_positions_to_original_icrs_invalid_format(self):
         work = WorkUnit(


### PR DESCRIPTION
Silence expected warnings during the unittests including:
- Variance image with zeros (from a fitsFactory that is intentionally generating zero layers).
- Dubious date from using an MJD at zero (fixes the date).
- A warning about a missing WCS in a test that a call without a WCS returns None.