### PR TITLE
Allow result stamp generation to be disabled

### DIFF
--- a/docs/source/user_manual/search_params.rst
+++ b/docs/source/user_manual/search_params.rst
@@ -26,6 +26,15 @@ The dictionary values take precedence over all other settings, allowing you to u
 
 In addition :py:class:`~kbmod.configuration.SearchConfiguration` objects are automatically saved and loaded within a :py:class:`~~kbmod.work_unit.WorkUnit`.
 
+To skip all result-image generation, set the primary stamp type to YAML ``null``
+and leave the coadd list empty::
+
+    stamp_type: null
+    coadds: []
+    save_all_stamps: false
+
+Coadds needed by an enabled peak-offset or CNN filter are still generated.
+
 
 Configuration Parameters
 ------------------------
@@ -59,13 +68,10 @@ Configuration Parameters
 |                        |                             | relative to differences in distances   |
 |                        |                             | during clustering.                     |
 +------------------------+-----------------------------+----------------------------------------+
-| ``coadds``             | []                          | A list of additional coadds to create. |
-|                        |                             | These are not used in filtering, but   |
-|                        |                             | saved to columns for analysis. Can     |
+| ``coadds``             | []                          | A list of named coadds to create and   |
+|                        |                             | save as columns for analysis. Can      |
 |                        |                             | include: "sum", "mean", "median", and  |
 |                        |                             | "weighted".                            |
-|                        |                             | The filtering coadd is controlled by   |
-|                        |                             | the ``stamp_type`` parameter.          |
 +------------------------+-----------------------------+----------------------------------------+
 | ``cpu_only``           | False                       | Perform the core search on the CPU     |
 |                        |                             | (even if the GPU is available).        |
@@ -168,7 +174,8 @@ Configuration Parameters
 |                        |                             | (in pixels).                           |
 +------------------------+-----------------------------+----------------------------------------+
 | ``stamp_type``         | sum                         | The type of coadd to use as the main   |
-|                        |                             | stamp:                                 |
+|                        |                             | legacy ``stamp`` column. Set to        |
+|                        |                             | ``None``/YAML ``null`` to omit it:     |
 |                        |                             | * ``sum`` - (default) Per pixel sum    |
 |                        |                             | * ``median`` - Per pixel median        |
 |                        |                             | * ``mean`` - Per pixel mean            |

--- a/src/kbmod/analysis/plotting.py
+++ b/src/kbmod/analysis/plotting.py
@@ -535,7 +535,8 @@ def plot_result_row(row, times=None, coadd_col="stamp", figure=None):
         The array of the time stamps. If ``None`` then uses equally
         spaced points. `None` by default.
     coadd_col : `str`
