### PR TITLE
Anchor known-object matching at the stack's first obstime

### DIFF
--- a/src/kbmod/filters/known_object_filters.py
+++ b/src/kbmod/filters/known_object_filters.py
@@ -187,7 +187,12 @@ class KnownObjsMatcher:
         for result_idx in range(len(result_data)):
             # Generate (RA, Dec) pairs for all of the valid observations for this result trajectory
             valid_obstimes = self.obstimes[result_data[result_idx]["obs_valid"]]
-            trj_skycoords = trajectory_predict_skypos(trj_list[result_idx], wcs, valid_obstimes)
+            # The trajectory's starting pixel is defined at the stack's first obstime, not at
+            # its first *valid* obstime, so anchor the prediction there. Otherwise every
+            # predicted position is displaced whenever the first observation is invalid.
+            trj_skycoords = trajectory_predict_skypos(
+                trj_list[result_idx], wcs, valid_obstimes, t0=self.obstimes[0]
+            )
 
             # Because we're only matching using the subset of obstimes that were valid for this result, we
             # can use this to later map back to the original index of all observations in the stack.

--- a/src/kbmod/trajectory_utils.py
+++ b/src/kbmod/trajectory_utils.py
@@ -105,7 +105,7 @@ def make_trajectory_from_ra_dec(ra, dec, v_ra, v_dec, wcs):
     return Trajectory(x=x0, y=y0, vx=(x1 - x0), vy=(y1 - y0))
 
 
-def trajectory_predict_skypos(trj, wcs, times):
+def trajectory_predict_skypos(trj, wcs, times, t0=None):
     """Predict the (RA, dec) locations of the trajectory at different times.
 
     Parameters
@@ -116,6 +116,15 @@ def trajectory_predict_skypos(trj, wcs, times):
         The WCS for the images.
     times : `list` or `numpy.ndarray`
         The times at which to predict the positions in MJD.
+    t0 : `float`, optional
+        The epoch (in MJD) at which the trajectory's starting pixel
+        (``trj.x``, ``trj.y``) is defined. Times are offset relative to this
+        epoch. If ``None`` (the default) the first entry of ``times`` is used,
+        which is only correct when ``times`` starts at the trajectory's own
+        epoch. Callers passing a subset of the stack's obstimes (for example,
+        only the valid observations of a result) must pass the stack's first
+        obstime here, otherwise every predicted position is displaced by
+        ``|v| * (times[0] - t0)``.
 
     .. note::
        The motion is approximated as linear and will be approximately correct
@@ -129,9 +138,11 @@ def trajectory_predict_skypos(trj, wcs, times):
         A SkyCoord with the transformed locations.
     """
     dt = np.asarray(times)
+    if t0 is None:
+        t0 = dt[0]
     # Note that we do a reassignment to avoid modifying the input, which may
     # happen if `times` is already an array and `np.asarray` is a no-op.
-    zeroed_dt = dt - dt[0]
+    zeroed_dt = dt - t0
 
     # Predict locations in pixel space.
     x_vals = trj.x + trj.vx * zeroed_dt

--- a/tests/test_known_object_filters.py
+++ b/tests/test_known_object_filters.py
@@ -308,6 +308,52 @@ class TestKnownObjMatcher(unittest.TestCase):
             if i != 1 and i != 8:
                 self.assertEqual(0, len(matches[i]))
 
+    def test_match_first_obs_invalid(self):
+        """A result whose first observation is invalid must still match a known
+        object sitting exactly on its trajectory.
+
+        `trj.x` / `trj.y` are defined at the stack's first obstime, so predicting
+        over only the valid obstimes has to stay anchored there. Zeroing on the
+        first valid obstime instead displaces every predicted position by
+        |v| * (t_first_valid - t_first), which is far more than `sep_thresh`.
+        """
+        trj = Trajectory(x=6, y=7, vx=0.25, vy=-0.25, flux=500.0)
+
+        # A perfect catalog: the object is exactly on the trajectory at every
+        # obstime, predicted over the full obstime vector (the stack's epoch),
+        # which is the same convention used for the global_ra/global_dec columns.
+        truth = trajectory_predict_skypos(trj, self.wcs, self.obstimes)
+        catalog = Table(
+            {
+                "Name": ["perfect_match"] * len(self.obstimes),
+                "RA": truth.ra.degree,
+                "DEC": truth.dec.degree,
+                "mjd_mid": self.obstimes,
+            }
+        )
+        matcher = KnownObjsMatcher(
+            catalog,
+            self.obstimes,
+            self.matcher_name,
+            self.sep_thresh,
+            self.time_thresh_s,
+        )
+
+        for first_obs_valid in [True, False]:
+            with self.subTest(first_obs_valid=first_obs_valid):
+                res = Results.from_trajectories([trj], track_filtered=True)
+                obs_valid = np.full((1, len(self.obstimes)), True)
+                obs_valid[0][0] = first_obs_valid
+                res.update_obs_valid(obs_valid)
+
+                res = matcher.match(res, self.wcs)
+                matched = res[self.matcher_name][0]
+
+                # Every valid observation should match, whether or not the first
+                # observation of the stack was one of them.
+                self.assertIn("perfect_match", matched)
+                self.assertEqual(int(obs_valid.sum()), sum(matched["perfect_match"]))
+
     def test_match_excessive_spatial_filtering(self):
         # Here we only filter for exact spatial matches and should return no results
         self.sep_thresh = 0.0

