### PR TITLE
Add a few more helper functions for testing

### DIFF
--- a/tests/test_fake_results_creator.py
+++ b/tests/test_fake_results_creator.py
@@ -110,6 +110,49 @@ class test_fake_result_creator(unittest.TestCase):
             self.assertEqual(results["coadd_mean"][i].shape, (7, 7))
             self.assertEqual(results["coadd_median"][i].shape, (21, 21))
 
+    def test_add_fake_psi_phi_to_results(self):
+        num_results = 100
+        num_times = 10
+        num_pts = num_results * num_times
+
+        results = make_fake_results(num_times, 200, 250, num_results)
+
+        # Add default fake psi and phi curves.
+        results = add_fake_psi_phi_to_results(results, signal_mean=10.0, data_var=0.5)
+        self.assertTrue(np.all(np.abs(results["psi_curve"] - 20.0) < 2.0))
+        self.assertTrue(np.all(np.abs(results["phi_curve"] - 2.0) < 0.5))
+        self.assertTrue(np.all(results["obs_valid"]))
+
+        # Add fake psi and phi curves with masking.
+        results = make_fake_results(num_times, 200, 250, num_results)
+        results = add_fake_psi_phi_to_results(results, masked_fraction=0.2)
+        valid = results["obs_valid"]
+
+        self.assertFalse(np.any(np.isnan(results["psi_curve"][valid])))
+        self.assertFalse(np.any(np.isnan(results["phi_curve"][valid])))
+        self.assertTrue(np.all(np.isnan(results["psi_curve"][~valid])))
+        self.assertTrue(np.all(np.isnan(results["psi_curve"][~valid])))
+
+        self.assertAlmostEqual(np.sum(valid) / num_pts, 0.8, delta=0.1)
+        self.assertAlmostEqual(np.mean(results["psi_curve"][valid]), 20.0, delta=4.0)
+        self.assertAlmostEqual(np.mean(results["phi_curve"][valid]), 2.0, delta=0.5)
+
+        # Add fake psi and phi curves with outliers.
+        results = make_fake_results(num_times, 200, 250, num_results)
+        results = add_fake_psi_phi_to_results(
+            results,
+            signal_mean=10.0,
+            data_var=0.5,
+            outlier_fraction=0.3,
+            outlier_mean=100.0,
+            masked_fraction=0.0,
+        )
+        not_outlier = results["psi_curve"] < 50.0
+        self.assertTrue(np.all(not_outlier == results["obs_valid"]))
+        self.assertAlmostEqual(np.mean(results["psi_curve"][not_outlier]), 20.0, delta=4.0)
+        self.assertAlmostEqual(np.mean(results["psi_curve"][~not_outlier]), 100.0, delta=10.0)
+        self.assertAlmostEqual(np.mean(results["phi_curve"]), 2.0, delta=0.5)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_trajectory_utils.py
+++ b/tests/test_trajectory_utils.py
@@ -4,7 +4,8 @@ import unittest
 from astropy.wcs import WCS
 
 from kbmod.trajectory_utils import *
-from kbmod.search import *
+from kbmod.results import Results
+from kbmod.search import Trajectory
 
 
 class test_trajectory_utils(unittest.TestCase):
@@ -119,6 +120,27 @@ class test_trajectory_utils(unittest.TestCase):
         self.assertAlmostEqual(mse, 0.25 + 0.01)
 
         self.assertRaises(ValueError, evaluate_trajectory_mse, trj, [], [], [])
+
+    def test_trajectory_results_best_match(self):
+        queries = [
+            Trajectory(x=0, y=0, vx=0.0, vy=0.0),
+            Trajectory(x=10, y=10, vx=0.5, vy=-2.0),
+            Trajectory(x=50, y=80, vx=-1.0, vy=0.0),
+        ]
+
+        candidates = [
+            Trajectory(x=0, y=0, vx=0.0, vy=0.0),
+            Trajectory(x=1, y=0, vx=0.0, vy=0.0),
+            Trajectory(x=15, y=15, vx=0.5, vy=-2.0),
+            Trajectory(x=49, y=82, vx=-1.0, vy=0.01),
+            Trajectory(x=10, y=10, vx=0.6, vy=-2.1),
+            Trajectory(x=0, y=0, vx=0.0, vy=0.01),
+        ]
+        results = Results.from_trajectories(candidates)
+
+        # Do a greedy matching.
+        match_dist, match_idx = trajectory_results_best_match(queries, results, times=[0.0, 10.0])
+        self.assertTrue(np.array_equal(match_idx, [0, 4, 3]))
 
     def test_match_trajectory_sets(self):
         queries = [


### PR DESCRIPTION
- Add a function that greedily finds the best matching row in a `Result` object. We could do this with earlier functions, but at the cost of building a list of trajectories each time we do an evaluation. This is a more efficient implementation.
- Add more noise parameters to creating a fake result set.