-        The name of the coadd to display.
+        The name of the coadd to display. If the column is absent, use the
+        first available named ``coadd_*`` column.
     figure : `matplotlib.pyplot.Figure` or `None`
         Figure, `None` by default.
     """
@@ -548,6 +549,8 @@ def plot_result_row(row, times=None, coadd_col="stamp", figure=None):
     # In the top subfigure plot the coadded stamp on the left and
     # the light curve on the right.
     ax_stamp, ax_lc = fig_top.subplots(1, 2)
+    if coadd_col not in row.colnames:
+        coadd_col = next((name for name in row.colnames if name.startswith("coadd_")), None)
     if coadd_col in row.colnames and row[coadd_col] is not None:
         plot_image(row[coadd_col], ax=ax_stamp, figure=fig_top, norm=True, title="Coadded Stamp")
     else:

--- a/src/kbmod/analysis/visualizer.py
+++ b/src/kbmod/analysis/visualizer.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from kbmod.analysis.plotting import plot_multiple_images
 from kbmod.core.image_stack_py import ImageStackPy
-from kbmod.core.stamp_utils import create_stamps_from_image_stack
+from kbmod.core.stamp_utils import coadd_sum, create_stamps_from_image_stack
 from kbmod.util_functions import mjd_to_day
 
 
@@ -25,6 +25,7 @@ class Visualizer:
     def __init__(self, im_stack, results):
         if isinstance(im_stack, ImageStackPy):
             self.obstimes = im_stack.times
+        self.im_stack = im_stack
         self.results = results
         self.trajectories = results.make_trajectory_list()
 
@@ -102,8 +103,13 @@ class Visualizer:
                     # Add the stamps together
                     daily_coadds[day] += curr_stamp
 
-        # First we'll plot the full coadd
-        imgs = [self.results.table["stamp"][result_idx]]
+        # Preserve the configured primary stamp when present. Otherwise derive
+        # the full sum from the valid individual stamps.
+        if "stamp" in result_row.colnames:
+            full_coadd = result_row["stamp"]
+        else:
+            full_coadd = coadd_sum(result_row["all_stamps"][result_row["obs_valid"]])
+        imgs = [full_coadd]
         labels = [f"Coadd for result {result_idx}"]
 
         # Add images and labels for each individual day

--- a/src/kbmod/configuration.py
+++ b/src/kbmod/configuration.py
@@ -355,9 +355,9 @@ _SUPPORTED_PARAMS = [
     _ParamInfo(
         name="stamp_type",
         default_value="sum",
-        description="The type of stamp to extract.",
+        description="The type of primary stamp to extract. Set to None to omit the legacy stamp column.",
         section="stamps",
-        validate_func=lambda x: x in ["sum", "mean", "median", "weighted"],
+        validate_func=lambda x: x is None or x in ["sum", "mean", "median", "weighted"],
     ),
     _ParamInfo(
         name="timeout_hours",

--- a/src/kbmod/run_search.py
+++ b/src/kbmod/run_search.py
@@ -22,6 +22,18 @@ from .trajectory_utils import predict_pixel_locations
 logger = kb.Logging.getLogger(__name__)
 
 
+def _get_coadd_types(config):
+    """Return the coadd types needed for output and enabled filters."""
+    coadds = set(config["coadds"])
+    if config["stamp_type"] is not None:
+        coadds.add(config["stamp_type"])
+    if config["peak_offset_max"] is not None:
+        coadds.add("mean")
+    if config["cnn_filter"]:
+        coadds.add(config["cnn_coadd_type"])
+    return coadds
+
+
 def configure_kb_search_stack(search, config):
     """Configure the kbmod SearchStack object from a search configuration.
 
@@ -490,21 +502,20 @@ class SearchRunner:
             keep.filter_rows(np.arange(config["max_results"]), "max_results")
             self._end_phase("max_results")
 
-        # Generate coadded stamps without filtering -- both the "stamp" column
-        # as well as any additional coadds.
+        # Generate any coadds needed for output or filtering.
         self._start_phase("stamp generation")
         stamp_radius = config["stamp_radius"]
         stamp_type = config["stamp_type"]
-        coadds = set(config["coadds"])
-        coadds.add(stamp_type)
+        coadds = _get_coadd_types(config)
 
-        # Add all the "coadd_*" columns and a "stamp" column. This is only
-        # short term until we stop using the "stamp" column.
-        self._start_phase("appending co-adds")
-        append_coadds(keep, stack, coadds, stamp_radius, nightly=config["nightly_coadds"])
-        if f"coadd_{stamp_type}" in keep.colnames:
+        if coadds:
+            self._start_phase("appending co-adds")
+            append_coadds(keep, stack, coadds, stamp_radius, nightly=config["nightly_coadds"])
+            self._end_phase("appending co-adds")
+
+        # Keep the legacy "stamp" column only when explicitly configured.
+        if stamp_type is not None:
             keep.table["stamp"] = keep.table[f"coadd_{stamp_type}"]
-        self._end_phase("appending co-adds")
 
         # peak_offset_filter is used only if max offset is declared
         if config["peak_offset_max"] is not None:

--- a/src/kbmod_cmdline/kbmod_stamps.py
+++ b/src/kbmod_cmdline/kbmod_stamps.py
@@ -20,6 +20,8 @@ The type specifies which stamp type to generate:
      The output is a 4-d numpy array of shape (num results, num nights, stamp width, stamp width)
   - "sum-nightly" generates a stamp sum coadded stamp for each (result, night) pair.
      The output is a 4-d numpy array of shape (num results, num nights, stamp width, stamp width)
+  - "weighted" generates a variance-weighted coadded stamp for each result.
+  - "weighted-nightly" generates a variance-weighted coadded stamp for each (result, night) pair.
 
 You can specify a subset of indices (rows in the results file) using the --indices flag.
 For example "--indices=1,3,5" will generate stamps from rows 1, 3, and 5.
