### PR TITLE
Add an option to limit the maximum number of results produced.

### DIFF
--- a/docs/source/user_manual/search_params.rst
+++ b/docs/source/user_manual/search_params.rst
@@ -92,9 +92,10 @@ Configuration Parameters
 | ``lh_level``           | 10.0                        | The minimum computed likelihood for an |
 |                        |                             | object to be accepted.                 |
 +------------------------+-----------------------------+----------------------------------------+
-| ``max_results``        | 10000                       | The maximum number of results to save  |
+| ``max_results``        | 100000                      | The maximum number of results to save  |
 |                        |                             | after all filtering.  The highest      |
-|                        |                             | likelihood results are saved.          |
+|                        |                             | likelihood results are saved. Use -1   |
+|                        |                             | to save all results.                   |
 +------------------------+-----------------------------+----------------------------------------+
 | ``near_dup_thresh``    | 10                          | The grid size (in pixels) for near     |
 |                        |                             | duplicate pre-filtering. Use ``None``  |

--- a/docs/source/user_manual/search_params.rst
+++ b/docs/source/user_manual/search_params.rst
@@ -92,6 +92,10 @@ Configuration Parameters
 | ``lh_level``           | 10.0                        | The minimum computed likelihood for an |
 |                        |                             | object to be accepted.                 |
 +------------------------+-----------------------------+----------------------------------------+
+| ``max_results``        | 10000                       | The maximum number of results to save  |
+|                        |                             | after all filtering.  The highest      |
+|                        |                             | likelihood results are saved.          |
++------------------------+-----------------------------+----------------------------------------+
 | ``near_dup_thresh``    | 10                          | The grid size (in pixels) for near     |
 |                        |                             | duplicate pre-filtering. Use ``None``  |
 |                        |                             | to skip this filtering step.           |

--- a/src/kbmod/configuration.py
+++ b/src/kbmod/configuration.py
@@ -45,14 +45,15 @@ class SearchConfiguration:
             "generate_psi_phi": True,
             "gpu_filter": False,
             "lh_level": 10.0,
+            "max_results": 10000,
             "near_dup_thresh": 10,
             "nightly_coadds": False,
             "num_obs": 10,
             "psf_val": 1.4,
             "result_filename": None,
-            "save_config": True,
             "results_per_pixel": 8,
             "save_all_stamps": False,
+            "save_config": True,
             "sigmaG_filter": True,
             "sigmaG_lims": [25, 75],
             "stamp_radius": 10,
@@ -138,6 +139,9 @@ class SearchConfiguration:
         # Check parameters that have known constraints.
         if self._params["results_per_pixel"] <= 0:
             logger.warning(f"Invalid results_per_pixel: {self._params['results_per_pixel']}")
+            return False
+        if self._params["max_results"] <= 0:
+            logger.warning(f"Invalid max_results: {self._params['max_results']}")
             return False
 
         if self._params["encode_num_bytes"] not in set([-1, 1, 2, 4]):

--- a/src/kbmod/configuration.py
+++ b/src/kbmod/configuration.py
@@ -45,7 +45,7 @@ class SearchConfiguration:
             "generate_psi_phi": True,
             "gpu_filter": False,
             "lh_level": 10.0,
-            "max_results": 10000,
+            "max_results": 100_000,
             "near_dup_thresh": 10,
             "nightly_coadds": False,
             "num_obs": 10,
@@ -139,9 +139,6 @@ class SearchConfiguration:
         # Check parameters that have known constraints.
         if self._params["results_per_pixel"] <= 0:
             logger.warning(f"Invalid results_per_pixel: {self._params['results_per_pixel']}")
-            return False
-        if self._params["max_results"] <= 0:
-            logger.warning(f"Invalid max_results: {self._params['max_results']}")
             return False
 
         if self._params["encode_num_bytes"] not in set([-1, 1, 2, 4]):

--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -335,6 +335,32 @@ class Results:
         ]
         return trajectories
 
+    def sort(self, colname, descending=True):
+        """Sort the results by a given column.
+
+        Parameters
+        ----------
+        colname : `str`
+            The name of the column to sort by.
+        reversdescendinge : `bool`
+            Whether to sort in descending order. By default this is true,
+            so that the highest likelihoods and num obs are the the top.
+            Default: True.
+
+        Returns
+        -------
+        self : `Results`
+            Returns a reference to itself to allow chaining.
+
+        Raises
+        ------
+        Raises a KeyError if the column is not in the data.
+        """
+        if colname not in self.table.colnames:
+            raise KeyError(f"Column {colname} not found.")
+        self.table.sort(colname, reverse=descending)
+        return self
+
     def compute_likelihood_curves(self, filter_obs=True, mask_value=0.0):
         """Create a matrix of likelihood curves where each row has a likelihood
         curve for a single trajectory.
@@ -737,6 +763,15 @@ class Results:
                 f"Unsupported file type '{filepath.suffix}' " f"use one of {self._supported_formats}."
             )
 
+        # Include optional arguments for hdf5 to avoid a warning.
+        if filepath.suffix == ".hdf5":
+            kwargs = {
+                "path": "__astropy_table__",
+                "serialize_meta": True,
+            }
+        else:
+            kwargs = {}
+
         # Add global meta data that we can retrieve.
         if self.wcs is not None:
             logger.debug("Saving WCS to Results table meta data.")
@@ -753,7 +788,7 @@ class Results:
                 self.table.meta[key] = val
 
         # Write out the table.
-        self.table.write(filename, overwrite=overwrite)
+        self.table.write(filename, overwrite=overwrite, **kwargs)
 
     def write_column(self, colname, filename):
         """Save a single column's data as a numpy data file.

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -409,6 +409,16 @@ class SearchRunner:
             apply_clustering(keep, cluster_params)
             self._end_phase("clustering")
 
