### PR TITLE
Validate Image Stack Mask Shape Based on Current Mask Shape

### DIFF
--- a/src/kbmod/core/image_stack_py.py
+++ b/src/kbmod/core/image_stack_py.py
@@ -131,7 +131,7 @@ class ImageStackPy:
         if mask is not None:
             for idx in range(self.num_times):
                 current_mask = np.asanyarray(mask[idx])
-                if current_mask.shape != (self.height, self.width):
+                if current_mask.shape != self.sci[idx].shape:
                     raise ValueError("Science and Mask data must have the same shape.")
                 masked_pixels = current_mask > 0
                 self.sci[idx][masked_pixels] = np.nan
@@ -333,7 +333,7 @@ class ImageStackPy:
         # Apply the mask if it is provided.
         if mask is not None:
             mask = np.asanyarray(mask)
-            if mask.shape != (self.height, self.width):
+            if mask.shape != self.sci[current_idx].shape:
                 raise ValueError("Science and Mask data must have the same shape.")
             masked_pixels = mask > 0
             self.sci[current_idx][masked_pixels] = np.nan

--- a/src/kbmod/core/image_stack_py.py
+++ b/src/kbmod/core/image_stack_py.py
@@ -321,6 +321,12 @@ class ImageStackPy:
         psfs : np.array or PSF
             The PSF information for this time.
         """
+        # Validate the mask if it is provided before making any modifications to the image stack.
+        if mask is not None:
+            mask = np.asanyarray(mask)
+            if mask.shape != sci.shape:
+                raise ValueError("Science and Mask data must have the same shape.")
+
         current_idx = self.num_times
         self.sci.append(self._standardize_image(sci))
         self.var.append(self._standardize_image(var))
@@ -332,9 +338,6 @@ class ImageStackPy:
 
         # Apply the mask if it is provided.
         if mask is not None:
-            mask = np.asanyarray(mask)
-            if mask.shape != self.sci[current_idx].shape:
-                raise ValueError("Science and Mask data must have the same shape.")
             masked_pixels = mask > 0
             self.sci[current_idx][masked_pixels] = np.nan
             self.var[current_idx][masked_pixels] = np.nan

--- a/tests/test_image_stack_py.py
+++ b/tests/test_image_stack_py.py
@@ -1,7 +1,6 @@
 import logging
 import numpy as np
 import unittest
-import pytest
 
 from kbmod.core.image_stack_py import ImageStackPy, LayeredImagePy
 
@@ -321,7 +320,7 @@ class test_image_stack_py(unittest.TestCase):
         sci2 = np.ones((5, 20))
         var2 = np.ones((5, 20))
         mask2 = np.ones((5, 20))
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             # Using a mask of the wrong size should fail
             stack.append_image(1.0, sci2, var2, mask=mask1)
         self.assertEqual(len(stack), 1)  # Should still only have 1 image
@@ -347,7 +346,7 @@ class test_image_stack_py(unittest.TestCase):
         sci5 = np.ones((10, 10))
         var5 = np.ones((10, 10))
         mask5 = np.ones((10, 10))
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             # Using a mask with the shape of the largest image should still fail
             # for a smaller image
             mask4 = np.ones((35, 25))

--- a/tests/test_image_stack_py.py
+++ b/tests/test_image_stack_py.py
@@ -324,6 +324,7 @@ class test_image_stack_py(unittest.TestCase):
         with pytest.raises(ValueError):
             # Using a mask of the wrong size should fail
             stack.append_image(1.0, sci2, var2, mask=mask1)
+        self.assertEqual(len(stack), 1)  # Should still only have 1 image
         stack.append_image(1.0, sci2, var2, mask=mask2)
         self.assertEqual(stack.width, 20)
         self.assertEqual(stack.height, 10)  # Height stays the same, width grows
@@ -351,6 +352,7 @@ class test_image_stack_py(unittest.TestCase):
             # for a smaller image
             mask4 = np.ones((35, 25))
             stack.append_image(4.0, sci5, var5, mask=mask4)
+        self.assertEqual(len(stack), 4)  # Should still only have 4 images
         stack.append_image(4.0, sci5, var5, mask=mask5)
         self.assertEqual(stack.width, 25)
         self.assertEqual(stack.height, 35)

--- a/tests/test_image_stack_py.py
+++ b/tests/test_image_stack_py.py
@@ -1,6 +1,7 @@
 import logging
 import numpy as np
 import unittest
+import pytest
 
 from kbmod.core.image_stack_py import ImageStackPy, LayeredImagePy
 
@@ -311,14 +312,19 @@ class test_image_stack_py(unittest.TestCase):
         # Add 10x10 image
         sci1 = np.ones((10, 10))
         var1 = np.ones((10, 10))
-        stack.append_image(0.0, sci1, var1)
+        mask1 = np.ones((10, 10))
+        stack.append_image(0.0, sci1, var1, mask=mask1)
         self.assertEqual(stack.width, 10)
         self.assertEqual(stack.height, 10)
 
         # Add 5x20 image (wider)
         sci2 = np.ones((5, 20))
         var2 = np.ones((5, 20))
-        stack.append_image(1.0, sci2, var2)
+        mask2 = np.ones((5, 20))
+        with pytest.raises(ValueError):
+            # Using a mask of the wrong size should fail
+            stack.append_image(1.0, sci2, var2, mask=mask1)
+        stack.append_image(1.0, sci2, var2, mask=mask2)
         self.assertEqual(stack.width, 20)
         self.assertEqual(stack.height, 10)  # Height stays the same, width grows
 
@@ -339,7 +345,13 @@ class test_image_stack_py(unittest.TestCase):
         # Add another 10x10 image (should not shrink)
         sci5 = np.ones((10, 10))
         var5 = np.ones((10, 10))
-        stack.append_image(4.0, sci5, var5)
+        mask5 = np.ones((10, 10))
+        with pytest.raises(ValueError):
+            # Using a mask with the shape of the largest image should still fail
+            # for a smaller image
+            mask4 = np.ones((35, 25))
+            stack.append_image(4.0, sci5, var5, mask=mask4)
+        stack.append_image(4.0, sci5, var5, mask=mask5)
         self.assertEqual(stack.width, 25)
         self.assertEqual(stack.height, 35)
 


### PR DESCRIPTION
We allow a KBMOD image stack to have images of different shapes, and when we add a new image to the stack we want to compare the dimensions of that mask to its corresponding science image.