### PR TITLE
Fix toWorkUnit for non-cached standardizers and harden against missing mask flags

### DIFF
--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -623,9 +623,17 @@ class ButlerStandardizer(Standardizer):
             # flip_bits makes ignore_flags into mask_these_flags
             bit_flag_map = self.exp.mask.getMaskPlaneDict()
             bit_flag_map = {key: int(2**val) for key, val in bit_flag_map.items()}
+
+            # Filter out any configured mask flags not present in this
+            # exposure's mask plane to avoid KeyError at lookup time.
+            available_flags = [f for f in self.config["mask_flags"] if f in bit_flag_map]
+            missing_flags = set(self.config["mask_flags"]) - set(available_flags)
+            if missing_flags:
+                logger.debug(f"Mask flags {missing_flags} not found in exposure mask plane, skipping.")
+
             mask = bitmask.bitfield_to_boolean_mask(
                 bitfield=mask,
-                ignore_flags=self.config["mask_flags"],
+                ignore_flags=available_flags,
                 flag_name_map=bit_flag_map,
                 flip_bits=True,
             )

--- a/tests/test_butlerstd.py
+++ b/tests/test_butlerstd.py
@@ -270,6 +270,29 @@ class TestButlerStandardizer(unittest.TestCase):
                     else:
                         self.assertEqual(mask.ravel()[i], False)
 
+    def test_bitmasking_missing_flags(self):
+        """Test masking succeeds when mask_flags config contains flags
+        not present in the exposure's mask plane (e.g. 'SPIKE')."""
+        butler = MockButler("/far/far/away", mock_images_f=self.mock_kbmodv1like_bitmasking)
+
+        # Add flags that don't exist in the mock exposure's mask plane
+        extra_flags = ButlerStandardizerConfig.mask_flags + ["SPIKE", "GHOST", "NONEXISTENT"]
+        conf = StandardizerConfig(grow_mask=False, mask_flags=extra_flags)
+        std = Standardizer.get(DatasetId(9), butler=butler, config=conf)
+
+        # Should not raise KeyError
+        standardizedMask = std.standardizeMaskImage()
+
+        # Masking behavior should be identical to the default config
+        # since the extra flags don't exist in the data
+        for mask in standardizedMask:
+            for i, flag in enumerate(KBMODV1Config.bit_flag_map):
+                with self.subTest("Failed to mask expected", flag=flag):
+                    if flag in ButlerStandardizerConfig.mask_flags:
+                        self.assertEqual(mask.ravel()[i], True)
+                    else:
+                        self.assertEqual(mask.ravel()[i], False)
+
     def mock_kbmodv1like_thresholding(self, mockedexp):
         """Set image pixel [1, 1] to 1 and [2, 2] to 3."""
         mockedexp.image.array[1, 1] = 1


### PR DESCRIPTION
This PR provides two small fixes:

## Fix 1:
A recent rename of the `dataId` parameter to `tgt` in `ButlerStandardizer.__init__` broke `ImageCollection.toWorkUnit()` for ImageCollections without cached standardizers. 

The `load_std()` function in `ImageCollection.get_standardizer()` reconstructs standardizers by unpacking table columns as arguments, so the columns must match the positional parameter in `__init__`. So simply renaming `tgt` back to `dataId` fixes it.

## Fix 2:
Some flags like SPIKE are available in later Rubin data but seem to be missing from say First Look. Now we ignore and log missing flags rather than raising an error