### PR TITLE
Fix generate_all_trajectories() calls in TrajectoryExplorer

### DIFF
--- a/src/kbmod/trajectory_explorer.py
+++ b/src/kbmod/trajectory_explorer.py
@@ -227,9 +227,10 @@ class TrajectoryExplorer:
         trj_generator = PencilSearch(vx, vy, max_ang_offset, ang_step, max_vel_offset, vel_step)
         candidates = generate_all_trajectories(
             trj_generator,
-            self.config["candidate_dup_px"],
-            np.max(self.search.zeroed_times) - np.min(self.search.zeroed_times),
+            candidate_dup_px=self.config["candidate_dup_px"],
+            max_dt=np.max(self.im_stack.zeroed_times) - np.min(self.im_stack.zeroed_times),
         )
+        num_trj = len(candidates)
 
         # Set the search bounds to right around the trajectory's starting position and
         # turn off all filtering.
@@ -326,8 +327,8 @@ class TrajectoryExplorer:
         )
         candidates = generate_all_trajectories(
             trj_generator,
-            reduced_config["candidate_dup_px"],
-            np.max(self.search.zeroed_times) - np.min(self.search.zeroed_times),
+            candidate_dup_px=reduced_config["candidate_dup_px"],
+            max_dt=np.max(self.search.zeroed_times) - np.min(self.search.zeroed_times),
         )
 
         # Do the actual search.

--- a/tests/test_trajectory_explorer.py
+++ b/tests/test_trajectory_explorer.py
@@ -156,12 +156,7 @@ class test_trajectory_explorer(unittest.TestCase):
         self.assertLess(np.abs(results["vx"][0] - self.vx), 1.0)
         self.assertLess(np.abs(results["vy"][0] - self.vy), 1.0)
 
-    # The two CPU (use_gpu=False) tests below are intentionally NOT gated on
-    # kb_has_gpu(). The candidate-generation path they exercise
-    # (generate_all_trajectories, num_trj, im_stack.zeroed_times) runs before any
-    # GPU work, so a GPU-only test would skip -- and hence miss -- a break there
-    # on CI without a GPU (as happened with the generate_all_trajectories
-    # keyword-only refactor).
+    # The two CPU (use_gpu=False) tests below test the pre-GPU candidate-generation path
     def test_evaluate_around_linear_trajectory_cpu(self):
         radius = 3
         num_pixels = (2 * radius + 1) * (2 * radius + 1)

--- a/tests/test_trajectory_explorer.py
+++ b/tests/test_trajectory_explorer.py
@@ -156,6 +156,49 @@ class test_trajectory_explorer(unittest.TestCase):
         self.assertLess(np.abs(results["vx"][0] - self.vx), 1.0)
         self.assertLess(np.abs(results["vy"][0] - self.vy), 1.0)
 
+    # The two CPU (use_gpu=False) tests below are intentionally NOT gated on
+    # kb_has_gpu(). The candidate-generation path they exercise
+    # (generate_all_trajectories, num_trj, im_stack.zeroed_times) runs before any
+    # GPU work, so a GPU-only test would skip -- and hence miss -- a break there
+    # on CI without a GPU (as happened with the generate_all_trajectories
+    # keyword-only refactor).
+    def test_evaluate_around_linear_trajectory_cpu(self):
+        radius = 3
+        num_pixels = (2 * radius + 1) * (2 * radius + 1)
+        results = self.explorer.evaluate_around_linear_trajectory(
+            self.x0,
+            self.y0,
+            self.vx,
+            self.vy,
+            pixel_radius=radius,
+            max_ang_offset=0.2618,
+            ang_step=0.035,
+            max_vel_offset=10.0,
+            vel_step=0.5,
+            use_gpu=False,
+        )
+        # 615 trajectories generated per starting pixel (see GPU counterpart).
+        self.assertEqual(len(results), num_pixels * 615)
+
+    def test_refine_linear_trajectory_cpu(self):
+        # Start with a trajectory that is offset from the true one.
+        results = self.explorer.refine_linear_trajectory(
+            self.x0 + 1,
+            self.y0 - 1,
+            self.vx + 2.5,
+            self.vy - 2.5,
+            pixel_radius=3,
+            max_dv=10.0,
+            dv_steps=21,
+            use_gpu=False,
+        )
+        # We get one result and it recovers the true trajectory.
+        self.assertEqual(len(results), 1)
+        self.assertAlmostEqual(results["x"][0], self.x0, delta=1)
+        self.assertAlmostEqual(results["y"][0], self.y0, delta=1)
+        self.assertLess(np.abs(results["vx"][0] - self.vx), 1.0)
+        self.assertLess(np.abs(results["vy"][0] - self.vy), 1.0)
+
     @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_refine_all_results(self):
         # Create a small fake data set.


### PR DESCRIPTION
The #1148 deduplication change made generate_all_trajectories() take candidate_dup_px/max_dt as keyword-only args (and updated run_search.py), but left trajectory_explorer.py calling them positionally. It also referenced self.search.zeroed_times before initialize_data() (self.search is None) in evaluate_around_linear_trajectory, and dropped the `num_trj` definition.

- Pass candidate_dup_px/max_dt as keyword args at both call sites
- Use self.im_stack.zeroed_times (available pre-init) for max_dt in evaluate_around_linear_trajectory
- Restore num_trj = len(candidates)

Fixes 3 failing GPU-only tests in test_trajectory_explorer.py, and adds basic CPU-side coverage.