+        # Filter by max_results, keeping only the results with the highest likelihoods.
+        # This should be the last step of the filtering phase, but before we add auxiliary
+        # information like stamps.
+        if config["max_results"] < len(keep):
+            self._start_phase("max_results")
+            logger.info(f"Filtering {len(keep)}results to max_results={config['max_results']}")
+            keep.sort("likelihood", descending=True)
+            keep.filter_rows(np.arange(config["max_results"]), "max_results")
+            self._end_phase("max_results")
+
         # Generate coadded stamps without filtering -- both the "stamp" column
         # as well as any additional coadds.
         self._start_phase("stamp generation")

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -412,7 +412,7 @@ class SearchRunner:
         # Filter by max_results, keeping only the results with the highest likelihoods.
         # This should be the last step of the filtering phase, but before we add auxiliary
         # information like stamps.
-        if config["max_results"] < len(keep):
+        if config["max_results"] > -1 and config["max_results"] < len(keep):
             self._start_phase("max_results")
             logger.info(f"Filtering {len(keep)}results to max_results={config['max_results']}")
             keep.sort("likelihood", descending=True)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -192,6 +192,33 @@ class test_results(unittest.TestCase):
         for i in range(self.num_entries):
             self.assertEqual(table1["x"][i], i)
 
+    def test_sort(self):
+        trj_list = [
+            Trajectory(x=0, y=0, vx=0, vy=0, lh=100.0, obs_count=10),
+            Trajectory(x=1, y=1, vx=0, vy=0, lh=110.0, obs_count=9),
+            Trajectory(x=2, y=2, vx=0, vy=0, lh=90.0, obs_count=8),
+            Trajectory(x=3, y=3, vx=0, vy=0, lh=120.0, obs_count=11),
+            Trajectory(x=4, y=4, vx=0, vy=0, lh=80.0, obs_count=15),
+            Trajectory(x=5, y=5, vx=0, vy=0, lh=85.0, obs_count=12),
+            Trajectory(x=6, y=6, vx=0, vy=0, lh=75.0, obs_count=5),
+            Trajectory(x=7, y=7, vx=0, vy=0, lh=125.0, obs_count=14),
+        ]
+        table = Results.from_trajectories(trj_list)
+        self.assertTrue(np.array_equal(table["x"], [0, 1, 2, 3, 4, 5, 6, 7]))
+        self.assertTrue(np.array_equal(table["y"], [0, 1, 2, 3, 4, 5, 6, 7]))
+
+        table.sort("likelihood")
+        self.assertTrue(np.array_equal(table["x"], [7, 3, 1, 0, 2, 5, 4, 6]))
+        self.assertTrue(np.array_equal(table["y"], [7, 3, 1, 0, 2, 5, 4, 6]))
+
+        table.sort("obs_count")
+        self.assertTrue(np.array_equal(table["x"], [4, 7, 5, 3, 0, 1, 2, 6]))
+        self.assertTrue(np.array_equal(table["y"], [4, 7, 5, 3, 0, 1, 2, 6]))
+
+        table.sort("x", descending=False)
+        self.assertTrue(np.array_equal(table["x"], [0, 1, 2, 3, 4, 5, 6, 7]))
+        self.assertTrue(np.array_equal(table["y"], [0, 1, 2, 3, 4, 5, 6, 7]))
+
     def test_add_psi_phi(self):
         num_to_use = 3
         table = Results.from_trajectories(self.trj_list[0:num_to_use])

--- a/tests/test_run_search.py
+++ b/tests/test_run_search.py
@@ -450,6 +450,10 @@ class test_run_search(unittest.TestCase):
             self.assertAlmostEqual(keep1["vy"][i], keep2["vy"][i])
             self.assertAlmostEqual(keep1["likelihood"][i], keep2["likelihood"][i])
 
+        config.set("max_results", -1)
+        keep3 = runner.run_search(config, fake_ds.stack_py, trj_generator=trj_gen)
+        self.assertGreater(len(keep3), 100)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds a safeguard to avoid producing an excessive number of results. The "max_results" flag will return a limited number of top results.  By default we use the (very high) value of 100,000 results. If the flag is set to -1 all results are returned.

The PR also adds sorting functionality to the `Results` data structure and cleans up a warning when saving to “.hdf5” (due to not specifying a path argument).