### PR TITLE
Fix wrong PSF assigned to every image in parallel reprojection

### DIFF
--- a/src/kbmod/reprojection.py
+++ b/src/kbmod/reprojection.py
@@ -438,7 +438,10 @@ def _reproject_work_unit_in_parallel(
         stack = ImageStackPy()
         for result in future_reprojections:
             science_add, variance_add, mask_add, time = result.result()
-            psf = _get_first_psf_at_time(work_unit, obstime)
+            # Use the time carried by this result. Reading the submission loop's
+            # `obstime` here leaked its final value into every iteration, giving
+            # every image the last obstime's PSF.
+            psf = _get_first_psf_at_time(work_unit, time)
 
             stack.append_image(
                 time,

--- a/src/kbmod/reprojection.py
+++ b/src/kbmod/reprojection.py
@@ -438,9 +438,6 @@ def _reproject_work_unit_in_parallel(
         stack = ImageStackPy()
         for result in future_reprojections:
             science_add, variance_add, mask_add, time = result.result()
-            # Use the time carried by this result. Reading the submission loop's
-            # `obstime` here leaked its final value into every iteration, giving
-            # every image the last obstime's PSF.
             psf = _get_first_psf_at_time(work_unit, time)
 
             stack.append_image(

--- a/tests/test_reprojection.py
+++ b/tests/test_reprojection.py
@@ -196,7 +196,7 @@ class test_reprojection(unittest.TestCase):
         k2 = np.array([[0.0, 0.0, 0.0], [0.0, 0.1, 0.2], [0.0, 0.2, 0.5]], dtype=np.float32)
         kernels = [k0 / k0.sum(), k1 / k1.sum(), k2 / k2.sum()]
 
-        # Guard the guard: the test is meaningless if these are not distinct.
+        # Validate that the PSFs are distinct.
         for a in range(len(kernels)):
             for b in range(a + 1, len(kernels)):
                 assert not np.allclose(kernels[a], kernels[b])
@@ -218,7 +218,7 @@ class test_reprojection(unittest.TestCase):
         kernels = self._distinct_psf_kernels()
         self.assertEqual(len(unique_times), len(kernels))
 
-        # Assign one distinct kernel per unique time; images sharing a time share a kernel.
+        # Assign one distinct PSF kernel per unique time; images sharing a time share a kernel.
         expected_by_time = {}
         for kernel, time, indices in zip(kernels, unique_times, unique_indices):
             for i in indices:
@@ -236,11 +236,11 @@ class test_reprojection(unittest.TestCase):
 
                 self.assertEqual(len(reprojected.im_stack), len(unique_times))
                 for i, time in enumerate(reprojected.im_stack.times):
-                    expected = expected_by_time[float(time)]
-                    actual = reprojected.im_stack.psfs[i]
+                    expected_kernel = expected_by_time[float(time)]
+                    actual_kernel = reprojected.im_stack.psfs[i]
                     np.testing.assert_allclose(
-                        actual,
-                        expected,
+                        actual_kernel,
+                        expected_kernel,
                         err_msg=(
                             f"image {i} at obstime {time} carries the wrong PSF "
                             f"(parallelize={parallelize})"

--- a/tests/test_reprojection.py
+++ b/tests/test_reprojection.py
@@ -182,6 +182,71 @@ class test_reprojection(unittest.TestCase):
         except ValueError as e:
             assert str(e) == f"Observation time {time} not found in work unit."
 
+    @staticmethod
+    def _distinct_psf_kernels():
+        """Three deliberately distinct, normalized 3x3 PSF kernels.
+
+        They differ in peak position and asymmetry, not merely in scale, so that
+        selecting the wrong one cannot be masked by a loose numerical tolerance.
+        The shipped reprojection fixture stores four *identical* PSFs, which makes
+        a wrong-PSF selection undetectable; these replace them.
+        """
+        k0 = np.array([[0.5, 0.2, 0.0], [0.2, 0.1, 0.0], [0.0, 0.0, 0.0]], dtype=np.float32)
+        k1 = np.array([[0.0, 0.2, 0.0], [0.2, 0.2, 0.2], [0.0, 0.2, 0.0]], dtype=np.float32)
+        k2 = np.array([[0.0, 0.0, 0.0], [0.0, 0.1, 0.2], [0.0, 0.2, 0.5]], dtype=np.float32)
+        kernels = [k0 / k0.sum(), k1 / k1.sum(), k2 / k2.sum()]
+
+        # Guard the guard: the test is meaningless if these are not distinct.
+        for a in range(len(kernels)):
+            for b in range(a + 1, len(kernels)):
+                assert not np.allclose(kernels[a], kernels[b])
+        return kernels
+
+    def test_reproject_selects_psf_of_matching_time(self):
+        """Each reprojected image must carry the PSF of *its own* obstime.
+
+        Regression test for the leaked-loop-variable defect in the parallel
+        reprojection path, where the PSF was looked up with the final value of the
+        submission loop's `obstime` rather than the time of the result being
+        processed. That gave every output image the last obstime's PSF.
+
+        Images that share an obstime are deliberately given the *same* kernel so
+        that this test isolates the wrong-time defect from the separate question of
+        which of several same-time constituent PSFs should be chosen.
+        """
+        unique_times, unique_indices = self.test_wunit.get_unique_obstimes_and_indices()
+        kernels = self._distinct_psf_kernels()
+        self.assertEqual(len(unique_times), len(kernels))
+
+        # Assign one distinct kernel per unique time; images sharing a time share a kernel.
+        expected_by_time = {}
+        for kernel, time, indices in zip(kernels, unique_times, unique_indices):
+            for i in indices:
+                self.test_wunit.im_stack.psfs[i] = kernel.copy()
+            expected_by_time[float(time)] = kernel
+
+        for parallelize in [False, True]:
+            with self.subTest(parallelize=parallelize):
+                reprojected = reproject_work_unit(
+                    self.test_wunit,
+                    self.common_wcs,
+                    parallelize=parallelize,
+                    show_progress=False,
+                )
+
+                self.assertEqual(len(reprojected.im_stack), len(unique_times))
+                for i, time in enumerate(reprojected.im_stack.times):
+                    expected = expected_by_time[float(time)]
+                    actual = reprojected.im_stack.psfs[i]
+                    np.testing.assert_allclose(
+                        actual,
+                        expected,
+                        err_msg=(
+                            f"image {i} at obstime {time} carries the wrong PSF "
+                            f"(parallelize={parallelize})"
+                        ),
+                    )
+
     def test_validate_original_wcs(self):
         """Make sure that the original WCS is validated correctly."""
         wcs = self.test_wunit.get_wcs(0)


### PR DESCRIPTION
In `_reproject_work_unit_in_parallel`, the PSF lookup read `obstime` -- the leaked final value of the earlier for loop -- rather than the local variable of `time`, the per-result value already unpacked on the preceding line and used for `append_image`.

Because the carried over `obstime` is constant across the results loop, every reprojected image received the PSF associated with final obstime within the `WorkUnit`

Since the reprojection test used `shifted_wcs_diff_dimms_tiled.fits`, stores four byte-identical 3x3 PSFs, so selecting the wrong one returns an identical array. This error did not appear in production since we were using a uniform default PSF kernel rather than one derived from Butler, and once we fix that, this error would have surfaced. 

The new regression test therefore supplies its own deliberately distinct per-time kernels, differing in peak position and asymmetry rather than only in scale. Images sharing an obstime are given the same kernel so the test isolates the wrong-time defect from the separate question of which of several same-time constituent PSFs should be chosen; that remains unaddressed here.

Verified:
- New test failed on main (image 0 at t=60414 received the t=60416 kernel) and passes after the fix, on both serial and parallel paths. The serial path was already correct.
- Reprojected science, variance, mask, times, and per-image indices are bit-identical before and after the change on the existing test, whose identical PSFs make the corrected selection a no-op there.