### PR TITLE
Small Improvements to Fake Data Generation

### DIFF
--- a/tests/test_core_search_exact.py
+++ b/tests/test_core_search_exact.py
@@ -38,7 +38,7 @@ class test_search_exact(unittest.TestCase):
             psf_val=1.0,
             rng=rng,
         )
-        image_stack_add_fake_object(image_stack_py, start_x, start_y, xvel, yvel, object_flux)
+        image_stack_add_fake_object(image_stack_py, start_x, start_y, xvel, yvel, flux=object_flux)
 
         # Turn off all filtering and use a custom trajectory generator that
         # tests 1681 velocities per pixel and includes the true velocity.

--- a/tests/test_fake_data_creator.py
+++ b/tests/test_fake_data_creator.py
@@ -68,8 +68,8 @@ class test_fake_image_creator(unittest.TestCase):
         fake_times = np.arange(num_times)
         sci = np.full((num_times, height, width), 0.0)
         var = np.full((num_times, height, width), 1.0)
-        sci[3][53, 66] = np.nan
-        var[3][53, 66] = np.nan
+        sci[3][66, 53] = np.nan
+        var[3][66, 53] = np.nan
         psfs = [PSF.from_gaussian(0.5) for i in range(num_times)]
         fake_stack = ImageStackPy(fake_times, sci, var, psfs=psfs)
 

--- a/tests/test_fake_data_creator.py
+++ b/tests/test_fake_data_creator.py
@@ -6,7 +6,6 @@ import unittest
 from pathlib import Path
 
 from kbmod.fake_data.fake_data_creator import *
-from kbmod.search import *
 from kbmod.wcs_utils import make_fake_wcs
 from kbmod.work_unit import WorkUnit
 
@@ -44,8 +43,55 @@ class test_fake_image_creator(unittest.TestCase):
             self.assertTrue(np.allclose(fake_stack.var[idx], 4.0))
         self.assertEqual(len(fake_stack.psfs), 10)
 
+    def test_mask_fake_image_stack(self):
+        """Test that we can add random masking to an ImageStackPy."""
+        fake_times = np.arange(10)
+        fake_stack = make_fake_image_stack(200, 300, fake_times)
+
+        # Nothing is masked by default.
+        self.assertTrue(np.all(fake_stack.num_masked_pixels() == 0))
+
+        # Mask 10% of the pixels in each image.
+        rng = np.random.default_rng(103)
+        image_stack_add_random_masks(fake_stack, 0.1, rng=rng)
+        self.assertTrue(np.all(fake_stack.num_masked_pixels() > 0))
+        self.assertTrue(np.all(fake_stack.get_masked_fractions() > 0.05))
+        self.assertTrue(np.all(fake_stack.get_masked_fractions() < 0.15))
+
     def test_image_stack_add_fake_object(self):
-        """Test that we can inset a fake object into an ImageStackPy."""
+        """Test that we can insert a fake object into an ImageStackPy."""
+        num_times = 5
+        height = 200
+        width = 300
+
+        # Create a fake ImageStackPy with 5 time steps and a masked pixel at time 3.
+        fake_times = np.arange(num_times)
+        sci = np.full((num_times, height, width), 0.0)
+        var = np.full((num_times, height, width), 1.0)
+        sci[3][53, 66] = np.nan
+        var[3][53, 66] = np.nan
+        psfs = [PSF.from_gaussian(0.5) for i in range(num_times)]
+        fake_stack = ImageStackPy(fake_times, sci, var, psfs=psfs)
+
+        image_stack_add_fake_object(fake_stack, 50, 60, 1.0, 2.0, flux=100.0)
+        for t_idx, t_val in enumerate(fake_times):
+            # Check that we receive a signal at the correct location that
+            # is non-zero but less than the flux (due to the PSF) at each time step.
+            px = int(50 + t_val + 0.5)
+            py = int(60 + 2.0 * t_val + 0.5)
+
+            if t_idx == 3:
+                # At time 3, the pixel is masked, so we should not have a signal.
+                self.assertTrue(np.isnan(fake_stack.sci[t_idx][py, px]))
+            else:
+                self.assertGreater(fake_stack.sci[t_idx][py, px], 50.0)
+                self.assertLess(fake_stack.sci[t_idx][py, px], 100.0)
+
+            # Far away from the object, the signal should be zero.
+            self.assertAlmostEqual(fake_stack.sci[t_idx][30, 40], 0.0)
+
+    def test_image_stack_add_fake_object_quadratic(self):
+        """Test that we can insert a fake object with a quadratic trajectory into an ImageStackPy."""
         num_times = 5
         height = 200
         width = 300
@@ -56,12 +102,12 @@ class test_fake_image_creator(unittest.TestCase):
         psfs = [PSF.from_gaussian(0.5) for i in range(num_times)]
         fake_stack = ImageStackPy(fake_times, sci, var, psfs=psfs)
 
