### PR TITLE
Remove DETECTED and DETECTED_NEGATIVE from mask defaults

### DIFF
--- a/src/kbmod_cmdline/kbmod_build_ic.py
+++ b/src/kbmod_cmdline/kbmod_build_ic.py
@@ -42,8 +42,6 @@ RUBIN_MASK_FLAGS = [
     "CLIPPED",
     "CR",
     "CROSSTALK",
-    "DETECTED",
-    "DETECTED_NEGATIVE",
     "EDGE",
     "INEXACT_PSF",
     "INJECTED",


### PR DESCRIPTION
Remove DETECTED and DETECTED_NEGATIVE from mask defaults.

Per the definitions provided in [lsst::afw::image::Mask](https://pipelines.lsst.io/v/DM-22499/cpp-api/class/classlsst_1_1afw_1_1image_1_1_mask.html) 

```
DETECTED This pixel lies within an object’s Footprint

DETECTED_NEGATIVE This pixel lies within an object’s Footprint, and the detection was looking for pixels below a specified level
```

These masks are a reasonable choice when using KBMOD for searching for new objects. However we often want to recover existing detected objects for science validation and ML training.