--- a/tests/test_trajectory_utils.py
+++ b/tests/test_trajectory_utils.py
@@ -77,6 +77,35 @@ class test_trajectory_utils(unittest.TestCase):
             self.assertAlmostEqual(my_sky.ra[1].deg, 45.2, delta=0.01)
             self.assertAlmostEqual(my_sky.dec[1].deg, -15.5, delta=0.01)
 
+    def test_predict_skypos_t0(self):
+        """Predicting on a subset of the times must give the same answer as
+        predicting on the full vector and then subsetting, as long as the
+        trajectory's own epoch is passed as t0."""
+        my_wcs = WCS(naxis=2)
+        my_wcs.wcs.crpix = [10.0, 10.0]
+        my_wcs.wcs.crval = [45.0, -15.0]
+        my_wcs.wcs.cdelt = [0.1, 0.1]
+        my_wcs.wcs.ctype = ["RA---TAN-SIP", "DEC--TAN-SIP"]
+
+        trj = Trajectory(x=9, y=9, vx=2.0, vy=-5.0)
+        obstimes = np.array([57921.0, 57922.0, 57923.0, 57924.0])
+
+        # The reference: predict over every time, anchored at the first one.
+        full = trajectory_predict_skypos(trj, my_wcs, obstimes)
+
+        # A subset that does not include the trajectory's epoch. Without t0 the
+        # subset is re-zeroed on its own first element and the positions shift.
+        subset = obstimes[2:]
+        with_t0 = trajectory_predict_skypos(trj, my_wcs, subset, t0=obstimes[0])
+        self.assertTrue(np.all(with_t0.separation(full[2:]).arcsec < 1e-6))
+
+        without_t0 = trajectory_predict_skypos(trj, my_wcs, subset)
+        self.assertTrue(np.any(without_t0.separation(full[2:]).arcsec > 1.0))
+
+        # Passing the first time explicitly matches the default behavior.
+        explicit = trajectory_predict_skypos(trj, my_wcs, obstimes, t0=obstimes[0])
+        self.assertTrue(np.all(explicit.separation(full).arcsec < 1e-6))
+
     def test_fit_trajectory_from_pixels(self):
         x_vals = np.array([5.0, 7.0, 9.0, 11.0])
         y_vals = np.array([4.0, 3.0, 2.0, 1.0])


### PR DESCRIPTION
trajectory_predict_skypos() zeroed its time vector on whatever array it was handed (dt - dt[0]). KnownObjsMatcher.match() hands it only the valid obstimes for each result for efficiency, but trj.x and trj.y are defined at the stack's first obstime. Whenever obs_valid[0] was False, every predicted position was displaced by |v| * (t_first_valid - t_first) and the trajectory was compared against the catalog at the wrong place on the sky.

This was found while investigating why certain synthetic objects were not being recovered on deeply stacked WorkUnits (including workunits that span up to 80 days). In practice, most of the 7 million results across those 10 workunits were affected by the matching, but since we match at a 5″ threshold, the discrepancy was not large enough to exclude most results from being matched.

```
  ┌──────────────┬───────────────┬───────────────┬─────────────────────┐
  │    patch     │ start-invalid │ displaced >5″ │ median displacement │
  ├──────────────┼───────────────┼───────────────┼─────────────────────┤
  │ 471085       │         55.2% │          3.4% │               0.44″ │
  ├──────────────┼───────────────┼───────────────┼─────────────────────┤
  │ 471086       │         37.9% │          4.2% │               0.30″ │
  ├──────────────┼───────────────┼───────────────┼─────────────────────┤
  │ 467847       │         39.0% │          5.7% │               0.27″ │
  ├──────────────┼───────────────┼───────────────┼─────────────────────┤
  │ 468387       │         36.2% │          5.2% │               0.20″ │
  ├──────────────┼───────────────┼───────────────┼─────────────────────┤
  │ 471626       │         67.2% │          8.8% │               0.37″ │
  ├──────────────┼───────────────┼───────────────┼─────────────────────┤
  │ 473251       │         28.5% │         14.9% │               8.81″ │
  ├──────────────┼───────────────┼───────────────┼─────────────────────┤
  │ 471625       │         90.0% │         40.8% │               1.20″ │
  ├──────────────┼───────────────┼───────────────┼─────────────────────┤
  │ 472166       │         85.5% │         61.3% │             110.84″ │
  ├──────────────┼───────────────┼───────────────┼─────────────────────┤
  │ 472706       │         89.7% │         89.7% │             331.19″ │
  └──────────────┴───────────────┴───────────────┴─────────────────────┘

```

Add an explicit t0= parameter to trajectory_predict_skypos(), defaulting to times[0] so existing callers are unchanged, and have the matcher pass t0=self.obstimes[0]. This seems to be the only callsite in KBMOD to have been affected by the bug.

Claude helped determine that the existing known object tests missed this by seed luck: under seed 500 only results 0 and 6 have obs_valid[0] == False, and every generated known object is built from results 1, 3, 5, 7 and 8, all of which start valid. Adds two regression tests that fail on the old code: a unit test that a subset prediction with t0 reproduces the full-vector prediction, and a matcher test that a perfect catalog matches every valid observation with obs_valid[0] both True and False.

As a note:
Other places where we calculate RA, Dec positions of KBMOD results were unaffected, and for efficiency and consistency we should probably do a small refactor with https://github.com/dirac-institute/kbmod/issues/1155 