### PR TITLE
initial documentation update to include peak_offset_max

### DIFF
--- a/docs/source/user_manual/search_params.rst
+++ b/docs/source/user_manual/search_params.rst
@@ -114,6 +114,11 @@ Configuration Parameters
 |                        |                             | -1 then it is reduced to the number of |
 |                        |                             | the valid images.                      |
 +------------------------+-----------------------------+----------------------------------------+
+| ``peak_offset_max``    | None                        | The radius to use for the              |
+|                        |                             | ``peak_offset_max``` filter.           |
+|                        |                             | If ``None``, then does not apply       |
+|                        |                             | ``peak_offset_max``.                   |
++------------------------+-----------------------------+----------------------------------------+
 | ``psf_val``            | 1.4                         | The value for the standard deviation of|
 |                        |                             | the point spread function (PSF) in     |
 |                        |                             | pixels                                 |


### PR DESCRIPTION
Adds `peak_offset_max` to table of search params in KBMOD User Manual