### PR TITLE
Incorporate the image filtering into work flow

### DIFF
--- a/docs/source/user_manual/search_params.rst
+++ b/docs/source/user_manual/search_params.rst
@@ -95,6 +95,10 @@ Configuration Parameters
 | ``lh_level``           | 10.0                        | The minimum computed likelihood for an |
 |                        |                             | object to be accepted.                 |
 +------------------------+-----------------------------+----------------------------------------+
+| ``max_masked_pixels``  | 1.0                         | The maximum fraction of masked pixels  |
+|                        |                             | allowed in an image for it to be       |
+|                        |                             | included in the search.                |
++------------------------+-----------------------------+----------------------------------------+
 | ``max_results``        | 100000                      | The maximum number of results to save  |
 |                        |                             | after all filtering.  The highest      |
 |                        |                             | likelihood results are saved. Use -1   |

--- a/src/kbmod/configuration.py
+++ b/src/kbmod/configuration.py
@@ -46,6 +46,7 @@ class SearchConfiguration:
             "generate_psi_phi": True,
             "gpu_filter": False,
             "lh_level": 10.0,
+            "max_masked_pixels": 0.5,
             "max_results": 100_000,
             "near_dup_thresh": 10,
             "nightly_coadds": False,


### PR DESCRIPTION
Partially addresses #953 

Drop images from the search if too many of the pixels are masked.