### PR TITLE
Add obs_day to Butler standardizer meta data

### DIFF
--- a/tests/test_butlerstd.py
+++ b/tests/test_butlerstd.py
@@ -66,6 +66,7 @@ class TestButlerStandardizer(unittest.TestCase):
             + (hdr["EXPREQ"] + 0.5) / 2.0 / 60.0 / 60.0 / 24.0,
             "filter": hdr["FILTER"],
         }
+        expected["obs_day"] = ButlerStandardizer._mjd_to_obs_day(expected["mjd_mid"])
 
         for k, v in expected.items():
             with self.subTest("Value not standardized as expected.", key=k):
@@ -285,6 +286,22 @@ class TestButlerStandardizer(unittest.TestCase):
         # times can only be compred approximately, because sometimes we
         # calculate the time in the middle of the exposure
         self.assertAlmostEqual(expected_mjd, img.time, 2)
+
+    def test_mjd_to_obs_day(self):
+        """Test that _mjd_to_obs_day works as expected."""
+        # Check that all entries for the night of June 1-2, 2025 map to 20250601 as obs_day
+        # We test from June 1, 2025 22:00 to June 2, 2025 08:00
+        for hour in range(0, 10):
+            mjd = 60827.91666667 + hour / 24.0
+            obs_day = ButlerStandardizer._mjd_to_obs_day(mjd)
+            self.assertEqual(obs_day, 20250601)
+
+        # Check that all entries for the night of June 2-3, 2025 map to 20250602 as obs_day
+        # We test from June 2, 2025 22:00 to June 3, 2025 08:00
+        for hour in range(0, 10):
+            mjd = 60828.91666667 + hour / 24.0
+            obs_day = ButlerStandardizer._mjd_to_obs_day(mjd)
+            self.assertEqual(obs_day, 20250602)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #779 

Compute the obs_day from the mjd_mid using the approach from:
https://github.com/lsst/astro_metadata_translator/blob/main/python/astro_metadata_translator/translators/decam.py#L85

This automatically gets propagated to the image collection.