-        image_stack_add_fake_object(fake_stack, 50, 60, 1.0, 2.0, 100.0)
+        image_stack_add_fake_object(fake_stack, 50, 60, 1.0, 2.0, ax=1.1, ay=-0.5, flux=100.0)
         for t_idx, t_val in enumerate(fake_times):
             # Check that we receive a signal at the correct location that
             # is non-zero but less than the flux (due to the PSF) at each time step.
-            px = int(50 + t_val + 0.5)
-            py = int(60 + 2.0 * t_val + 0.5)
+            px = int(50 + t_val + 0.5 * 1.1 * t_val * t_val + 0.5)
+            py = int(60 + 2.0 * t_val + 0.5 * (-0.5) * t_val * t_val + 0.5)
             self.assertGreater(fake_stack.sci[t_idx][py, px], 50.0)
             self.assertLess(fake_stack.sci[t_idx][py, px], 100.0)
 
@@ -82,9 +128,59 @@ class test_fake_image_creator(unittest.TestCase):
             self.assertGreater(t, last_time)
             last_time = t
 
+    def test_create_fake_data_set_parameters(self):
+        """Test that we can create a FakeDataSet with specific noise parameters."""
+        times = create_fake_times(10)
+        ds = FakeDataSet(
+            256,
+            256,
+            times,
+            mask_fraction=0.3,
+            noise_level=0.5,
+            use_seed=105,
+        )
+        self.assertEqual(ds.stack_py.num_times, 10)
+
+        for i in range(ds.stack_py.num_times):
+            masked = ds.stack_py.get_mask(i)
+            self.assertAlmostEqual(np.sum(masked) / ds.stack_py.npixels, 0.3, delta=0.1)
+
+            # Check that we get the expected mean and std of science.
+            self.assertAlmostEqual(np.mean(ds.stack_py.sci[i][~masked]), 0.0, delta=0.05)
+            self.assertAlmostEqual(np.std(ds.stack_py.sci[i][~masked]), 0.5, delta=0.05)
+            self.assertTrue(np.all(ds.stack_py.var[i][~masked] == 0.25))
+
+    def test_fake_data_set_insert_artifacts(self):
+        """Test that we can insert artifacts into a FakeDataSet."""
+        width = 200
+        height = 300
+        times = create_fake_times(10)
+        ds = FakeDataSet(
+            width,
+            height,
+            times,
+            mask_fraction=0.0,  # No masking
+            noise_level=0.1,  # Low noise level
+            use_seed=105,
+        )
+
+        # Check that everything is basically noise.
+        self.assertEqual(ds.stack_py.num_times, 10)
+        for i in range(ds.stack_py.num_times):
+            self.assertEqual(np.count_nonzero(ds.stack_py.sci[i] > 2.0), 0)
+
+        # Insert a bunch of artifacts and test that they are inserted correctly.
+        ds.insert_random_artifacts(0.1, 20.0, 0.1)
+        for i in range(ds.stack_py.num_times):
+            artifacts = ds.stack_py.sci[i] > 2.0
+
+            self.assertAlmostEqual(np.sum(artifacts) / (width * height), 0.1, delta=0.1)
+            self.assertAlmostEqual(np.mean(ds.stack_py.sci[i][artifacts]), 20.0, delta=0.2)
+            self.assertAlmostEqual(np.mean(ds.stack_py.sci[i][~artifacts]), 0.0, delta=0.2)
+
     def test_insert_object(self):
         times = create_fake_times(5, 57130.2, 3, 0.01, 1)
-        ds = FakeDataSet(128, 128, times, use_seed=True)
+        ds = FakeDataSet(128, 128, times, use_seed=101)
         self.assertEqual(ds.stack_py.num_times, 5)
         self.assertEqual(len(ds.trajectories), 0)
 

--- a/tests/test_known_object_filters.py
+++ b/tests/test_known_object_filters.py
@@ -33,7 +33,7 @@ class TestKnownObjMatcher(unittest.TestCase):
         orig_obstimes = self.obstimes.copy()
         # Check that all obstimes are greater or equal to the start time
         self.assertTrue(np.all(self.obstimes >= start_time))
-        ds = FakeDataSet(15, 10, self.obstimes, use_seed=True)
+        ds = FakeDataSet(15, 10, self.obstimes, use_seed=101)
         self.wcs = make_fake_wcs(10.0, 15.0, 15, 10)
         ds.set_wcs(self.wcs)
 

--- a/tests/test_regression_test.py
+++ b/tests/test_regression_test.py
@@ -50,7 +50,7 @@ def make_fake_images(times, trjs, psf_vals):
     rng = np.random.default_rng(1001)
     stack = make_fake_image_stack(dim_y, dim_x, times, noise_level=4.0, psfs=psfs, rng=rng)
     for trj in trjs:
