### PR TITLE
Fix the occasional crashing bug

### DIFF
--- a/src/kbmod/reprojection_utils.py
+++ b/src/kbmod/reprojection_utils.py
@@ -7,7 +7,6 @@ from astropy.coordinates import (
     ICRS,
     solar_system_ephemeris,
     get_body_barycentric,
-    EarthLocation,
 )
 from astropy.time import Time
 from astropy.wcs.utils import fit_wcs_from_points, skycoord_to_pixel

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -14,7 +14,7 @@ from .filters.clustering_grid import apply_trajectory_grid_filter
 from .filters.sigma_g_filter import SigmaGClipping, apply_clipped_sigma_g
 from .filters.sns_filters import peak_offset_filter, predictive_line_cluster
 from .filters.stamp_filters import append_all_stamps, append_coadds, filter_stamps_by_cnn
-from .reprojection_utils import image_positions_to_original_icrs, invert_correct_parallax_vectorized
+from .reprojection_utils import invert_correct_parallax_vectorized
 from .results import Results, write_results_to_files_destructive
 from .trajectory_generator import create_trajectory_generator
 from .trajectory_utils import predict_pixel_locations
@@ -200,6 +200,7 @@ class SearchRunner:
             The current phase.
         """
         self._check_timeout()
+        logger.debug(f"Starting {phase_name}.")
 
         # Record the start time.
         self.phase_times[phase_name] = [time.time(), None]
@@ -370,12 +371,14 @@ class SearchRunner:
 
         # Do the actual search.
         self._start_phase("grid search")
-        logger.debug(f"{trj_generator}")
+        logger.debug(f"Trajectory Generator: {trj_generator}")
         candidates = [trj for trj in trj_generator]
+        logger.debug(f"Using {len(candidates)} candidates per pixel.")
         try:
             search.search_all(candidates, use_gpu)
         except:
             # Delete the search object to force the memory cleanup.
+            logger.error("Error during grid search. Cleaning up memory.")
             del search
             raise
         self._end_phase("grid search")
@@ -434,11 +437,13 @@ class SearchRunner:
         # so that the metadata is correctly handled. Otherwise we just filter the image stack.
         if config["max_masked_pixels"] < 1.0:
             keep_mask = stack.get_masked_fractions() <= config["max_masked_pixels"]
+            logger.debug(f"Filtering images from the stack. Keeping: {keep_mask}")
             if workunit is not None:
                 workunit.filter_images(keep_mask)
                 stack = workunit.im_stack
             else:
                 stack.filter_images(keep_mask)
+        logger.debug(f"Number of images to use in search: {stack.num_times}")
 
         # Determine how many images have at least 10% valid pixels.  Make sure
         # num_obs is no larger than 80% of the valid images.

--- a/src/kbmod/search/pydocs/common_docs.h
+++ b/src/kbmod/search/pydocs/common_docs.h
@@ -102,6 +102,12 @@ static const auto DOC_Trajectory_is_valid = R"doc(
      True if all parameters are valid, False otherwise.
   )doc";
 
+
+static const auto DOC_Trajectory_clear = R"doc(
+  Reset all attributes to the default values.
+  )doc";
+
+
 }  // namespace pydocs
 
 #endif /* COMMON_DOCS */

--- a/src/kbmod/search/pydocs/trajectory_list_docs.h
+++ b/src/kbmod/search/pydocs/trajectory_list_docs.h
@@ -52,6 +52,14 @@ static const auto DOC_TrajectoryList_get_trajectory = R"doc(
   on the GPU.
   )doc";
 
+static const auto DOC_TrajectoryList_reset_all = R"doc(
+  Set all the parameters of all the trajectories to their default values.
+
+  Raises
+  ------
+  Raises a ``RuntimeError`` if the data currently resideson the GPU.
+  )doc";
+
 static const auto DOC_TrajectoryList_set_trajectory = R"doc(
   Set a trajectory in the list. The data must reside on the CPU.
 

--- a/src/kbmod/search/trajectory_list.cpp
+++ b/src/kbmod/search/trajectory_list.cpp
@@ -22,6 +22,9 @@ TrajectoryList::TrajectoryList(uint64_t max_list_size) {
     data_on_gpu = false;
     cpu_list.resize(max_size);
     gpu_array.resize(max_size);
+
+    // Clear the entries.
+    reset_all();
 }
 
 TrajectoryList::TrajectoryList(const std::vector<Trajectory>& prev_list) {
@@ -53,10 +56,17 @@ void TrajectoryList::resize(uint64_t new_size) {
     // Make sure the new entries have the default parameters.
     uint64_t new_entries = (new_size > max_size) ? new_size - max_size : 0;
     for (uint64_t i = 0; i < new_entries; ++i) {
-        cpu_list[max_size + i] = Trajectory();
+        cpu_list[max_size + i].clear();
     }
 
     max_size = new_size;
+}
+
+void TrajectoryList::reset_all() {
+    if (data_on_gpu) throw std::runtime_error("Data on GPU");
+    for (uint64_t i = 0; i < max_size; ++i) {
+        cpu_list[i].clear();
+    }
 }
 
 void TrajectoryList::set_trajectories(const std::vector<Trajectory>& new_values) {
@@ -247,6 +257,7 @@ static void trajectory_list_binding(py::module& m) {
             .def("estimate_memory", &trjl::estimate_memory, pydocs::DOC_TrajectoryList_estimate_memory)
             .def("get_trajectory", &trjl::get_trajectory, py::return_value_policy::reference_internal,
                  pydocs::DOC_TrajectoryList_get_trajectory)
+            .def("reset_all", &trjl::reset_all, pydocs::DOC_TrajectoryList_reset_all)
             .def("set_trajectory", &trjl::set_trajectory, pydocs::DOC_TrajectoryList_set_trajectory)
             .def("set_trajectories", &trjl::set_trajectories, pydocs::DOC_TrajectoryList_set_trajectories)
             .def("get_list", &trjl::get_list, pydocs::DOC_TrajectoryList_get_list)

--- a/src/kbmod/search/trajectory_list.h
+++ b/src/kbmod/search/trajectory_list.h
@@ -47,6 +47,8 @@ public:
     }
 
     // --- Setter functions ----------------
+    void reset_all();
+
     inline void set_trajectory(uint64_t index, const Trajectory& new_value) {
         if (index >= max_size) throw std::runtime_error("Index out of bounds.");
         if (data_on_gpu) throw std::runtime_error("Data on GPU");

--- a/src/kbmod/work_unit.py
+++ b/src/kbmod/work_unit.py
@@ -18,7 +18,7 @@ from tqdm import tqdm
 from kbmod import is_interactive
 from kbmod.configuration import SearchConfiguration
 from kbmod.core.image_stack_py import ImageStackPy, LayeredImagePy
-from kbmod.reprojection_utils import invert_correct_parallax, image_positions_to_original_icrs
+from kbmod.reprojection_utils import image_positions_to_original_icrs
 from kbmod.search import Logging
 from kbmod.util_functions import get_matched_obstimes
 from kbmod.wcs_utils import (

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -64,6 +64,19 @@ class test_common(unittest.TestCase):
         self.assertEqual(trj4.obs_count, 0)
         self.assertTrue(trj4.is_valid())
 
+    def test_trajectory_clear(self):
+        trj1 = Trajectory(x=1, y=2, vx=3.0, vy=-4.0, obs_count=7)
+        trj1.clear()
+
+        self.assertEqual(trj1.x, 0)
+        self.assertEqual(trj1.y, 0)
+        self.assertEqual(trj1.vx, 0.0)
+        self.assertEqual(trj1.vy, 0.0)
+        self.assertEqual(trj1.flux, 0.0)
+        self.assertEqual(trj1.lh, 0.0)
+        self.assertEqual(trj1.obs_count, 0)
+        self.assertTrue(trj1.is_valid())
+
     def test_trajectory_is_valid(self):
         self.assertTrue(Trajectory(x=1, y=2, vx=3.0, vy=-4.0, obs_count=7).is_valid())
         self.assertFalse(Trajectory(x=1, y=2, vx=3.0, vy=-4.0, obs_count=-1).is_valid())

--- a/tests/test_trajectory_list.py
+++ b/tests/test_trajectory_list.py
@@ -37,6 +37,12 @@ class test_trajectory_list(unittest.TestCase):
         for i in range(8):
             self.assertEqual(trj_list2.get_trajectory(i).x, 2 * i)
 
+    def test_reset_all(self):
+        trj_list2 = TrajectoryList([Trajectory(x=2 * i) for i in range(8)])
+        trj_list2.reset_all()
+        for i in range(8):
+            self.assertEqual(trj_list2.get_trajectory(i).x, 0)
+
     def test_estimate_memory(self):
         self.assertEqual(TrajectoryList.estimate_memory(10), 280)
 


### PR DESCRIPTION
The tests were crashing in some cases due to invalid memory access during the CPU-only search. This only happened when the number of candidate trajectories was smaller than the results per pixel. The PR fixes it with improved bounds checking.

During debugging, I spent a while adding more safety checks throughout the core search. The PR includes those extra checks.