### PR TITLE
Remove unused function in Results

### DIFF
--- a/src/kbmod/core/psf.py
+++ b/src/kbmod/core/psf.py
@@ -87,7 +87,7 @@ class PSF:
 
     def copy(self):
         """Returns a copy of the PSF."""
-        return PSF(np.copy(self.kernel.copy()))
+        return PSF(self.kernel.copy())
 
     def _normalize(self):
         """Normalizes the PSF so that it sums to 1."""

--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -530,42 +530,6 @@ class Results:
             self._update_likelihood()
         return self
 
-    def mask_based_on_invalid_obs(self, input_mat, mask_value):
-        """Mask the entries in a given input matrix based on the invalid observations
-        in the results. If an observation in result i, time t is invalid, then the corresponding
-        entry input_mat[i][t] will be masked. This helper function is used when computing
-        statistics on arrays of information.
-
-        The input should be N x T where N is the number of results and T is the number of time steps.
-
-        Parameters
-        ----------
-        input_mat : `numpy.ndarray`
-            An N x T input matrix.
-        mask_value : any
-            The value to subsitute into the input array.
-
-        Returns
-        -------
-        result : `numpy.ndarray`
-            An N x T output matrix where ``result[i][j]`` is ``input_mat[i][j]`` if
-            result ``i``, timestep ``j`` is valid and ``mask_value`` otherwise.
-
-        Raises
-        ------
-        Raises a ``ValueError`` if the array sizes do not match.
-        """
-        if len(input_mat) != len(self.table):
-            raise ValueError(f"Incorrect input matrix dimensions.")
-        masked_mat = np.copy(input_mat)
-
-        # If we do have validity information, use it to do the mask.
-        if "obs_valid" in self.table.colnames:
-            if input_mat.shape[1] != self.table["obs_valid"].shape[1]:
-                raise ValueError(f"Incorrect input matrix dimensions.")
-            masked_mat[~self.table["obs_valid"]] = mask_value
-        return masked_mat
-
     def is_empty_value(self, colname):
         """Create a Boolean vector indicating whether the entry in each row
         is an 'empty' value (None or anything of length 0). Used to mark or

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -668,36 +668,6 @@ class test_results(unittest.TestCase):
             self.assertEqual(data[2][0], "filter2")
             self.assertEqual(data[2][1], "3")
 
-    def test_mask_based_on_invalid_obs(self):
-        num_times = 5
-        mjds = np.array([i for i in range(num_times)])
-
-        num_results = 6
-        trj_all = [Trajectory(x=i) for i in range(num_results)]
-        table = Results.from_trajectories(trj_all)
-        self.assertEqual(len(table), num_results)
-
-        obs_valid = np.array(
-            [
-                [True, True, True, False, True],
-                [True, True, True, True, False],
-                [False, False, True, True, True],
-                [False, True, True, True, False],
-                [True, False, False, False, True],
-                [False, False, True, False, False],
-            ]
-        )
-        table.update_obs_valid(obs_valid)
-
-        data_mat = np.full((num_results, num_times), 1.0)
-        masked_mat = table.mask_based_on_invalid_obs(data_mat, -1.0)
-        for r in range(num_results):
-            for c in range(num_times):
-                if obs_valid[r][c]:
-                    self.assertEqual(masked_mat[r][c], 1.0)
-                else:
-                    self.assertEqual(masked_mat[r][c], -1.0)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Remove the unused `mask_based_on_invalid_obs` function from `Results`.  This was implemented for an old filtering approach that did not work out.

Also clean up an extra copy in `PSF.copy()`.