-        image_stack_add_fake_object(stack, trj.x, trj.y, trj.vx, trj.vy, trj.flux)
+        image_stack_add_fake_object(stack, trj.x, trj.y, trj.vx, trj.vy, flux=trj.flux)
     return stack
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -71,7 +71,7 @@ class test_search(unittest.TestCase):
             self.start_y,
             self.vxel,
             self.vyel,
-            self.object_flux,
+            flux=self.object_flux,
         )
 
         # Mask a pixel in every other image.
@@ -245,7 +245,7 @@ class test_search(unittest.TestCase):
             psf_val=1.0,
             rng=rng,
         )
-        image_stack_add_fake_object(image_stack_py, -3, 12, 25.0, 10.0, self.object_flux)
+        image_stack_add_fake_object(image_stack_py, -3, 12, 25.0, 10.0, flux=self.object_flux)
 
         search = StackSearch(
             image_stack_py.sci,

--- a/tests/test_search_encode.py
+++ b/tests/test_search_encode.py
@@ -50,7 +50,7 @@ class test_search_filter(unittest.TestCase):
             fake_times,
             noise_level=2.0,
             psf_val=1.0,
-            use_seed=True,
+            use_seed=101,
         )
         fake_ds.insert_object(self.trj)
         self.stack = fake_ds.stack_py

--- a/tests/test_stack_search_results.py
+++ b/tests/test_stack_search_results.py
@@ -117,7 +117,7 @@ class test_search(unittest.TestCase):
             time_list,
             noise_level=1.0,
             psf_val=0.5,
-            use_seed=True,
+            use_seed=101,
         )
 
         # Create fake result trajectories with given initial likelihoods. The two final ones

--- a/tests/test_stamp_filters.py
+++ b/tests/test_stamp_filters.py
@@ -20,8 +20,8 @@ class test_stamp_filters(unittest.TestCase):
             25,  # width
             35,  # height
             self.fake_times,  # time stamps
-            1.0,  # noise level
-            0.5,  # psf value
+            noise_level=1.0,  # noise level
+            psf_val=0.5,  # psf value
             psfs=None,  # No per-image PSFs
             use_seed=101,  # Use a fixed seed for testing
         )

--- a/tests/test_stamp_filters.py
+++ b/tests/test_stamp_filters.py
@@ -23,7 +23,7 @@ class test_stamp_filters(unittest.TestCase):
             1.0,  # noise level
             0.5,  # psf value
             psfs=None,  # No per-image PSFs
-            use_seed=True,  # Use a fixed seed for testing
+            use_seed=101,  # Use a fixed seed for testing
         )
 
         # Insert a single fake object with known parameters.

--- a/tests/test_stamp_utils.py
+++ b/tests/test_stamp_utils.py
@@ -266,7 +266,7 @@ class test_stamp_utils(unittest.TestCase):
             fake_times,  # time stamps
             noise_level=1.0,  # noise level
             psf_val=0.5,  # psf value
-            use_seed=True,  # Use a fixed seed for testing
+            use_seed=101,  # Use a fixed seed for testing
         )
 
         # Insert a single fake object with known parameters.
@@ -318,7 +318,7 @@ class test_stamp_utils(unittest.TestCase):
             fake_times,  # time stamps
             noise_level=1.0,  # noise level
             psf_val=0.5,  # psf value
-            use_seed=True,  # Use a fixed seed for testing
+            use_seed=101,  # Use a fixed seed for testing
         )
 
         # Insert a single fake object with known parameters.

--- a/tests/test_trajectory_explorer.py
+++ b/tests/test_trajectory_explorer.py
@@ -30,7 +30,7 @@ class test_trajectory_explorer(unittest.TestCase):
             fake_times,
             noise_level=2.0,
             psf_val=1.0,
-            use_seed=True,
+            use_seed=101,
         )
         self.fake_ds.insert_object(self.trj)
 

--- a/tests/test_work_unit.py
+++ b/tests/test_work_unit.py
@@ -46,7 +46,7 @@ class test_work_unit(unittest.TestCase):
         )
 
         # Add a random bright object (to add some bright pixels).
-        image_stack_add_fake_object(self.im_stack_py, 150, 155, 1.0, 1.0, 250.0)
+        image_stack_add_fake_object(self.im_stack_py, 150, 155, 1.0, 1.0, flux=250.0)
 
         # Mask one of the pixels in each image.  This is done directly to the science
         # and variance layers since ImageStackPy does not have a separate mask layer.


### PR DESCRIPTION
A bunch of small upgrades to the fake data creation functions:
- Add random masking to the fake data generator
- Add inserting non-background news, like diff artifacts, that are brighter (to test potential spurious bright pixels).
- Allow inserted fake objects to have quadratic trajectories (to test performance against non-linearity).
- Don’t insert objects on top of masked pixels.
- `FakeDataSet` constructor takes a specific seed instead of a Boolean to allow more flexibility.