### PR TITLE
Avoid copying butler in ButlerStandardizer.deepcopy

### DIFF
--- a/src/kbmod/injection.py
+++ b/src/kbmod/injection.py
@@ -306,26 +306,11 @@ def inject_sources_into_ic(ic, catalog, butler, inject_config=None):
     # Stack all the injected catalogs
     injected_cats = vstack(injected_cats)
 
-    # Rebuild the standardizers with the new exposures.
-    # ButlerStandardizer holds a reference to a DirectButler. copy.deepcopy
-    # pickles/unpickles that butler, and each unpickle calls
-    # DirectButler.create_from_config which opens a fresh psycopg2 connection
-    # to the registry. For N images this fans out into N new DB connections
-    # per call -- and across parallel workers that overwhelms the registry
-    # pooler (manifests as SSLConnectionClosed / server_login_retry). Detach
-    # the butler around the deepcopy and share the original instance with the
-    # new standardizer.
+    # Rebuild the standardizers with the new exposures
     standardizers = ic.get_standardizers(butler=butler)
     new_standardizers = []
     for std, ref, exp in zip(standardizers, references, exposures):
-        original_std = std["std"]
-        saved_butler = getattr(original_std, "butler", None)
-        try:
-            original_std.butler = None
-            new_std = copy.deepcopy(original_std)
-        finally:
-            original_std.butler = saved_butler
-        new_std.butler = saved_butler
+        new_std = copy.deepcopy(std["std"])
         new_std.exp = exp
         new_std.ref = ref
         new_standardizers.append(new_std)

--- a/src/kbmod/injection.py
+++ b/src/kbmod/injection.py
@@ -306,11 +306,26 @@ def inject_sources_into_ic(ic, catalog, butler, inject_config=None):
     # Stack all the injected catalogs
     injected_cats = vstack(injected_cats)
 
-    # Rebuild the standardizers with the new exposures
+    # Rebuild the standardizers with the new exposures.
+    # ButlerStandardizer holds a reference to a DirectButler. copy.deepcopy
+    # pickles/unpickles that butler, and each unpickle calls
+    # DirectButler.create_from_config which opens a fresh psycopg2 connection
+    # to the registry. For N images this fans out into N new DB connections
+    # per call -- and across parallel workers that overwhelms the registry
+    # pooler (manifests as SSLConnectionClosed / server_login_retry). Detach
+    # the butler around the deepcopy and share the original instance with the
+    # new standardizer.
     standardizers = ic.get_standardizers(butler=butler)
     new_standardizers = []
     for std, ref, exp in zip(standardizers, references, exposures):
-        new_std = copy.deepcopy(std["std"])
+        original_std = std["std"]
+        saved_butler = getattr(original_std, "butler", None)
+        try:
+            original_std.butler = None
+            new_std = copy.deepcopy(original_std)
+        finally:
+            original_std.butler = saved_butler
+        new_std.butler = saved_butler
         new_std.exp = exp
         new_std.ref = ref
         new_standardizers.append(new_std)

--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -287,11 +287,11 @@ class ButlerStandardizer(Standardizer):
         cls = self.__class__
         new = cls.__new__(cls)
         memo[id(self)] = new
-        butler = getattr(self, "butler", None)
-        if butler is not None:
-            memo[id(butler)] = butler
         for k, v in self.__dict__.items():
-            setattr(new, k, copy.deepcopy(v, memo))
+            if k == "butler":
+                new.butler = v
+            else:
+                setattr(new, k, copy.deepcopy(v, memo))
         return new
 
     def _fitWCSFallback(self, wcs, naxis1, naxis2, n_rand_pts, sip_degree, sample_outside_chip=True):

--- a/src/kbmod/standardizers/butler_standardizer.py
+++ b/src/kbmod/standardizers/butler_standardizer.py
@@ -2,6 +2,7 @@
 via the Rubin Data Butler.
 """
 
+import copy
 import importlib
 import logging
 import uuid
@@ -275,6 +276,23 @@ class ButlerStandardizer(Standardizer):
         self._metadata = None
         self._naxis1 = None
         self._naxis2 = None
+
+    def __deepcopy__(self, memo):
+        # Share self.butler across the copy. DirectButler pickles to a config
+        # and unpickles by calling create_from_config, which opens a fresh
+        # psycopg2 connection to the registry. Deep-copying many standardizers
+        # (e.g. in kbmod.injection.inject_sources_into_ic) would otherwise fan
+        # out into one new DB connection per image and overwhelm the registry
+        # pooler under parallel workers.
+        cls = self.__class__
+        new = cls.__new__(cls)
+        memo[id(self)] = new
+        butler = getattr(self, "butler", None)
+        if butler is not None:
+            memo[id(butler)] = butler
+        for k, v in self.__dict__.items():
+            setattr(new, k, copy.deepcopy(v, memo))
+        return new
 
     def _fitWCSFallback(self, wcs, naxis1, naxis2, n_rand_pts, sip_degree, sample_outside_chip=True):
         """Create a simple TAN WCS centered on the detector through sampling random points.

--- a/tests/test_butlerstd.py
+++ b/tests/test_butlerstd.py
@@ -1,3 +1,4 @@
+import copy
 import uuid
 import unittest
 from unittest import mock
@@ -385,6 +386,21 @@ class TestButlerStandardizer(unittest.TestCase):
             mjd = 60828.91666667 + hour / 24.0
             obs_day = ButlerStandardizer._mjd_to_obs_day(mjd)
             self.assertEqual(obs_day, 20250602)
+
+    def test_deepcopy(self):
+        """Deep-copying a ButlerStandardizer yields an independent object
+        whose butler attribute is the same instance as the original's."""
+        std = ButlerStandardizer(DatasetId(7, fill_metadata=True), butler=self.butler)
+        std._metadata = {"k": "v"}
+
+        new_std = copy.deepcopy(std)
+
+        self.assertIsNot(new_std, std)
+        self.assertIs(new_std.butler, std.butler)
+        # Other state is independent: mutating the copy's dict does not affect the original.
+        self.assertIsNot(new_std._metadata, std._metadata)
+        new_std._metadata["k"] = "mutated"
+        self.assertEqual(std._metadata["k"], "v")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #1147

Reduces butler connections from being recreated when copying ButlerStandardizers, an event that occurs during our injection tasks. As we have scaled up concurrently generating injections, mass recreating butler objects and their connections seems to lead to connection pool errors with the butler registry.