### PR TITLE
Fix issue 1060

### DIFF
--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -455,7 +455,8 @@ class ButlerStandardizer(Standardizer):
             sip_degree = self.config["wcs_fallback_sips_degree"]
             self._wcs = self._fitWCSFallback(wcs, self._naxis1, self._naxis2, n_rand_pts, sip_degree)
 
-        self._metadata["pixel_scale"] = wcs.getPixelScale().asArcseconds()
+        center_pt = bbox.getCenter()
+        self._metadata["pixel_scale"] = wcs.getPixelScale(center_pt).asArcseconds()
 
         # calculate the WCS "error" (max difference between edge coordinates
         # from Rubin's more powerful SkyWCS and Atropy's Fits-WCS)


### PR DESCRIPTION
Closes #1060

Uses the bounding box of the CCD to compute the center point and passes that to getPixelScale.