@@ -36,6 +38,7 @@ from kbmod.core.stamp_utils import (
     coadd_sum,
     extract_stamp_stack,
 )
+from kbmod.filters.stamp_filters import append_coadds
 from kbmod.results import Results
 from kbmod.trajectory_utils import predict_pixel_locations
 from kbmod.util_functions import mjd_to_day
@@ -90,6 +93,28 @@ def generate_all_stamps(results, images, radius=10, indices=None):
         all_stamps[out_i, :, :, :] = extract_stamp_stack(sci_data, xvals[in_i, :], yvals[in_i, :], radius)
 
     return all_stamps
+
+
+def generate_coadds(results, images, coadd_type, radius=10, indices=None, nightly=False):
+    """Generate coadds using the same valid-observation logic as a KBMOD search."""
+    if coadd_type not in ["mean", "median", "sum", "weighted"]:
+        raise ValueError(f"Unrecognized coadd type {coadd_type}")
+    if radius <= 0:
+        raise ValueError(f"Stamp radius must be > 0 (received {radius}).")
+
+    if indices is None:
+        indices = np.arange(len(results))
+    else:
+        indices = np.asanyarray(indices)
+
+    selected_results = Results(results.table[indices].copy(), wcs=results.wcs)
+    append_coadds(selected_results, images, [coadd_type], radius, nightly=nightly)
+
+    if not nightly:
+        return np.asarray(selected_results[f"coadd_{coadd_type}"])
+
+    day_columns = sorted(col for col in selected_results.colnames if col.startswith(f"coadd_{coadd_type}_"))
+    return np.stack([np.asarray(selected_results[col]) for col in day_columns], axis=1)
 
 
 def coadd_all_stamps(all_stamps, coadd_type):
@@ -198,18 +223,19 @@ def execute(args):
         if np.any(indices < 0) or np.any(indices >= len(results)):
             raise ValueError(f"Invalid indices. Values must be in [0, {len(results)-1}].")
 
-    all_stamps = generate_all_stamps(results, wu.im_stack, args.radius, indices)
-
     if args.coadd_type == "all":
-        result_stamps = all_stamps
-    elif "-nightly" in args.coadd_type:
-        result_stamps = coadd_all_nightly(
-            all_stamps,
-            wu.im_stack.times,
-            args.coadd_type,
-        )
+        result_stamps = generate_all_stamps(results, wu.im_stack, args.radius, indices)
     else:
-        result_stamps = coadd_all_stamps(all_stamps, args.coadd_type)
+        nightly = args.coadd_type.endswith("-nightly")
+        coadd_type = args.coadd_type.removesuffix("-nightly")
+        result_stamps = generate_coadds(
+            results,
+            wu.im_stack,
+            coadd_type,
+            radius=args.radius,
+            indices=indices,
+            nightly=nightly,
+        )
     np.save(args.outfile, result_stamps)
 
 
@@ -257,9 +283,20 @@ def main():
         type=str,
         default="all",
         dest="coadd_type",
