### PR TITLE
Fix for creating image stacks with variably sized images on latest butler

### DIFF
--- a/src/kbmod/core/image_stack_py.py
+++ b/src/kbmod/core/image_stack_py.py
@@ -180,10 +180,10 @@ class ImageStackPy:
             self.height = img.shape[0]
 
         # Check that the image is the correct size.
-        if img.shape[1] != self.width:
-            raise ValueError(f"Incorrect image width. Expected {self.width}. Received {img.shape[1]}")
-        if img.shape[0] != self.height:
-            raise ValueError(f"Incorrect image height. Expected {self.height}. Received {img.shape[0]}")
+        if img.shape[1] > self.width:
+            self.width = img.shape[1]
+        if img.shape[0] > self.height:
+            self.height = img.shape[0]
 
         return img
 

--- a/src/kbmod/core/image_stack_py.py
+++ b/src/kbmod/core/image_stack_py.py
@@ -42,12 +42,12 @@ class LayeredImagePy:
 
     @property
     def width(self):
-        """The width of the image."""
+        """The width of the widest image in the stack."""
         return self.sci.shape[1]
 
     @property
     def height(self):
-        """The height of the image."""
+        """The height of the tallest image in the stack."""
         return self.sci.shape[0]
 
 
@@ -179,7 +179,9 @@ class ImageStackPy:
             self.width = img.shape[1]
             self.height = img.shape[0]
 
-        # Check that the image is the correct size.
+        # We allow images of different sizes to be added to the stack,
+        # so update our height and width properties if this image is larger.
+        # In practice, we expect most images will be the same or similar in size.
         if img.shape[1] > self.width:
             self.width = img.shape[1]
         if img.shape[0] > self.height:

--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -170,10 +170,11 @@ class ButlerStandardizer(Standardizer):
         # Somewhere around w_2024_ builds the datastore.root
         # was removed as an attribute of the datastore, not sure
         # it was ever replaced with anything back-compatible
-        try:
-            super().__init__(str(butler._datastore.root), config=config)
-        except AttributeError:
-            super().__init__(butler.datastore.root, config=config)
+        #try:
+        super().__init__(str(butler._datastore.roots), config=config)
+        #except AttributeError as e:
+        #    print(e)
+        #    super().__init__(butler.datastore.root, config=config)
 
         self.butler = butler
 

--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -169,12 +169,23 @@ class ButlerStandardizer(Standardizer):
 
         # Somewhere around w_2024_ builds the datastore.root
         # was removed as an attribute of the datastore, not sure
-        # it was ever replaced with anything back-compatible
-        try:
-            super().__init__(str(butler._datastore.roots), config=config)
-        except AttributeError as e:
-            print(e)
-            super().__init__(butler.datastore.root, config=config)
+        # it was ever replaced with anything back-compatible. We simply
+        # check for the which _datastore attribute is available for this
+        # butler and then check wherther it has a root or roots attribute.
+        
+        if hasattr(butler, "datastore"):
+            datastore_root = butler.datastore.root
+        elif hasattr(butler, "_datastore"):
+            if hasattr(butler._datastore, "root"):
+                datastore_root = butler._datastore.root
+            elif hasattr(butler._datastore, "roots"):
+                datastore_root = butler._datastore.roots
+            else:
+                raise AttributeError("Butler does not have a valid datastore root attribute.")
+        else:
+            raise AttributeError("Butler does not have a valid datastore root attribute.")
+    
+        super().__init__(str(datastore_root), config=config)
 
         self.butler = butler
 

--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -172,7 +172,7 @@ class ButlerStandardizer(Standardizer):
         # it was ever replaced with anything back-compatible. We simply
         # check for the which _datastore attribute is available for this
         # butler and then check wherther it has a root or roots attribute.
-        
+
         if hasattr(butler, "datastore"):
             datastore_root = butler.datastore.root
         elif hasattr(butler, "_datastore"):
@@ -184,7 +184,7 @@ class ButlerStandardizer(Standardizer):
                 raise AttributeError("Butler does not have a valid datastore root attribute.")
         else:
             raise AttributeError("Butler does not have a valid datastore root attribute.")
-    
+
         super().__init__(str(datastore_root), config=config)
 
         self.butler = butler

--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -170,11 +170,11 @@ class ButlerStandardizer(Standardizer):
         # Somewhere around w_2024_ builds the datastore.root
         # was removed as an attribute of the datastore, not sure
         # it was ever replaced with anything back-compatible
