### PR TITLE
Support Chunked Reading of Large Result Files and Improve Image Column Support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
 kbmod-create-test-data = "kbmod_cmdline.kbmod_create_test_data:main"
 kbmod-filter = "kbmod_cmdline.kbmod_filter:main"
 kbmod-merge-results = "kbmod_cmdline.kbmod_merge_results:main"
+kbmod-migrate-results = "kbmod_cmdline.kbmod_migrate_results:main"
 kbmod-rater = "kbmod_cmdline.kbmod_results_rater:main"
 kbmod-stamps = "kbmod_cmdline.kbmod_stamps:main"
 kbmod-stats = "kbmod_cmdline.kbmod_stats:main"

--- a/src/kbmod/results.py
+++ b/src/kbmod/results.py
@@ -450,7 +450,8 @@ class Results:
                 shape = tuple(shape) if isinstance(shape, list) else shape
                 logger.debug(f"Reshaping column '{colname}' to {shape}")
                 try:
-                    self.table[colname] = [np.reshape(row, shape) for row in self.table[colname]]
+                    new_shape = tuple([len(self)] + list(shape))
+                    self.table[colname] = np.reshape(self.table[colname], new_shape)
                 except ValueError as e:
                     logger.warning(
                         f"Could not reshape column '{colname}' to {shape}: {e}. "

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -810,13 +810,6 @@ class test_results(unittest.TestCase):
     def test_read_table_chunks(self):
         """Test the chunked reading of a parquet file."""
         max_save = 15
-        table = Results.from_trajectories(
-            self.trj_list[0:max_save] if max_save <= self.num_entries else self.trj_list * 2
-        )
-
-        # Make sure we have enough entries for meaningful chunking
-        while len(table) < max_save:
-            table.extend(Results.from_trajectories(self.trj_list))
         table = Results.from_trajectories([self.trj_list[i % self.num_entries] for i in range(max_save)])
 
         # Add fake times to test metadata extraction


### PR DESCRIPTION
A bump for astropy >= 5.3  ([released May 2023](https://pypi.org/project/astropy/5.3/)) and a few intertwined issues aimed to help us deal with large result files on USDF:

* For large KBMOD results files (say 20GB or more) we seem to run into segfaults or memory constraints. We introduce `Results.read_table_chunks` to support yielding these chunks one at a time. This currently ignores auxiliary files since this is usually reading large files for analysis and we don't want to load that many stamps into memory anyway.

* When serializing KBMOD results with image columns specified as separate auxiliary columns, we were mistakenly writing out image columns as parquets rather than .fits files. This was because when astropy serialized the image columns to parquet, multidimensional numpy arrays get flattened. These flattened arrays are then no longer considered image columns when loaded back into memory. I considered solving this through converting to byte arrays or pickling (or even  nested pandas over astropy tables), but instead we now store metadata of array shape for image columns in our serialized metadata. This is used to automatically reshape the image column arrays on load. There was an issue for roundtrip serialization in the CI environment that testing uncovered that was resolved by bumping our astropy version to >= 5.3

* We provide a commandline tool `kbmod-migrate-results` to glob over a directory's parquet Result files and splitting out any image columns into separate .fits files. This lets us take advantage of better compression to save on storage costs.

Example usage:
```
      # Finds parquet files with flattened coadd image columns and writes the images as auxilary columns
      kbmod-migrate-results --input=/path/to/results.parquet --image-columns '*coadd*' --stamp-dim 101
```

On an example test, this has let us change a 20 GB parquet file into 11 GB of a parquet file and associated rice_1 compressed fits files.