+        choices=[
+            "all",
+            "sum",
+            "sum-nightly",
+            "mean",
+            "mean-nightly",
+            "median",
+            "median-nightly",
+            "weighted",
+            "weighted-nightly",
+        ],
         help=(
             "The stamp type. Must be one of 'all', 'sum', 'sum-nightly', 'mean', "
-            "'mean-nightly', 'median', or 'median-nightly'."
+            "'mean-nightly', 'median', 'median-nightly', 'weighted', or 'weighted-nightly'."
         ),
     )
     optional.add_argument(

--- a/tests/test_cmdline_stamps.py
+++ b/tests/test_cmdline_stamps.py
@@ -1,0 +1,66 @@
+import unittest
+
+import numpy as np
+
+from kbmod.core.image_stack_py import ImageStackPy
+from kbmod.fake_data.fake_data_creator import create_fake_times
+from kbmod.results import Results
+from kbmod.search import Trajectory
+from kbmod_cmdline.kbmod_stamps import generate_coadds
+
+
+class TestCmdlineStamps(unittest.TestCase):
+    def setUp(self):
+        self.times = create_fake_times(10, 57130.2, 4, 0.01, 1)
+        self.images = ImageStackPy(
+            times=self.times,
+            sci=[np.full((25, 35), float(i)) for i in range(10)],
+            var=[np.full((25, 35), 0.5) for _ in range(10)],
+        )
+        trj = Trajectory(8, 7, 0.0, 0.0)
+        self.results = Results.from_trajectories([trj, trj])
+
+        valid = np.full((2, 10), True)
+        valid[1, [1, 4, 6, 7, 9]] = False
+        self.results.update_obs_valid(valid)
+
+    def test_generate_coadds_uses_valid_observations(self):
+        coadds = generate_coadds(self.results, self.images, "mean", radius=1)
+
+        self.assertEqual(coadds.shape, (2, 3, 3))
+        self.assertTrue(np.allclose(coadds[0], 4.5))
+        self.assertTrue(np.allclose(coadds[1], 3.6))
+
+    def test_generate_coadds_preserves_selection_and_nightly_shape(self):
+        coadds = generate_coadds(
+            self.results,
+            self.images,
+            "mean",
+            radius=1,
+            indices=[1],
+            nightly=True,
+        )
+
+        self.assertEqual(coadds.shape, (1, 3, 3, 3))
+        self.assertTrue(np.allclose(coadds[0, 0], 5.0 / 3.0))
+        self.assertTrue(np.allclose(coadds[0, 1], 5.0))
+        self.assertTrue(np.allclose(coadds[0, 2], 8.0))
+
+    def test_generate_weighted_nightly_coadds(self):
+        coadds = generate_coadds(
+            self.results,
+            self.images,
+            "weighted",
+            radius=1,
+            indices=[1],
+            nightly=True,
+        )
+
+        self.assertEqual(coadds.shape, (1, 3, 3, 3))
+        self.assertTrue(np.allclose(coadds[0, 0], 5.0 / 3.0))
+        self.assertTrue(np.allclose(coadds[0, 1], 5.0))
+        self.assertTrue(np.allclose(coadds[0, 2], 8.0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -134,6 +134,14 @@ class test_configuration(unittest.TestCase):
         config.set("y_pixel_bounds", [10, 20])
         self.assertTrue(config.validate())
 
+        # A null stamp_type disables the legacy stamp column.
+        config.set("stamp_type", None)
+        self.assertTrue(config.validate())
+        config.set("stamp_type", "invalid")
+        self.assertFalse(config.validate())
+        config.set("stamp_type", "sum")
+        self.assertTrue(config.validate())
+
         # Re-enable warnings.
         logging.disable(logging.NOTSET)
 
@@ -143,6 +151,7 @@ class test_configuration(unittest.TestCase):
             "num_obs": 5,
             "cluster_type": None,
             "do_clustering": False,
+            "stamp_type": None,
             "generator_config": {"name": "test_gen", "p1": [1.0, 2.0], "p2": 2.0},
         }
         config = SearchConfiguration.from_dict(d)
@@ -152,6 +161,7 @@ class test_configuration(unittest.TestCase):
         self.assertEqual(yaml_dict["result_filename"], "Here2")
         self.assertEqual(yaml_dict["num_obs"], 5)
         self.assertEqual(yaml_dict["cluster_type"], None)
+        self.assertIsNone(yaml_dict["stamp_type"])
         self.assertEqual(yaml_dict["generator_config"]["name"], "test_gen")
         self.assertEqual(yaml_dict["generator_config"]["p1"], [1.0, 2.0])
         self.assertEqual(yaml_dict["generator_config"]["p2"], 2.0)

--- a/tests/test_run_search.py
+++ b/tests/test_run_search.py
@@ -3,6 +3,7 @@
 import logging
 import tempfile
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 from astropy.coordinates import EarthLocation
@@ -15,6 +16,7 @@ from kbmod.reprojection_utils import fit_barycentric_wcs
 from kbmod.results import Results
 from kbmod.run_search import (
     SearchRunner,
+    _get_coadd_types,
     append_positions_to_results,
     configure_kb_search_stack,
 )
@@ -25,6 +27,59 @@ from kbmod.work_unit import WorkUnit
 
 
 class test_run_search(unittest.TestCase):
+    def test_required_coadd_types(self):
+        config = SearchConfiguration()
+        self.assertEqual(_get_coadd_types(config), {"sum"})
+
+        config.set("stamp_type", None)
+        self.assertEqual(_get_coadd_types(config), set())
+
+        config.set("coadds", ["median"])
+        self.assertEqual(_get_coadd_types(config), {"median"})
+
+        config.set("peak_offset_max", 2)
+        self.assertEqual(_get_coadd_types(config), {"mean", "median"})
+
+        config.set("cnn_filter", True)
+        config.set("cnn_coadd_type", "sum")
+        self.assertEqual(_get_coadd_types(config), {"mean", "median", "sum"})
+
+    def test_optional_result_stamp_columns(self):
+        fake_ds = FakeDataSet(15, 10, create_fake_times(3, t0=60676.0))
+        trj = Trajectory(x=7, y=5, vx=0.0, vy=0.0, obs_count=3, lh=100.0)
+
+        def run_with(config):
+            runner = SearchRunner()
+            with patch.object(
+                runner,
+                "do_core_search",
+                return_value=Results.from_trajectories([trj]),
+            ):
+                return runner.run_search(config, fake_ds.stack_py)
+
+        config = SearchConfiguration({"do_clustering": False})
+        results = run_with(config)
+        self.assertIn("stamp", results.colnames)
+        self.assertIn("coadd_sum", results.colnames)
+
+        config = SearchConfiguration({"do_clustering": False, "stamp_type": None})
+        with patch("kbmod.run_search.append_coadds") as append:
+            results = run_with(config)
+        append.assert_not_called()
+        self.assertNotIn("stamp", results.colnames)
+        self.assertFalse(any(col.startswith("coadd_") for col in results.colnames))
+
+        config = SearchConfiguration({"do_clustering": False, "stamp_type": None, "coadds": ["mean"]})
+        results = run_with(config)
+        self.assertNotIn("stamp", results.colnames)
+        self.assertIn("coadd_mean", results.colnames)
+
+        config = SearchConfiguration({"do_clustering": False, "stamp_type": None, "save_all_stamps": True})
+        results = run_with(config)
+        self.assertNotIn("stamp", results.colnames)
+        self.assertFalse(any(col.startswith("coadd_") for col in results.colnames))
+        self.assertIn("all_stamps", results.colnames)
+
     @unittest.skipIf(not kb_has_gpu(), "Skipping test (no GPU detected)")
     def test_run_search_bad_config(self):
         """Test cases where the search configuration is bad."""

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import patch
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from kbmod.analysis.plotting import plot_result_row
+from kbmod.analysis.visualizer import Visualizer
+from kbmod.core.image_stack_py import ImageStackPy
+from kbmod.results import Results
+from kbmod.search import Trajectory
+
+
+class TestVisualizerWithoutLegacyStamp(unittest.TestCase):
+    def test_daily_coadds_uses_all_stamps(self):
+        times = np.array([60000.0, 60000.1, 60001.0])
+        images = ImageStackPy(
+            times=times,
+            sci=[np.zeros((5, 5)) for _ in times],
+            var=[np.ones((5, 5)) for _ in times],
+        )
+        results = Results.from_trajectories([Trajectory(2, 2, 0.0, 0.0)])
+        results.update_obs_valid(np.array([[True, False, True]]))
+        results.table["all_stamps"] = [
+            np.array([np.full((3, 3), 1.0), np.full((3, 3), 100.0), np.full((3, 3), 3.0)])
+        ]
+        results.table["num_days"] = [2]
+
+        visualizer = Visualizer(images, results)
+        with patch("kbmod.analysis.visualizer.plot_multiple_images") as plot_images:
+            visualizer.plot_daily_coadds(0)
+
+        plotted = plot_images.call_args.args[0]
+        self.assertTrue(np.allclose(plotted[0], 4.0))
+
+    def test_plot_result_row_falls_back_to_named_coadd(self):
+        results = Results.from_trajectories([Trajectory(2, 2, 0.0, 0.0)])
+        results.table["coadd_mean"] = [np.full((3, 3), 2.0)]
+
+        with patch("kbmod.analysis.plotting.plot_image") as plot_image:
+            figure = plot_result_row(results.table[0])
+
+        self.assertTrue(np.allclose(plot_image.call_args.args[0], 2.0))
+        plt.close(figure)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes https://github.com/dirac-institute/kbmod/issues/1153

Allows a search "stamp" to be "null" in the SearchConfiguration to avoid generation if no other parameters (such as peak-offset or CNN filters require it).

This change ended up being more involved than expected to preserve compatibility with the visualization code and the kbmod stamps commandline extraction tool. 