### PR TITLE
Commandline Tool for Ingesting Butler Collections as KBMOD ImageCollections

### DIFF
--- a/src/kbmod_cmdline/kbmod_build_ic.py
+++ b/src/kbmod_cmdline/kbmod_build_ic.py
@@ -118,7 +118,7 @@ def execute(args):
         # Sort collections by largest to smallest
         collection_cnts = {k: v for k, v in sorted(collection_cnts.items(), key=lambda x: x[1], reverse=True)}
         for name, size in collection_cnts.items():
-            print(f"Coolection {name}: has {size} exposures")
+            print(f"Collection {name}: has {size} exposures")
         return 0
 
     # Ingest each collection


### PR DESCRIPTION
Provides a simple commandline tool for ingesting Butler collections as ImageCollections.

The user must provide a butler repository path, and a butler datasetType, such as `preliminary_visit_image` or `difference_image`, to ingest. Then the user can either provide a list of collections to process or a regex across the repository's collection names.

Then for each specified collection, a KBMOD ImageCollection is created and serialized to a specified output directory.