### PR TITLE
injection matcher: fix obs_ratio sign bug + expose obs_ratio in match…

### DIFF
--- a/src/kbmod/filters/known_object_filters.py
+++ b/src/kbmod/filters/known_object_filters.py
@@ -373,7 +373,7 @@ class KnownObjsMatcher:
                     raise ValueError(f"Unknown known object {name}")
 
                 curr_obs_ratio = np.count_nonzero(matches[name]) / known_obj_cnts[name]
-                if curr_obs_ratio <= obs_ratio:
+                if curr_obs_ratio >= obs_ratio:
                     matched_objs[-1].add(name)
 
         # Add the matched objects to the results table, converting our de-deduplicated sets

--- a/src/kbmod/injection.py
+++ b/src/kbmod/injection.py
@@ -327,6 +327,7 @@ def match_injection_results(
     sep_thresh=5.0,
     time_thresh_s=60.0,
     min_obs=3,
+    obs_ratio=None,
     matcher_name="injected_sources",
 ):
     """Match KBMOD search results against an injection catalog.
@@ -451,10 +452,17 @@ def match_injection_results(
     match_col = matcher.match_min_obs_col(min_obs)
     recovered, missed = matcher.get_recovered_objects(results, match_col)
 
+    # Optionally also add an object-completeness (obs_ratio) recovery column:
+    # fraction of the KNOWN object's observations that matched (>= obs_ratio).
+    if obs_ratio is not None:
+        results = matcher.match_on_obs_ratio(results, obs_ratio=obs_ratio)
+
     n_total = len(set(catalog["obj_ids"]))
     logger.info(
         f"Injection recovery: {len(recovered)}/{n_total} objects recovered "
-        f"({len(missed)} missed) with min_obs={min_obs}, sep_thresh={sep_thresh}"
+        f"({len(missed)} missed) with min_obs={min_obs}"
+        + (f", obs_ratio={obs_ratio}" if obs_ratio is not None else "")
+        + f", sep_thresh={sep_thresh}"
     )
 
     return results, recovered, missed

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -376,6 +376,33 @@ class TestMatchInjectionResults(unittest.TestCase):
             list(matched_results.table["recovered_injected_sources_min_obs_3"][0]), [str(injected_obj_id)]
         )
 
+        # Without the obs_ratio kwarg no obs_ratio column is added.
+        self.assertFalse(
+            any("obs_ratio" in name for name in matched_results.table.colnames),
+        )
+
+        # Rebuild the results with the last observation marked invalid, so only
+        # 2 of the object's 3 catalog observations can match: an obs_ratio of 2/3.
+        results = Results.from_trajectories([trj])
+        results.wcs = wcs
+        results.mjd_mid = np.array(obstimes)
+        results.table["obs_valid"] = [np.array([True, True, False])]
+
+        # obs_ratio is a minimum, so a threshold below 2/3 still recovers the object.
+        matched_results, _, _ = match_injection_results(
+            catalog, results, guess_distance=None, sep_thresh=1.0, min_obs=2, obs_ratio=0.5
+        )
+        self.assertEqual(
+            list(matched_results.table["recovered_injected_sources_obs_ratio_0.5"][0]),
+            [str(injected_obj_id)],
+        )
+
+        # A threshold above 2/3 does not.
+        matched_results, _, _ = match_injection_results(
+            catalog, results, guess_distance=None, sep_thresh=1.0, min_obs=2, obs_ratio=0.9
+        )
+        self.assertEqual(list(matched_results.table["recovered_injected_sources_obs_ratio_0.9"][0]), [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_known_object_filters.py
+++ b/tests/test_known_object_filters.py
@@ -556,14 +556,24 @@ class TestKnownObjMatcher(unittest.TestCase):
     def test_match_obs_ratio(self):
         # Here we test considering a known object recovered based on the ratio of observations
         # in the catalog that were temporally within
+        # `obs_ratio` is a *minimum*: an object is recovered when at least that
+        # fraction of the object's own catalog observations matched. Only two of
+        # the catalog objects match at all here, at these ratios:
+        #   spatial_close_time_close_1: 20 of its 25 observations = 0.8
+        #       (result 1 has 5 invalid observations, which can never match)
+        #   sparse_8:                    2 of its  3 observations = 0.667
         min_obs_ratios = [
-            0.0,
-            1.0,
+            0.0,  # Every matched object clears a zero minimum.
+            0.7,  # Only the denser of the two objects clears this.
+            0.8,  # The comparison is inclusive, so 0.8 still clears it.
+            1.0,  # Neither object matched every one of its observations.
         ]
         # The expected matching objects for each min_obs_ratio parameter chosen.
         expected_matches = [
-            set([]),
             set(["spatial_close_time_close_1", "sparse_8"]),
+            set(["spatial_close_time_close_1"]),
+            set(["spatial_close_time_close_1"]),
+            set([]),
         ]
         orig_res = self.res.table.copy()
         for obs_ratio, expected in zip(min_obs_ratios, expected_matches):


### PR DESCRIPTION
Fix "obs_ratio" column for synthetic recovery. This was not the primary metric for gating recovery, so has not been affecting reporting.

- KnownObjsMatcher.match_on_obs_ratio compared curr_obs_ratio <= obs_ratio, the inverse of its documented 'minimum ratio' semantics (match_on_min_obs correctly uses >=). An object counts as recovered when >= obs_ratio of ITS observations match; fixed the comparison.
- match_injection_results gains an obs_ratio kwarg that adds the recovered_<matcher>_obs_ratio_<r> column alongside the min_obs column.