-        #try:
-        super().__init__(str(butler._datastore.roots), config=config)
-        #except AttributeError as e:
-        #    print(e)
-        #    super().__init__(butler.datastore.root, config=config)
+        try:
+            super().__init__(str(butler._datastore.roots), config=config)
+        except AttributeError as e:
+            print(e)
+            super().__init__(butler.datastore.root, config=config)
 
         self.butler = butler
 
@@ -340,6 +340,8 @@ class ButlerStandardizer(Standardizer):
         meta["NAXIS1"] = self._naxis1
         meta["NAXIS2"] = self._naxis2
         self._wcs = WCS(meta)
+
+        self._metadata["pixel_scale"] = wcs.getPixelScale().asArcseconds()
 
         # calculate the WCS "error" (max difference between edge coordinates
         # from Rubin's more powerful SkyWCS and Atropy's Fits-WCS)

--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -183,7 +183,7 @@ class ButlerStandardizer(Standardizer):
             else:
                 raise AttributeError("Butler does not have a valid datastore root attribute.")
         else:
-            raise AttributeError("Butler does not have a valid datastore root attribute.")
+            raise AttributeError("Butler does not have a valid datastore attribute.")
 
         super().__init__(str(datastore_root), config=config)
 

--- a/tests/test_image_stack_py.py
+++ b/tests/test_image_stack_py.py
@@ -305,6 +305,44 @@ class test_image_stack_py(unittest.TestCase):
         expected = [-1, 0, 0, -1, 1, 4, 5, 5, 7, 7, -1]
         self.assertTrue(np.array_equal(matched_inds, expected))
 
+    def test_image_stack_py_grows_with_larger_images(self):
+        """Test that ImageStackPy updates width and height to match the largest image added and does not shrink."""
+        stack = ImageStackPy()
+        # Add 10x10 image
+        sci1 = np.ones((10, 10))
+        var1 = np.ones((10, 10))
+        stack.append_image(0.0, sci1, var1)
+        self.assertEqual(stack.width, 10)
+        self.assertEqual(stack.height, 10)
+
+        # Add 5x20 image (wider)
+        sci2 = np.ones((5, 20))
+        var2 = np.ones((5, 20))
+        stack.append_image(1.0, sci2, var2)
+        self.assertEqual(stack.width, 20)
+        self.assertEqual(stack.height, 10)  # Height stays the same, width grows
+
+        # Add 30x20 image (taller and wider)
+        sci3 = np.ones((30, 20))
+        var3 = np.ones((30, 20))
+        stack.append_image(2.0, sci3, var3)
+        self.assertEqual(stack.width, 20)
+        self.assertEqual(stack.height, 30)  # Height grows, width stays
+
+        # Add 35x25 image (both grow)
+        sci4 = np.ones((35, 25))
+        var4 = np.ones((35, 25))
+        stack.append_image(3.0, sci4, var4)
+        self.assertEqual(stack.width, 25)
+        self.assertEqual(stack.height, 35)
+
+        # Add another 10x10 image (should not shrink)
+        sci5 = np.ones((10, 10))
+        var5 = np.ones((10, 10))
+        stack.append_image(4.0, sci5, var5)
+        self.assertEqual(stack.width, 25)
+        self.assertEqual(stack.height, 35)
+
     def test_get_masked_fractions(self):
         """Test that we can compute the fraction of pixels masked at each index."""
         num_times = 20

--- a/tests/utils/mock_butler.py
+++ b/tests/utils/mock_butler.py
@@ -49,6 +49,7 @@ class UUID:
 class Datastore:
     def __init__(self, root):
         self.root = root
+        self.roots = [root]
 
 
 class DatasetType:
@@ -257,6 +258,7 @@ class MockButler:
 
     def __init__(self, root, ref=None, mock_images_f=None, registry=None, missing_headers=[]):
         self.datastore = Datastore(root)
+        self._datastore = Datastore(root)
         self.registry = Registry() if registry is None else registry
         self.mockImages = mock_images_f
         self.missing_headers = missing_headers


### PR DESCRIPTION
A small PR to fix some issues 

1. once the case where we are constructing an ImageStack with variably sized images. We see this in LSST even though most images will be similar in size in practice. To fix this rather than raising an error if not all images match in dimensions, we update the width and height properties of the stack to reflect the widest and tallest images that have been added respectively.

2. Currently the butler standardizer has some logic to provide backwards compatibility for an older API for the datastore root. We still preserve this logic, while also allowing for new butlers using the 'roots' property (a naming change that reflects chained collections)
