### PR TITLE
Add configuration for brightness search filter

### DIFF
--- a/src/kbmod/configuration.py
+++ b/src/kbmod/configuration.py
@@ -72,6 +72,22 @@ class _ParamInfo:
 # List of all the supported configuration parameters (in alphabetical order).
 _SUPPORTED_PARAMS = [
     _ParamInfo(
+        name="brightness_filter",
+        default_value=False,
+        description="If True, apply the brightness search filter to remove trajectories whose best-fit brightness lies at the extremes of the offset grid.",
+        section="filtering",
+        validate_func=lambda x: isinstance(x, bool),
+    ),
+    _ParamInfo(
+        name="brightness_filter_offsets",
+        default_value=[0.2, 0.9, 1.0, 1.1, 5.0],
+        description="Multiplicative offsets used by the brightness filter's local search around the estimated flux.",
+        section="filtering",
+        validate_func=lambda x: isinstance(x, list)
+        and len(x) >= 2
+        and all(isinstance(i, (int, float)) for i in x),
+    ),
+    _ParamInfo(
         name="clip_negative",
         default_value=False,
         description="If True remove all negative values prior to sigmaG computing the percentiles.",

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -9,6 +9,7 @@ from astropy.coordinates import EarthLocation, SkyCoord
 
 import kbmod.search as kb
 
+from .filters.brightness_filters import apply_brightness_search_filter
 from .filters.clustering_filters import apply_clustering
 from .filters.clustering_grid import apply_trajectory_grid_filter
 from .filters.sigma_g_filter import SigmaGClipping, apply_clipped_sigma_g
@@ -475,6 +476,15 @@ class SearchRunner:
             }
             apply_clustering(keep, cluster_params)
             self._end_phase("clustering")
+
+        if config["brightness_filter"] and len(keep) > 0:
+            self._start_phase("brightness filtering")
+            apply_brightness_search_filter(
+                keep,
+                stack,
+                offsets=config["brightness_filter_offsets"],
+            )
+            self._end_phase("brightness filtering")
 
         # Filter by max_results, keeping only the results with the highest likelihoods.
         # This should be the last step of the filtering phase, but before we add auxiliary

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -483,6 +483,7 @@ class SearchRunner:
                 keep,
                 stack,
                 offsets=config["brightness_filter_offsets"],
+                save_curves=False,
             )
             self._end_phase("brightness filtering")
 

--- a/tests/test_run_search.py
+++ b/tests/test_run_search.py
@@ -418,6 +418,69 @@ class test_run_search(unittest.TestCase):
         keep3 = runner.run_search(config, fake_ds.stack_py, trj_generator=trj_gen)
         self.assertGreater(len(keep3), 100)
 
+    def test_run_search_brightness_filter(self):
+        """Test that brightness_filter is applied and runs before max_results."""
+        num_times = 10
+        width = 20
+        height = 15
+        fake_times = [59000.0 + float(i) / num_times for i in range(num_times)]
+        fake_ds = FakeDataSet(width, height, fake_times, psf_val=0.01)
+
+        trj = Trajectory(x=17, y=12, vx=21.0, vy=16.0, flux=250.0)
+        fake_ds.insert_object(trj)
+
+        trj_gen = VelocityGridSearch(3, 15.0, 27.0, 3, 10.0, 22.0)
+
+        # Shared config settings
+        base_settings = {
+            "cpu_only": True,
+            "do_clustering": False,
+            "lh_level": 0.0,
+            "num_obs": 1,
+            "sigmaG_filter": False,
+            "near_dup_thresh": 1,
+        }
+
+        # Run WITHOUT brightness filter to get the unfiltered count.
+        config_no_bf = SearchConfiguration()
+        config_no_bf.set_multiple(base_settings)
+        config_no_bf.set("brightness_filter", False)
+
+        runner = SearchRunner()
+        keep_no_bf = runner.run_search(config_no_bf, fake_ds.stack_py, trj_generator=trj_gen)
+        n_no_bf = len(keep_no_bf)
+        self.assertGreater(n_no_bf, 0)
+
+        # Run WITH brightness filter (no max_results cap).
+        config_bf = SearchConfiguration()
+        config_bf.set_multiple(base_settings)
+        config_bf.set("brightness_filter", True)
+
+        keep_bf = runner.run_search(config_bf, fake_ds.stack_py, trj_generator=trj_gen)
+        n_bf = len(keep_bf)
+
+        # Brightness filter should remove some results.
+        self.assertLess(n_bf, n_no_bf)
+
+        # Verify sci/var curves are NOT saved (save_curves=False).
+        self.assertNotIn("sci_curve", keep_bf.colnames)
+        self.assertNotIn("var_curve", keep_bf.colnames)
+
+        # Verify ordering: brightness_filter runs BEFORE max_results.
+        # Set max_results between n_bf and n_no_bf. If brightness_filter
+        # runs first, we get exactly max_results (bf reduces the pool,
+        # then max_results caps). If max_results ran first, bf would
+        # further reduce below max_results.
+        if n_bf >= 2:
+            cap = n_bf - 1
+            config_bf_cap = SearchConfiguration()
+            config_bf_cap.set_multiple(base_settings)
+            config_bf_cap.set("brightness_filter", True)
+            config_bf_cap.set("max_results", cap)
+
+            keep_capped = runner.run_search(config_bf_cap, fake_ds.stack_py, trj_generator=trj_gen)
+            self.assertEqual(len(keep_capped), cap)
+
     def test_search_runner_filtering_masked(self):
         """Test that the SearchRunner correctly filters images based on max_masked_pixels."""
         num_times = 10


### PR DESCRIPTION
Wires the existing brightness search filter into the KBMOD configuration. 

The filter runs after clustering and before the `max_results` rank cut, so that we can hopefully remove bad candidates.


| Name | Type | Default | Section | Description |
|---|---|---|---|---|
| `brightness_filter` | `bool` | `False` | `filtering` | When `True`, applies the brightness search filter to the results. |
| `brightness_filter_offsets` | `list[float]` | `[0.2, 0.9, 1.0, 1.1, 5.0]` | `filtering` | Multiplicative offsets used for the local brightness search. Trajectories whose best-fit offset is the first or last entry are filtered. |
